### PR TITLE
Fix V-DOGE-VUL-005 & V-DOGE-VUL-006

### DIFF
--- a/protocol/skeleton.go
+++ b/protocol/skeleton.go
@@ -22,7 +22,7 @@ func getHeaders(clt proto.V1Client, req *proto.GetHeadersRequest) ([]*types.Head
 	headers := []*types.Header{}
 
 	for _, obj := range resp.Objs {
-		if obj.Spec == nil {
+		if obj == nil || obj.Spec == nil {
 			// this nil header comes from a faulty node, reject all blocks of it.
 			return nil, ErrNilHeaderRequest
 		}

--- a/protocol/skeleton.go
+++ b/protocol/skeleton.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	ErrNilHeaderRequest = errors.New("header request spec is nil")
+	ErrNilHeaderResponse = errors.New("header response is nil")
 )
 
 func getHeaders(clt proto.V1Client, req *proto.GetHeadersRequest) ([]*types.Header, error) {
@@ -24,7 +24,7 @@ func getHeaders(clt proto.V1Client, req *proto.GetHeadersRequest) ([]*types.Head
 	for _, obj := range resp.Objs {
 		if obj == nil || obj.Spec == nil {
 			// this nil header comes from a faulty node, reject all blocks of it.
-			return nil, ErrNilHeaderRequest
+			return nil, ErrNilHeaderResponse
 		}
 
 		header := &types.Header{}

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -725,13 +725,15 @@ func getHeader(clt proto.V1Client, num *uint64, hash *types.Hash) (*types.Header
 		return nil, ErrTooManyHeaders
 	}
 
-	if resp.Objs[0].Spec == nil || len(resp.Objs[0].Spec.Value) == 0 {
+	obj := resp.Objs[0]
+
+	if obj == nil || obj.Spec == nil || len(obj.Spec.Value) == 0 {
 		return nil, ErrNilHeaderRequest
 	}
 
 	header := &types.Header{}
 
-	if err := header.UnmarshalRLP(resp.Objs[0].Spec.Value); err != nil {
+	if err := header.UnmarshalRLP(obj.Spec.Value); err != nil {
 		return nil, err
 	}
 

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -37,6 +37,9 @@ var (
 	ErrForkNotFound           = errors.New("fork not found")
 	ErrPopTimeout             = errors.New("timeout")
 	ErrConnectionClosed       = errors.New("connection closed")
+	ErrTooManyHeaders         = errors.New("unexpected more than 1 result")
+	ErrDecodeDifficulty       = errors.New("failed to decode difficulty")
+	ErrInvalidTypeAssertion   = errors.New("invalid type assertion")
 )
 
 // SyncPeer is a representation of the peer the node is syncing with
@@ -187,7 +190,7 @@ func statusFromProto(p *proto.V1Status) (*Status, error) {
 
 	diff, ok := new(big.Int).SetString(p.Difficulty, 10)
 	if !ok {
-		return nil, fmt.Errorf("failed to decode difficulty")
+		return nil, ErrDecodeDifficulty
 	}
 
 	s.Difficulty = diff
@@ -494,7 +497,7 @@ func (s *Syncer) DeletePeer(peerID peer.ID) error {
 	if ok {
 		syncPeer, ok := p.(*SyncPeer)
 		if !ok {
-			return errors.New("invalid type assertion")
+			return ErrInvalidTypeAssertion
 		}
 
 		if err := syncPeer.conn.Close(); err != nil {
@@ -719,7 +722,7 @@ func getHeader(clt proto.V1Client, num *uint64, hash *types.Hash) (*types.Header
 	}
 
 	if len(resp.Objs) != 1 {
-		return nil, fmt.Errorf("unexpected more than 1 result")
+		return nil, ErrTooManyHeaders
 	}
 
 	if resp.Objs[0].Spec == nil || len(resp.Objs[0].Spec.Value) == 0 {

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -722,6 +722,10 @@ func getHeader(clt proto.V1Client, num *uint64, hash *types.Hash) (*types.Header
 		return nil, fmt.Errorf("unexpected more than 1 result")
 	}
 
+	if resp.Objs[0].Spec == nil || len(resp.Objs[0].Spec.Value) == 0 {
+		return nil, ErrNilHeaderRequest
+	}
+
 	header := &types.Header{}
 
 	if err := header.UnmarshalRLP(resp.Objs[0].Spec.Value); err != nil {

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -728,7 +728,7 @@ func getHeader(clt proto.V1Client, num *uint64, hash *types.Hash) (*types.Header
 	obj := resp.Objs[0]
 
 	if obj == nil || obj.Spec == nil || len(obj.Spec.Value) == 0 {
-		return nil, ErrNilHeaderRequest
+		return nil, ErrNilHeaderResponse
 	}
 
 	header := &types.Header{}


### PR DESCRIPTION
# Description

A malicious node could respond a maliciously-crafted header response to all its peers, which conduct a denial of service attack to bring down nodes in the network. The PR do reject all blocks from it when receiving nil header data.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually