### PR TITLE
Fix v-doge-vul-004

### DIFF
--- a/protocol/service_v1.go
+++ b/protocol/service_v1.go
@@ -14,6 +14,10 @@ import (
 	empty "google.golang.org/protobuf/types/known/emptypb"
 )
 
+var (
+	ErrNilRawRequest = errors.New("notify request raw is nil")
+)
+
 // serviceV1 is the GRPC server implementation for the v1 protocol
 type serviceV1 struct {
 	proto.UnimplementedV1Server
@@ -30,6 +34,11 @@ type rlpObject interface {
 }
 
 func (s *serviceV1) Notify(ctx context.Context, req *proto.NotifyReq) (*empty.Empty, error) {
+	if req.Raw == nil || len(req.Raw.Value) == 0 {
+		// malicious node conducted denial of service
+		return nil, ErrNilRawRequest
+	}
+
 	var id peer.ID
 
 	if ctx, ok := ctx.(*grpc.Context); ok {

--- a/protocol/service_v1.go
+++ b/protocol/service_v1.go
@@ -15,7 +15,8 @@ import (
 )
 
 var (
-	ErrNilRawRequest = errors.New("notify request raw is nil")
+	ErrNilRawRequest    = errors.New("notify request raw is nil")
+	ErrNilStatusRequest = errors.New("notify request status is nil")
 )
 
 // serviceV1 is the GRPC server implementation for the v1 protocol
@@ -37,6 +38,10 @@ func (s *serviceV1) Notify(ctx context.Context, req *proto.NotifyReq) (*empty.Em
 	if req.Raw == nil || len(req.Raw.Value) == 0 {
 		// malicious node conducted denial of service
 		return nil, ErrNilRawRequest
+	}
+
+	if req.Status == nil {
+		return nil, ErrNilStatusRequest
 	}
 
 	var id peer.ID

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -345,6 +345,7 @@ func (s *Syncer) Broadcast(b *types.Block) {
 
 // Start starts the syncer protocol
 func (s *Syncer) Start() {
+	// TODO: why not derived logger instead of null one?
 	s.serviceV1 = &serviceV1{syncer: s, logger: hclog.NewNullLogger(), store: s.blockchain}
 
 	// Get the current status of the syncer

--- a/protocol/syncer_test.go
+++ b/protocol/syncer_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dogechain-lab/jury/blockchain"
 	"github.com/dogechain-lab/jury/helper/tests"
 	"github.com/dogechain-lab/jury/network"
+	"github.com/dogechain-lab/jury/protocol/proto"
 	"github.com/dogechain-lab/jury/types"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
@@ -312,6 +313,72 @@ func TestWatchSyncWithPeer(t *testing.T) {
 			assert.Equal(t, tt.expectedHeight, syncer.status.Number)
 		})
 	}
+}
+
+func TestNilPointerAttackFromFaultyPeer(t *testing.T) {
+	tests := []struct {
+		name         string
+		headers      []*types.Header
+		peerHeaders  []*types.Header
+		numNewBlocks int
+	}{
+		{
+			name:         "should not crash even notify is nil",
+			headers:      blockchain.NewTestHeaderChainWithSeed(nil, 10, 0),
+			peerHeaders:  blockchain.NewTestHeaderChainWithSeed(nil, 1, 0),
+			numNewBlocks: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain, peerChain := NewMockBlockchain(tt.headers), NewMockBlockchain(tt.peerHeaders)
+
+			_, peerSyncers := SetupSyncerNetwork(t, chain, []blockchainShim{peerChain})
+			peerSyncer := peerSyncers[0]
+
+			newBlocks := GenerateNewBlocks(t, peerChain, tt.numNewBlocks)
+
+			for _, newBlock := range newBlocks {
+				assert.NoError(t, peerSyncer.blockchain.WriteBlock(newBlock))
+			}
+
+			for _, b := range newBlocks {
+				assert.NotPanics(t, func() {
+					peerSyncer.broadcastNilRawData(b)
+				})
+			}
+		})
+	}
+}
+
+func (s *Syncer) broadcastNilRawData(b *types.Block) {
+	// Get the chain difficulty associated with block
+	td, ok := s.blockchain.GetTD(b.Hash())
+	if !ok {
+		// not supposed to happen
+		s.logger.Error("total difficulty not found", "block number", b.Number())
+
+		return
+	}
+
+	// broadcast the new block to all the peers
+	req := &proto.NotifyReq{
+		Status: &proto.V1Status{
+			Hash:       b.Hash().String(),
+			Number:     b.Number(),
+			Difficulty: td.String(),
+		},
+		Raw: nil,
+	}
+
+	s.peers.Range(func(peerID, peer interface{}) bool {
+		if _, err := peer.(*SyncPeer).client.Notify(context.Background(), req); err != nil {
+			s.logger.Error("failed to notify", "err", err)
+		}
+
+		return true
+	})
 }
 
 func TestBulkSyncWithPeer(t *testing.T) {


### PR DESCRIPTION
# Description

All participating nodes in the blockchain listen on the gossip of new blocks leveraging `Protobuf` and `libp2p`. Nodes should not assume that these gossips are from valid nodes and should properly validate and sanitize the gossip messages.

The PR fixes a crash bug when a node send nil notify to another one, which would allow a malicious validator to trigger a null pointer dereferencing on all other nodes (including validators), thus crashing all of them, leading to denial of service or potentially more serious consequences.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually