### PR TITLE
fix auditing v-doge-vul-002

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -1126,6 +1126,13 @@ func (i *Ibft) runRoundChangeState() {
 			continue
 		}
 
+		if msg.View == nil {
+			// A malicious node conducted a DoS attack
+			i.logger.Error("view data in msg is nil")
+
+			continue
+		}
+
 		// we only expect RoundChange messages right now
 		num := i.state.AddRoundMessage(msg)
 

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -826,6 +826,13 @@ func (i *Ibft) runAcceptState() { // start new round
 			continue
 		}
 
+		if msg.Proposal == nil {
+			// A malicious node conducted a DoS attack
+			i.logger.Error("proposal data in msg is nil")
+
+			continue
+		}
+
 		// retrieve the block proposal
 		block := &types.Block{}
 		if err := block.UnmarshalRLP(msg.Proposal.Value); err != nil {
@@ -904,6 +911,13 @@ func (i *Ibft) runValidateState() {
 				"sequence", i.state.view.Sequence, "round", i.state.view.Round+1)
 			i.state.unlock()
 			i.setState(RoundChangeState)
+
+			continue
+		}
+
+		if msg.View == nil {
+			// A malicious node conducted a DoS attack
+			i.logger.Error("view data in msg is nil")
 
 			continue
 		}


### PR DESCRIPTION
# Description

Validators in the set listen on gossips from other validators to form consensus. Developers should assume that these gossips could be from a malicious validator in the network and properly sanitize the incoming messages in the channel. However, the current implementation has not fully validate and sanitize these unsafe messages. Specifically, the proposal attribute of gossiping message could be set to an arbitrary object, including being nil, while the following code attempts to dereference this attribute without proper validation. The missing validation could allow a malicious validator to trigger a null pointer dereferencing on all other validators, thus crashing all of them, leading to denial of service or potentially more
serious consequences.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

