### PR TITLE
Remove assets of init ValidatorSet

### DIFF
--- a/helper/validatorset/validatorset.go
+++ b/helper/validatorset/validatorset.go
@@ -2,7 +2,6 @@ package validatorset
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 
 	"github.com/dogechain-lab/jury/chain"
@@ -123,14 +122,6 @@ func PredeploySC(params PredeployParams) (*chain.GenesisAccount, error) {
 		Code: scHex,
 	}
 
-	// Parse the default staked balance value into *big.Int
-	val := DefaultStakedBalance
-	bigDefaultStakedBalance, err := types.ParseUint256orHex(&val)
-
-	if err != nil {
-		return nil, fmt.Errorf("unable to generate DefaultStatkedBalance, %w", err)
-	}
-
 	if params.Owner == types.ZeroAddress {
 		return nil, errors.New("contract owner should not be empty")
 	}
@@ -142,19 +133,12 @@ func PredeploySC(params PredeployParams) (*chain.GenesisAccount, error) {
 	stakedAmount := big.NewInt(0)
 
 	for indx, validator := range params.Validators {
-		// Update the total staked amount
-		stakedAmount.Add(stakedAmount, bigDefaultStakedBalance)
-
 		// Get the storage indexes
 		storageIndexes := getStorageIndexes(validator, int64(indx))
 
 		// Set the value for the owner
 		storageMap[types.BytesToHash(storageIndexes.OwnerIndex)] =
 			types.BytesToHash(params.Owner.Bytes())
-
-		// Set the value for the threshold
-		storageMap[types.BytesToHash(storageIndexes.ThresholdIndex)] =
-			types.BytesToHash(bigDefaultStakedBalance.Bytes())
 
 		// Set the value for the owner
 		storageMap[types.BytesToHash(storageIndexes.MinimumIndex)] =
@@ -169,10 +153,6 @@ func PredeploySC(params PredeployParams) (*chain.GenesisAccount, error) {
 		// Set the value for the address -> validator array index mapping
 		storageMap[types.BytesToHash(storageIndexes.AddressToIsValidatorIndex)] =
 			types.BytesToHash(bigTrueValue.Bytes())
-
-		// Set the value for the address -> staked amount mapping
-		storageMap[types.BytesToHash(storageIndexes.AddressToStakedAmountIndex)] =
-			types.StringToHash(hex.EncodeBig(bigDefaultStakedBalance))
 
 		// Set the value for the address -> validator index mapping
 		storageMap[types.BytesToHash(storageIndexes.AddressToValidatorIndexIndex)] =


### PR DESCRIPTION
# Description

The init Validators should not have any assets, including wDoge and DC.
Once it has any assets, the deployer could get profit from it.
What if the deployer is a bad guy? The network economy will crash instantly and cannot be recovered.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

New genesis file, needs new network deployment.

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually