### PR TITLE
Use proposer address as miner when building block

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -556,7 +556,7 @@ func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, e
 	header := &types.Header{
 		ParentHash: parent.Hash,
 		Number:     parent.Number + 1,
-		Miner:      types.Address{},
+		Miner:      i.validatorKeyAddr,
 		Nonce:      types.Nonce{},
 		MixHash:    IstanbulDigest,
 		// this is required because blockchain needs difficulty to organize blocks and forks


### PR DESCRIPTION
# Description

The `blockscout` explorer we used, would not show out the proposer of the block, and miner is always zero address instead, which is confusing.

This PR is to set proposer as miner to show it explicitly.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

* Set up a private test network using docker, and an explorer collecting its data.
* Then we should see the block miner validator address instead of zero address.
