### PR TITLE
Fix eth_gasPrice test failure

### DIFF
--- a/jsonrpc/eth_blockchain_test.go
+++ b/jsonrpc/eth_blockchain_test.go
@@ -326,7 +326,7 @@ func TestEth_Syncing(t *testing.T) {
 
 func TestEth_GasPrice(t *testing.T) {
 	store := newMockBlockStore()
-	store.averageGasPrice = 9999
+	store.averageGasPrice, _ = strconv.ParseInt(defaultMinGasPrice, 0, 64)
 	eth := newTestEthEndpoint(store)
 
 	res, err := eth.GasPrice()

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -15,6 +15,10 @@ import (
 	"github.com/umbracle/fastrlp"
 )
 
+const (
+	defaultMinGasPrice = "0Xba43b7400" // 50 GWei
+)
+
 type ethTxPoolStore interface {
 	// GetNonce returns the next nonce for this address
 	GetNonce(addr types.Address) uint64
@@ -428,9 +432,7 @@ func (e *Eth) GasPrice() (interface{}, error) {
 	var avgGasPrice string
 
 	// Grab the average gas price and convert it to a hex value
-	minGasPrice := new(big.Int).Mul(
-		big.NewInt(50),
-		new(big.Int).Exp(big.NewInt(10), big.NewInt(9), nil))
+	minGasPrice, _ := new(big.Int).SetString(defaultMinGasPrice, 0)
 
 	if e.store.GetAvgGasPrice().Cmp(minGasPrice) == -1 {
 		avgGasPrice = hex.EncodeBig(minGasPrice)


### PR DESCRIPTION
# Description

`eth_gasPrice` always fail in GitHub PR tests. There is a minimum gas price setting, the PR fixed this.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually