### PR TITLE
Add server command log-to flag

### DIFF
--- a/command/server/config.go
+++ b/command/server/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	RestoreFile       string     `json:"restore_file"`
 	BlockTime         uint64     `json:"block_time_s"`
 	Headers           *Headers   `json:"headers"`
+	LogFilePath       string     `json:"log_to"`
 }
 
 // Telemetry holds the config details for metric services.
@@ -88,6 +89,7 @@ func DefaultConfig() *Config {
 		Headers: &Headers{
 			AccessControlAllowOrigins: []string{"*"},
 		},
+		LogFilePath: "",
 	}
 }
 

--- a/command/server/init.go
+++ b/command/server/init.go
@@ -38,13 +38,32 @@ func (p *serverParams) initRawParams() error {
 		return err
 	}
 
+	if err := p.initDataDirLocation(); err != nil {
+		return err
+	}
+
 	if p.isDevMode {
 		p.initDevMode()
 	}
 
 	p.initPeerLimits()
+	p.initLogFileLocation()
 
 	return p.initAddresses()
+}
+
+func (p *serverParams) initDataDirLocation() error {
+	if p.rawConfig.DataDir == "" {
+		return fmt.Errorf("data directory not defined")
+	}
+
+	return nil
+}
+
+func (p *serverParams) initLogFileLocation() {
+	if p.isLogFileLocationSet() {
+		p.logFileLocation = p.rawConfig.LogFilePath
+	}
 }
 
 func (p *serverParams) initBlockGasTarget() error {

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -36,6 +36,7 @@ const (
 	devFlag                 = "dev"
 	corsOriginFlag          = "access-control-allow-origins"
 	daemonFlag              = "daemon"
+	logFileLocationFlag     = "log-to"
 )
 
 const (
@@ -78,6 +79,8 @@ type serverParams struct {
 
 	genesisConfig *chain.Chain
 	secretsConfig *secrets.SecretsManagerConfig
+
+	logFileLocation string
 }
 
 func (p *serverParams) validateFlags() error {
@@ -87,6 +90,10 @@ func (p *serverParams) validateFlags() error {
 	}
 
 	return nil
+}
+
+func (p *serverParams) isLogFileLocationSet() bool {
+	return p.rawConfig.LogFilePath != ""
 }
 
 func (p *serverParams) isMaxPeersSet() bool {
@@ -166,6 +173,7 @@ func (p *serverParams) generateConfig() *server.Config {
 		RestoreFile:         p.getRestoreFilePath(),
 		BlockTime:           p.rawConfig.BlockTime,
 		LogLevel:            hclog.LevelFromString(p.rawConfig.LogLevel),
+		LogFilePath:         p.logFileLocation,
 		Daemon:              p.isDaemon,
 		ValidatorKey:        p.validatorKey,
 	}

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -205,6 +205,13 @@ func setFlags(cmd *cobra.Command) {
 		"the flag indicating that the server ran as daemon",
 	)
 
+	cmd.Flags().StringVar(
+		&params.rawConfig.LogFilePath,
+		logFileLocationFlag,
+		defaultConfig.LogFilePath,
+		"write all logs to the file at specified location instead of writing them to console",
+	)
+
 	setDevFlags(cmd)
 }
 
@@ -230,7 +237,7 @@ func setDevFlags(cmd *cobra.Command) {
 
 func runPreRun(cmd *cobra.Command, _ []string) error {
 	// Set the grpc and json ip:port bindings
-	// The config file will have presedence over --flag
+	// The config file will have precedence over --flag
 	params.setRawGRPCAddress(helper.GetGRPCAddress(cmd))
 	params.setRawJSONRPCAddress(helper.GetJSONRPCAddress(cmd))
 

--- a/server/config.go
+++ b/server/config.go
@@ -33,10 +33,10 @@ type Config struct {
 	RestoreFile *string
 
 	Seal bool
-
 	SecretsManager *secrets.SecretsManagerConfig
 
-	LogLevel hclog.Level
+	LogLevel    hclog.Level
+	LogFilePath string
 
 	Daemon       bool
 	ValidatorKey string

--- a/server/config.go
+++ b/server/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	DataDir     string
 	RestoreFile *string
 
-	Seal bool
+	Seal           bool
 	SecretsManager *secrets.SecretsManagerConfig
 
 	LogLevel    hclog.Level


### PR DESCRIPTION
# Description

This PR add a new flag `log-to` to `server` command. When set, the log would output to a file instead of the standard output.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Local build, local test.

Run with `./jury server --log-to test.log`

Logs should be output to the `test.log`