### PR TITLE
Fix ibft not mining bug when network split on waiting for commit mess…

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -900,7 +900,20 @@ func (i *Ibft) runValidateState() {
 		}
 
 		if msg == nil {
+			i.logger.Debug("ValidateState got message timeout, should change round",
+				"sequence", i.state.view.Sequence, "round", i.state.view.Round+1)
+			i.state.unlock()
 			i.setState(RoundChangeState)
+
+			continue
+		}
+
+		// check msg number and round, might from some faulty nodes
+		if i.state.view.Sequence != msg.View.GetSequence() ||
+			i.state.view.Round != msg.View.GetRound() {
+			i.logger.Debug("ValidateState got message not matching sequence and round",
+				"my-sequence", i.state.view.Sequence, "my-round", i.state.view.Round+1,
+				"other-sequence", msg.View.GetSequence(), "other-round", msg.View.GetRound())
 
 			continue
 		}

--- a/contracts/abis/abis.go
+++ b/contracts/abis/abis.go
@@ -15,4 +15,7 @@ var (
 )
 
 // Temporarily deployed contract ABI
-var StressTestABI = abi.MustNewABI(StressTestJSONABI)
+var (
+	// StressTest contract abi
+	StressTestABI = abi.MustNewABI(StressTestJSONABI)
+)

--- a/e2e/framework/config.go
+++ b/e2e/framework/config.go
@@ -26,26 +26,27 @@ type SrvAccount struct {
 // TestServerConfig for the test server
 type TestServerConfig struct {
 	ReservedPorts           []ReservedPort
-	JSONRPCPort             int                  // The JSON RPC endpoint port
-	GRPCPort                int                  // The GRPC endpoint port
-	LibP2PPort              int                  // The Libp2p endpoint port
-	Seal                    bool                 // Flag indicating if blocks should be sealed
-	RootDir                 string               // The root directory for test environment
-	IBFTDirPrefix           string               // The prefix of data directory for IBFT
-	IBFTDir                 string               // The name of data directory for IBFT
-	PremineAccts            []*SrvAccount        // Accounts with existing balances (genesis accounts)
-	GenesisValidatorBalance *big.Int             // Genesis the balance for the validators
-	DevStakers              []types.Address      // List of initial staking addresses for the ValidatorSet SC with dev consensus
-	Consensus               ConsensusType        // Consensus MechanismType
-	Bootnodes               []string             // Bootnode Addresses
-	PriceLimit              *uint64              // Minimum gas price limit to enforce for acceptance into the pool
-	DevInterval             int                  // Dev consensus update interval [s]
-	EpochSize               uint64               // The epoch size in blocks for the IBFT layer
-	BlockGasLimit           uint64               // Block gas limit
-	BlockGasTarget          uint64               // Gas target for new blocks
-	ShowsLog                bool                 // Flag specifying if logs are shown
-	IsPos                   bool                 // Specifies the mechanism used for IBFT (PoA / PoS)
-	Signer                  *crypto.EIP155Signer // Signer used for transactions
+	JSONRPCPort             int           // The JSON RPC endpoint port
+	GRPCPort                int           // The GRPC endpoint port
+	LibP2PPort              int           // The Libp2p endpoint port
+	Seal                    bool          // Flag indicating if blocks should be sealed
+	RootDir                 string        // The root directory for test environment
+	IBFTDirPrefix           string        // The prefix of data directory for IBFT
+	IBFTDir                 string        // The name of data directory for IBFT
+	PremineAccts            []*SrvAccount // Accounts with existing balances (genesis accounts)
+	GenesisValidatorBalance *big.Int      // Genesis the balance for the validators
+	// List of initial staking addresses for the ValidatorSet SC with dev consensus
+	DevStakers     []types.Address
+	Consensus      ConsensusType        // Consensus MechanismType
+	Bootnodes      []string             // Bootnode Addresses
+	PriceLimit     *uint64              // Minimum gas price limit to enforce for acceptance into the pool
+	DevInterval    int                  // Dev consensus update interval [s]
+	EpochSize      uint64               // The epoch size in blocks for the IBFT layer
+	BlockGasLimit  uint64               // Block gas limit
+	BlockGasTarget uint64               // Gas target for new blocks
+	ShowsLog       bool                 // Flag specifying if logs are shown
+	IsPos          bool                 // Specifies the mechanism used for IBFT (PoA / PoS)
+	Signer         *crypto.EIP155Signer // Signer used for transactions
 }
 
 // DataDir returns path of data directory server uses


### PR DESCRIPTION
# Description

Jury IBFT consensus would not restore to mining in some network split use cases.

Suppose, proposer received enough prepare messages from other nodes, locked the validate state, and missed enough commit message, then the round change. The magic happen, the whole network would not mine at all. The only way to fix is to restart the whole network validator nodes, which is unacceptable.

This PR would fixed it, since we unlock the validate state when a new round change happen, then new propose could be handled properly.

By the way, we add IBFT message validation in validate state, which could prevent some faulty node attacks.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually