### PR TITLE
[TxPool] Self pruning stuck transactions

### DIFF
--- a/command/default.go
+++ b/command/default.go
@@ -3,14 +3,15 @@ package command
 import "github.com/dogechain-lab/jury/server"
 
 const (
-	DefaultGenesisFileName = "genesis.json"
-	DefaultChainName       = "jury"
-	DefaultChainID         = 100
-	DefaultPremineBalance  = "0x3635C9ADC5DEA00000" // 1000 ETH
-	DefaultConsensus       = server.IBFTConsensus
-	DefaultMaxSlots        = 4096
-	DefaultGenesisGasUsed  = 458752  // 0x70000
-	DefaultGenesisGasLimit = 5242880 // 0x500000
+	DefaultGenesisFileName     = "genesis.json"
+	DefaultChainName           = "jury"
+	DefaultChainID             = 100
+	DefaultPremineBalance      = "0x3635C9ADC5DEA00000" // 1000 ETH
+	DefaultConsensus           = server.IBFTConsensus
+	DefaultMaxSlots            = 4096
+	DefaultMaxAccountDemotions = 10      // account demotion counter limit
+	DefaultGenesisGasUsed      = 458752  // 0x70000
+	DefaultGenesisGasLimit     = 5242880 // 0x500000
 )
 
 const (

--- a/command/default.go
+++ b/command/default.go
@@ -8,6 +8,7 @@ const (
 	DefaultChainID             = 100
 	DefaultPremineBalance      = "0x3635C9ADC5DEA00000" // 1000 ETH
 	DefaultConsensus           = server.IBFTConsensus
+	DefaultPriceLimit          = 0
 	DefaultMaxSlots            = 4096
 	DefaultMaxAccountDemotions = 10      // account demotion counter limit
 	DefaultGenesisGasUsed      = 458752  // 0x70000

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -78,8 +78,8 @@ func DefaultConfig() *Config {
 		Telemetry:  &Telemetry{},
 		ShouldSeal: false,
 		TxPool: &TxPool{
-			PriceLimit:          0,
-			MaxSlots:            4096,
+			PriceLimit:          command.DefaultPriceLimit,
+			MaxSlots:            command.DefaultMaxSlots,
 			MaxAccountDemotions: command.DefaultMaxAccountDemotions,
 		},
 		LogLevel:    "INFO",

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/dogechain-lab/jury/command"
 	"github.com/dogechain-lab/jury/network"
 
 	"github.com/hashicorp/hcl"
@@ -47,8 +48,9 @@ type Network struct {
 
 // TxPool defines the TxPool configuration params
 type TxPool struct {
-	PriceLimit uint64 `json:"price_limit"`
-	MaxSlots   uint64 `json:"max_slots"`
+	PriceLimit          uint64 `json:"price_limit"`
+	MaxSlots            uint64 `json:"max_slots"`
+	MaxAccountDemotions uint64 `json:"max_account_demotions"`
 }
 
 // Headers defines the HTTP response headers required to enable CORS.
@@ -76,8 +78,9 @@ func DefaultConfig() *Config {
 		Telemetry:  &Telemetry{},
 		ShouldSeal: false,
 		TxPool: &TxPool{
-			PriceLimit: 0,
-			MaxSlots:   4096,
+			PriceLimit:          0,
+			MaxSlots:            4096,
+			MaxAccountDemotions: command.DefaultMaxAccountDemotions,
 		},
 		LogLevel:    "INFO",
 		RestoreFile: "",

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -2,8 +2,9 @@ package server
 
 import (
 	"errors"
-	"github.com/hashicorp/go-hclog"
 	"net"
+
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/dogechain-lab/jury/chain"
 	"github.com/dogechain-lab/jury/network"
@@ -13,27 +14,28 @@ import (
 )
 
 const (
-	configFlag            = "config"
-	genesisPathFlag       = "chain"
-	dataDirFlag           = "data-dir"
-	libp2pAddressFlag     = "libp2p"
-	prometheusAddressFlag = "prometheus"
-	natFlag               = "nat"
-	dnsFlag               = "dns"
-	sealFlag              = "seal"
-	maxPeersFlag          = "max-peers"
-	maxInboundPeersFlag   = "max-inbound-peers"
-	maxOutboundPeersFlag  = "max-outbound-peers"
-	priceLimitFlag        = "price-limit"
-	maxSlotsFlag          = "max-slots"
-	blockGasTargetFlag    = "block-gas-target"
-	secretsConfigFlag     = "secrets-config"
-	restoreFlag           = "restore"
-	blockTimeFlag         = "block-time"
-	devIntervalFlag       = "dev-interval"
-	devFlag               = "dev"
-	corsOriginFlag        = "access-control-allow-origins"
-	daemonFlag            = "daemon"
+	configFlag              = "config"
+	genesisPathFlag         = "chain"
+	dataDirFlag             = "data-dir"
+	libp2pAddressFlag       = "libp2p"
+	prometheusAddressFlag   = "prometheus"
+	natFlag                 = "nat"
+	dnsFlag                 = "dns"
+	sealFlag                = "seal"
+	maxPeersFlag            = "max-peers"
+	maxInboundPeersFlag     = "max-inbound-peers"
+	maxOutboundPeersFlag    = "max-outbound-peers"
+	priceLimitFlag          = "price-limit"
+	maxSlotsFlag            = "max-slots"
+	MaxAccountDemotionsFlag = "max-account-demotions"
+	blockGasTargetFlag      = "block-gas-target"
+	secretsConfigFlag       = "secrets-config"
+	restoreFlag             = "restore"
+	blockTimeFlag           = "block-time"
+	devIntervalFlag         = "dev-interval"
+	devFlag                 = "dev"
+	corsOriginFlag          = "access-control-allow-origins"
+	daemonFlag              = "daemon"
 )
 
 const (
@@ -155,15 +157,16 @@ func (p *serverParams) generateConfig() *server.Config {
 			MaxOutboundPeers: p.rawConfig.Network.MaxOutboundPeers,
 			Chain:            p.genesisConfig,
 		},
-		DataDir:        p.rawConfig.DataDir,
-		Seal:           p.rawConfig.ShouldSeal,
-		PriceLimit:     p.rawConfig.TxPool.PriceLimit,
-		MaxSlots:       p.rawConfig.TxPool.MaxSlots,
-		SecretsManager: p.secretsConfig,
-		RestoreFile:    p.getRestoreFilePath(),
-		BlockTime:      p.rawConfig.BlockTime,
-		LogLevel:       hclog.LevelFromString(p.rawConfig.LogLevel),
-		Daemon:         p.isDaemon,
-		ValidatorKey:   p.validatorKey,
+		DataDir:             p.rawConfig.DataDir,
+		Seal:                p.rawConfig.ShouldSeal,
+		PriceLimit:          p.rawConfig.TxPool.PriceLimit,
+		MaxSlots:            p.rawConfig.TxPool.MaxSlots,
+		MaxAccountDemotions: p.rawConfig.TxPool.MaxAccountDemotions,
+		SecretsManager:      p.secretsConfig,
+		RestoreFile:         p.getRestoreFilePath(),
+		BlockTime:           p.rawConfig.BlockTime,
+		LogLevel:            hclog.LevelFromString(p.rawConfig.LogLevel),
+		Daemon:              p.isDaemon,
+		ValidatorKey:        p.validatorKey,
 	}
 }

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -3,16 +3,17 @@ package server
 import (
 	"bufio"
 	"fmt"
-	"github.com/dogechain-lab/jury/command"
-	"github.com/dogechain-lab/jury/crypto"
-	"github.com/dogechain-lab/jury/helper/daemon"
-	"github.com/howeyc/gopass"
-	"github.com/spf13/cobra"
 	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/dogechain-lab/jury/command"
+	"github.com/dogechain-lab/jury/crypto"
+	"github.com/dogechain-lab/jury/helper/daemon"
+	"github.com/howeyc/gopass"
+	"github.com/spf13/cobra"
 
 	"github.com/dogechain-lab/jury/command/helper"
 	"github.com/dogechain-lab/jury/network"
@@ -174,6 +175,13 @@ func setFlags(cmd *cobra.Command) {
 		maxSlotsFlag,
 		command.DefaultMaxSlots,
 		"maximum slots in the pool",
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.rawConfig.TxPool.MaxAccountDemotions,
+		MaxAccountDemotionsFlag,
+		command.DefaultMaxAccountDemotions,
+		"maximum account demontion counter limit in the pool",
 	)
 
 	cmd.Flags().Uint64Var(

--- a/server/config.go
+++ b/server/config.go
@@ -21,9 +21,10 @@ type Config struct {
 	GRPCAddr   *net.TCPAddr
 	LibP2PAddr *net.TCPAddr
 
-	PriceLimit uint64
-	MaxSlots   uint64
-	BlockTime  uint64
+	PriceLimit          uint64
+	MaxSlots            uint64
+	BlockTime           uint64
+	MaxAccountDemotions uint64
 
 	Telemetry *Telemetry
 	Network   *network.Config

--- a/server/server.go
+++ b/server/server.go
@@ -173,6 +173,7 @@ func NewServer(config *Config) (*Server, error) {
 				Sealing:    m.config.Seal,
 				MaxSlots:   m.config.MaxSlots,
 				PriceLimit: m.config.PriceLimit,
+				MaxAccountDemotions: m.config.MaxAccountDemotions,
 			},
 		)
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -170,9 +170,9 @@ func NewServer(config *Config) (*Server, error) {
 			m.network,
 			m.serverMetrics.txpool,
 			&txpool.Config{
-				Sealing:    m.config.Seal,
-				MaxSlots:   m.config.MaxSlots,
-				PriceLimit: m.config.PriceLimit,
+				Sealing:             m.config.Seal,
+				MaxSlots:            m.config.MaxSlots,
+				PriceLimit:          m.config.PriceLimit,
 				MaxAccountDemotions: m.config.MaxAccountDemotions,
 			},
 		)

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -150,6 +150,7 @@ type account struct {
 	init               sync.Once
 	enqueued, promoted *accountQueue
 	nextNonce          uint64
+	demotions          uint
 }
 
 // getNonce returns the next expected nonce for this account.

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -150,7 +150,7 @@ type account struct {
 	init               sync.Once
 	enqueued, promoted *accountQueue
 	nextNonce          uint64
-	demotions          uint
+	demotions          uint64
 }
 
 // getNonce returns the next expected nonce for this account.

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -182,16 +182,17 @@ func NewTxPool(
 	config *Config,
 ) (*TxPool, error) {
 	pool := &TxPool{
-		logger:      logger.Named("txpool"),
-		forks:       forks,
-		store:       store,
-		metrics:     metrics,
-		accounts:    accountsMap{},
-		executables: newPricedQueue(),
-		index:       lookupMap{all: make(map[types.Hash]*types.Transaction)},
-		gauge:       slotGauge{height: 0, max: config.MaxSlots},
-		priceLimit:  config.PriceLimit,
-		sealing:     config.Sealing,
+		logger:              logger.Named("txpool"),
+		forks:               forks,
+		store:               store,
+		metrics:             metrics,
+		accounts:            accountsMap{},
+		executables:         newPricedQueue(),
+		index:               lookupMap{all: make(map[types.Hash]*types.Transaction)},
+		gauge:               slotGauge{height: 0, max: config.MaxSlots},
+		priceLimit:          config.PriceLimit,
+		sealing:             config.Sealing,
+		maxAccountDemotions: config.MaxAccountDemotions,
 	}
 
 	// Attach the event manager

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -78,9 +78,10 @@ type signer interface {
 }
 
 type Config struct {
-	PriceLimit uint64
-	MaxSlots   uint64
-	Sealing    bool
+	PriceLimit          uint64
+	MaxSlots            uint64
+	Sealing             bool
+	MaxAccountDemotions uint64
 }
 
 /* All requests are passed to the main loop
@@ -165,6 +166,9 @@ type TxPool struct {
 
 	// indicates which txpool operator commands should be implemented
 	proto.UnimplementedTxnPoolOperatorServer
+
+	// maximum account demotion count. when reach, drop all transactions of this account
+	maxAccountDemotions uint64
 }
 
 // NewTxPool returns a new pool for processing incoming transactions.

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -21,6 +21,10 @@ const (
 	txSlotSize  = 32 * 1024  // 32kB
 	txMaxSize   = 128 * 1024 //128Kb
 	topicNameV1 = "txpool/0.1"
+
+	//	maximum allowed number of times an account
+	//	was excluded from block building (ibft.writeTransactions)
+	maxAccountDemotions = uint(10)
 )
 
 // errors
@@ -317,6 +321,9 @@ func (p *TxPool) Pop(tx *types.Transaction) {
 	// pop the top most promoted tx
 	account.promoted.pop()
 
+	//	successfully popping an account resets its demotions count to 0
+	account.demotions = 0
+
 	// update state
 	p.gauge.decrease(slotsRequired(tx))
 
@@ -378,7 +385,28 @@ func (p *TxPool) Drop(tx *types.Transaction) {
 	)
 }
 
+// Demote excludes an account from being further processed during block building
+// due to a recoverable error.
+//
+// If an account has been demoted too many times (maxAccountDemotions), it is Dropped instead.
 func (p *TxPool) Demote(tx *types.Transaction) {
+	account := p.accounts.get(tx.From)
+	if account.demotions == maxAccountDemotions {
+		p.logger.Debug(
+			"Demote: threshold reached - dropping account",
+			"addr", tx.From.String(),
+		)
+
+		p.Drop(tx)
+
+		//	reset the demotions counter
+		account.demotions = 0
+
+		return
+	}
+
+	account.demotions++
+
 	p.eventManager.signalEvent(proto.EventType_DEMOTED, tx.Hash)
 }
 
@@ -684,6 +712,9 @@ func (p *TxPool) resetAccounts(stateNonces map[types.Address]uint64) {
 		//	append pruned
 		allPrunedPromoted = append(allPrunedPromoted, prunedPromoted...)
 		allPrunedEnqueued = append(allPrunedEnqueued, prunedEnqueued...)
+
+		// new state for account -> demotions are reset to 0
+		account.demotions = 0
 	}
 
 	//	pool cleanup callback

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -21,10 +21,6 @@ const (
 	txSlotSize  = 32 * 1024  // 32kB
 	txMaxSize   = 128 * 1024 //128Kb
 	topicNameV1 = "txpool/0.1"
-
-	//	maximum allowed number of times an account
-	//	was excluded from block building (ibft.writeTransactions)
-	defaultMaxAccountDemotions = uint64(10)
 )
 
 // errors
@@ -396,7 +392,7 @@ func (p *TxPool) Drop(tx *types.Transaction) {
 // If an account has been demoted too many times (maxAccountDemotions), it is Dropped instead.
 func (p *TxPool) Demote(tx *types.Transaction) {
 	account := p.accounts.get(tx.From)
-	if account.demotions == defaultMaxAccountDemotions {
+	if account.demotions == p.maxAccountDemotions {
 		p.logger.Debug(
 			"Demote: threshold reached - dropping account",
 			"addr", tx.From.String(),

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -24,7 +24,7 @@ const (
 
 	//	maximum allowed number of times an account
 	//	was excluded from block building (ibft.writeTransactions)
-	maxAccountDemotions = uint(10)
+	defaultMaxAccountDemotions = uint64(10)
 )
 
 // errors
@@ -391,7 +391,7 @@ func (p *TxPool) Drop(tx *types.Transaction) {
 // If an account has been demoted too many times (maxAccountDemotions), it is Dropped instead.
 func (p *TxPool) Demote(tx *types.Transaction) {
 	account := p.accounts.get(tx.From)
-	if account.demotions == maxAccountDemotions {
+	if account.demotions == defaultMaxAccountDemotions {
 		p.logger.Debug(
 			"Demote: threshold reached - dropping account",
 			"addr", tx.From.String(),

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1054,7 +1054,7 @@ func TestDemote(t *testing.T) {
 		assert.Equal(t, uint64(1), pool.gauge.read())
 		assert.Equal(t, uint64(1), pool.accounts.get(addr1).getNonce())
 		assert.Equal(t, uint64(1), pool.accounts.get(addr1).promoted.length())
-		assert.Equal(t, uint(0), pool.accounts.get(addr1).demotions)
+		assert.Equal(t, uint64(0), pool.accounts.get(addr1).demotions)
 
 		//	call demote
 		pool.Prepare()
@@ -1066,7 +1066,7 @@ func TestDemote(t *testing.T) {
 		assert.Equal(t, uint64(1), pool.accounts.get(addr1).promoted.length())
 
 		//	assert counter was incremented
-		assert.Equal(t, uint(1), pool.accounts.get(addr1).demotions)
+		assert.Equal(t, uint64(1), pool.accounts.get(addr1).demotions)
 	})
 
 	t.Run("Demote calls Drop", func(t *testing.T) {
@@ -1090,7 +1090,7 @@ func TestDemote(t *testing.T) {
 		assert.Equal(t, uint64(1), pool.accounts.get(addr1).promoted.length())
 
 		//	set counter to max allowed demotions
-		pool.accounts.get(addr1).demotions = maxAccountDemotions
+		pool.accounts.get(addr1).demotions = defaultMaxAccountDemotions
 
 		//	call demote
 		pool.Prepare()
@@ -1103,7 +1103,7 @@ func TestDemote(t *testing.T) {
 		assert.Equal(t, uint64(0), pool.accounts.get(addr1).promoted.length())
 
 		//	demotions are reset to 0
-		assert.Equal(t, uint(0), pool.accounts.get(addr1).demotions)
+		assert.Equal(t, uint64(0), pool.accounts.get(addr1).demotions)
 	})
 }
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1090,7 +1090,7 @@ func TestDemote(t *testing.T) {
 		assert.Equal(t, uint64(1), pool.accounts.get(addr1).promoted.length())
 
 		//	set counter to max allowed demotions
-		pool.accounts.get(addr1).demotions = defaultMaxAccountDemotions
+		pool.accounts.get(addr1).demotions = pool.maxAccountDemotions
 
 		//	call demote
 		pool.Prepare()

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -18,9 +18,10 @@ import (
 )
 
 const (
-	defaultPriceLimit uint64 = 1
-	defaultMaxSlots   uint64 = 4096
-	validGasLimit     uint64 = 4712350
+	defaultPriceLimit          uint64 = 1
+	defaultMaxSlots            uint64 = 4096
+	defaultMaxAccountDemotions uint64 = 10
+	validGasLimit              uint64 = 4712350
 )
 
 var (

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -87,9 +87,10 @@ func newTestPoolWithSlots(maxSlots uint64, mockStore ...store) (*TxPool, error) 
 		nil,
 		nilMetrics,
 		&Config{
-			PriceLimit: defaultPriceLimit,
-			MaxSlots:   maxSlots,
-			Sealing:    false,
+			PriceLimit:          defaultPriceLimit,
+			MaxSlots:            maxSlots,
+			Sealing:             false,
+			MaxAccountDemotions: defaultMaxAccountDemotions,
 		},
 	)
 }


### PR DESCRIPTION
# Description

This PR addresses the issue of valid "stuck" transactions. These transactions remain in the pool indefinitely due to being considered recoverable by consensus during block building.

The PR is merging from [Polygon-Edge PR 541](https://github.com/0xPolygon/polygon-edge/pull/541)

The only difference is we add a new server command option `max-account-demotions` to ease config modification.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
