### PR TITLE
Fix V-DOGE-VUL-011 & V-DOGE-VUL-012

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -145,6 +145,11 @@ func Factory(
 		}
 
 		epochSize = uint64(readSize)
+
+		if epochSize == 0 {
+			// epoch size should never be zero.
+			epochSize = DefaultEpochSize
+		}
 	}
 
 	p := &Ibft{


### PR DESCRIPTION
# Description

The PR fixes devide zero crash when epochSize set to zero.  We just simply set it to default value when given `0` in config file.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually