### PR TITLE
Fix issue can't fetch genesis block by hash

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1092,7 +1092,7 @@ func (b *Blockchain) GetBlockByHash(hash types.Hash, full bool) (*types.Block, b
 		Header: header,
 	}
 
-	if !full {
+	if !full || header.Number == 0 {
 		return block, true
 	}
 


### PR DESCRIPTION
# Description

This PR fixes the issue user can't get genesis block by hash. The reason was genesis block body was not stored to DB and the code didn't care about this when querying genesis block by hash.

Merging from [Polygon-Edge PR 514](https://github.com/0xPolygon/polygon-edge/pull/514)

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

* Call `eth_getBlockByHash` JSON RPC with Geneis block hash.