### PR TITLE
Fix V-DOGE-VUL-008

### DIFF
--- a/consensus/ibft/sign_test.go
+++ b/consensus/ibft/sign_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/dogechain-lab/jury/consensus/ibft/proto"
+	"github.com/dogechain-lab/jury/crypto"
 	"github.com/dogechain-lab/jury/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -75,11 +76,20 @@ func TestSign_CommittedSeals(t *testing.T) {
 	assert.Error(t, buildCommittedSeal([]string{"A"}))
 }
 
+func TestSign_EmptyMessages(t *testing.T) {
+	err := validateMsg(&proto.MessageReq{})
+	if assert.Error(t, err) {
+		assert.Equal(t, crypto.ErrEmptySignature, err)
+	}
+}
+
 func TestSign_Messages(t *testing.T) {
 	pool := newTesterAccountPool()
 	pool.add("A")
 
-	msg := &proto.MessageReq{}
+	msg := &proto.MessageReq{
+		Type: proto.MessageReq_RoundChange,
+	}
 	assert.NoError(t, signMsg(pool.get("A").priv, msg))
 	assert.NoError(t, validateMsg(msg))
 

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -21,6 +21,10 @@ import (
 )
 
 var (
+	ErrEmptySignature = errors.New("empty signature")
+)
+
+var (
 	big1 = big.NewInt(1)
 )
 
@@ -138,6 +142,11 @@ func Ecrecover(hash, sig []byte) ([]byte, error) {
 // RecoverPubkey verifies the compact signature "signature" of "hash" for the
 // secp256k1 curve.
 func RecoverPubkey(signature, hash []byte) (*ecdsa.PublicKey, error) {
+	if len(signature) == 0 {
+		// would not handle invalid signature and hash, which might from faulty nodes
+		return nil, ErrEmptySignature
+	}
+
 	size := len(signature)
 	term := byte(27)
 


### PR DESCRIPTION
# Description

The PR fixes index out of range in `ibft` message verification, which comes from a faulty node.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
