### PR TITLE
Update snapshot after processBlock ends

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -57,6 +57,7 @@ type gasPriceAverage struct {
 
 type Verifier interface {
 	VerifyHeader(parent, header *types.Header) error
+	ProcessHeaders(headers []*types.Header) error
 	GetBlockCreator(header *types.Header) (types.Address, error)
 	PreStateCommit(header *types.Header, txn *state.Transition) error
 }

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -701,6 +701,11 @@ func (b *Blockchain) WriteBlock(block *types.Block) error {
 		return err
 	}
 
+	//	update snapshot
+	if err := b.consensus.ProcessHeaders([]*types.Header{header}); err != nil {
+		return err
+	}
+
 	b.dispatchEvent(evnt)
 
 	// Update the average gas price

--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -197,6 +197,10 @@ func (m *MockVerifier) VerifyHeader(parent, header *types.Header) error {
 	return nil
 }
 
+func (m *MockVerifier) ProcessHeaders(headers []*types.Header) error {
+	return nil
+}
+
 func (m *MockVerifier) GetBlockCreator(header *types.Header) (types.Address, error) {
 	return header.Miner, nil
 }

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -22,6 +22,9 @@ type Consensus interface {
 	// VerifyHeader verifies the header is correct
 	VerifyHeader(parent, header *types.Header) error
 
+	// ProcessHeaders updates the snapshot based on the verified headers
+	ProcessHeaders(headers []*types.Header) error
+
 	// GetBlockCreator retrieves the block creator (or signer) given the block header
 	GetBlockCreator(header *types.Header) (types.Address, error)
 

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -211,6 +211,10 @@ func (d *Dev) VerifyHeader(parent *types.Header, header *types.Header) error {
 	return nil
 }
 
+func (d *Dev) ProcessHeaders(headers []*types.Header) error {
+	return nil
+}
+
 func (d *Dev) GetBlockCreator(header *types.Header) (types.Address, error) {
 	return header.Miner, nil
 }

--- a/consensus/dummy/dummy.go
+++ b/consensus/dummy/dummy.go
@@ -52,6 +52,10 @@ func (d *Dummy) VerifyHeader(parent *types.Header, header *types.Header) error {
 	return nil
 }
 
+func (d *Dummy) ProcessHeaders(headers []*types.Header) error {
+	return nil
+}
+
 func (d *Dummy) GetBlockCreator(header *types.Header) (types.Address, error) {
 	return header.Miner, nil
 }

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -1276,6 +1276,10 @@ func (i *Ibft) VerifyHeader(parent, header *types.Header) error {
 	return nil
 }
 
+func (i *Ibft) ProcessHeaders(headers []*types.Header) error {
+	return i.processHeaders(headers)
+}
+
 // GetBlockCreator retrieves the block signer from the extra data field
 func (i *Ibft) GetBlockCreator(header *types.Header) (types.Address, error) {
 	return ecrecoverFromHeader(header)

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -1268,11 +1268,6 @@ func (i *Ibft) VerifyHeader(parent, header *types.Header) error {
 		return err
 	}
 
-	// process the new block in order to update the snapshot
-	if err := i.processHeaders([]*types.Header{header}); err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
# Description

This PR delays the call to `processHeaders()` until after the block has been verified and processed completely.

Previously, snapshot updating was done during `verifyHeaders()` despite `processBlock()` potentially failing afterwards.

This PR is merging from [Polygon-Edge PR 482](https://github.com/0xPolygon/polygon-edge/pull/482)

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Tested manually with a 4-node cluster. Steps:

1. Spin up 4 nodes (develop build)
2. Sequentially restart all nodes (fix/snapshot_update build)
3. Nothing breaks
