### PR TITLE
fix v-doge-vul-009

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -940,7 +940,8 @@ func (i *Ibft) runValidateState() {
 			i.state.addCommitted(msg)
 
 		default:
-			panic(fmt.Sprintf("BUG: %s", reflect.TypeOf(msg.Type)))
+			i.logger.Error("BUG: %s, validate state don't not handle type.msg: %d",
+				reflect.TypeOf(msg.Type), msg.Type)
 		}
 
 		if i.state.numPrepared() > i.state.NumValid() {


### PR DESCRIPTION
# Description

msg.Type in runValidateState() could cause process panic. main process should not panic handle the msg came from outer. log the error info in stead of panic.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

