### PR TITLE
Add bridge contract options in TestServer

### DIFF
--- a/e2e/framework/config.go
+++ b/e2e/framework/config.go
@@ -47,6 +47,8 @@ type TestServerConfig struct {
 	ShowsLog       bool                 // Flag specifying if logs are shown
 	IsPos          bool                 // Specifies the mechanism used for IBFT (PoA / PoS)
 	Signer         *crypto.EIP155Signer // Signer used for transactions
+	BridgeOwner    types.Address        // bridge contract owner
+	BridgeSigners  []types.Address      // bridge contract signers
 }
 
 // DataDir returns path of data directory server uses
@@ -154,4 +156,12 @@ func (t *TestServerConfig) SetShowsLog(f bool) {
 // It controls the rate at which the validator set is updated
 func (t *TestServerConfig) SetEpochSize(epochSize uint64) {
 	t.EpochSize = epochSize
+}
+
+func (t *TestServerConfig) SetBridgeOwner(owner types.Address) {
+	t.BridgeOwner = owner
+}
+
+func (t *TestServerConfig) SetBridgeSigners(signers []types.Address) {
+	t.BridgeSigners = signers
 }

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -421,6 +421,9 @@ func NewTestServers(t *testing.T, num int, conf func(*TestServerConfig)) []*Test
 	// This method needs to be standardized in the future
 	bootnodes := []string{tests.GenerateTestMultiAddr(t).String()}
 
+	// It is safe to set contract configs here, since this init method is called for Dev consensus modes.
+	owner, signers := tests.GenerateTestBridgeAssociatedAddress(t, 1)
+
 	for i := 0; i < num; i++ {
 		dataDir, err := tempDir()
 		if err != nil {
@@ -429,6 +432,9 @@ func NewTestServers(t *testing.T, num int, conf func(*TestServerConfig)) []*Test
 
 		srv := NewTestServer(t, dataDir, conf)
 		srv.Config.SetBootnodes(bootnodes)
+		// do not forget to set the must options
+		srv.Config.SetBridgeOwner(owner)
+		srv.Config.SetBridgeSigners(signers)
 
 		if genesisErr := srv.GenerateGenesis(); genesisErr != nil {
 			t.Fatal(genesisErr)

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -292,6 +292,16 @@ func (t *TestServer) GenerateGenesis() error {
 	blockGasLimit := strconv.FormatUint(t.Config.BlockGasLimit, 10)
 	args = append(args, "--block-gas-limit", blockGasLimit)
 
+	// add bridge contract owner
+	if t.Config.BridgeOwner != types.ZeroAddress {
+		args = append(args, "--bridge-owner", t.Config.BridgeOwner.String())
+	}
+
+	// add bridge contract signers
+	for _, signer := range t.Config.BridgeSigners {
+		args = append(args, "--bridge-signer", signer.String())
+	}
+
 	cmd := exec.Command(binaryName, args...)
 	cmd.Dir = t.Config.RootDir
 

--- a/helper/tests/testing.go
+++ b/helper/tests/testing.go
@@ -60,6 +60,40 @@ func GenerateTestMultiAddr(t *testing.T) multiaddr.Multiaddr {
 	return addr
 }
 
+func GenerateTestBridgeAssociatedAddress(t *testing.T, signerCount int) (owner types.Address, signers []types.Address) {
+	t.Helper()
+
+	if signerCount <= 0 {
+		t.Fatalf("Bridge contract must have signers")
+	}
+
+	ownerKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("Unable to generate private key, %v", err)
+	}
+
+	owner, err = crypto.GetAddressFromKey(ownerKey)
+	if err != nil {
+		t.Fatalf("Unable to get address from private key, %v", err)
+	}
+
+	for i := 0; i < signerCount; i++ {
+		priv, err := crypto.GenerateKey()
+		if err != nil {
+			t.Fatalf("Unable to generate private key, %v", err)
+		}
+
+		address, err := crypto.GetAddressFromKey(priv)
+		if err != nil {
+			t.Fatalf("Unable to get address from private key, %v", err)
+		}
+
+		signers = append(signers, address)
+	}
+
+	return owner, signers
+}
+
 func RetryUntilTimeout(ctx context.Context, f func() (interface{}, bool)) (interface{}, error) {
 	type result struct {
 		data interface{}


### PR DESCRIPTION
# Description

To separate different test network in parallel test cases, we should add more different options like chainID, account, storage, etc.

This PR would bring up the difference by default, which would separate our test cases network transparently.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
