### PR TITLE
Remove contractAddress from receipt if not contract deployment

### DIFF
--- a/archive/restore_test.go
+++ b/archive/restore_test.go
@@ -2,7 +2,6 @@ package archive
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -203,13 +202,6 @@ func Test_parseBlock(t *testing.T) {
 			blockstream: newBlockStream(bytes.NewBuffer(blocks[0].MarshalRLP())),
 			block:       blocks[0],
 			err:         nil,
-		},
-		{
-			name:        "should return error",
-			blockstream: newBlockStream(bytes.NewBuffer((&Metadata{}).MarshalRLP())),
-			block:       nil,
-			// should fail by wrong format
-			err: errors.New("incorrect number of elements to decode block, expected 3 but found 2"),
 		},
 	}
 

--- a/archive/restore_test.go
+++ b/archive/restore_test.go
@@ -209,7 +209,7 @@ func Test_parseBlock(t *testing.T) {
 			blockstream: newBlockStream(bytes.NewBuffer((&Metadata{}).MarshalRLP())),
 			block:       nil,
 			// should fail by wrong format
-			err: errors.New("not enough elements to decode block, expected 3 but found 2"),
+			err: errors.New("incorrect number of elements to decode block, expected 3 but found 2"),
 		},
 	}
 
@@ -235,12 +235,6 @@ func Test_parseMetadata(t *testing.T) {
 			blockstream: newBlockStream(bytes.NewBuffer(metadata.MarshalRLP())),
 			metadata:    &metadata,
 			err:         nil,
-		},
-		{
-			name:        "should return error",
-			blockstream: newBlockStream(bytes.NewBuffer(blocks[0].MarshalRLP())),
-			metadata:    nil,
-			err:         errors.New("not enough elements to decode Metadata, expected 2 but found 3"),
 		},
 	}
 

--- a/archive/types.go
+++ b/archive/types.go
@@ -45,8 +45,9 @@ func (m *Metadata) UnmarshalRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) error {
 		return err
 	}
 
-	if num := len(elems); num != 2 {
-		return fmt.Errorf("not enough elements to decode Metadata, expected 2 but found %d", num)
+	if num := len(elems); num < 2 {
+		return fmt.Errorf("incorrect number of elements to decode Metadata, expected at least 2 but found %d",
+			len(elems))
 	}
 
 	if m.Latest, err = elems[0].GetUint64(); err != nil {

--- a/blockchain/storage/testing.go
+++ b/blockchain/storage/testing.go
@@ -371,7 +371,7 @@ func testReceipts(t *testing.T, m MockStorage) {
 		TxHash:            txn.Hash,
 		LogsBloom:         types.Bloom{0x1},
 		GasUsed:           10,
-		ContractAddress:   types.Address{0x1},
+		ContractAddress:   &types.Address{0x1},
 		Logs: []*types.Log{
 			{
 				Address: addr2,

--- a/consensus/ibft/extra.go
+++ b/consensus/ibft/extra.go
@@ -135,8 +135,9 @@ func (i *IstanbulExtra) UnmarshalRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) er
 		return err
 	}
 
-	if num := len(elems); num != 3 {
-		return fmt.Errorf("not enough elements to decode istambul extra, expected 3 but found %d", num)
+	if num := len(elems); num < 3 {
+		return fmt.Errorf("incorrect number of elements to decode istambul extra, expected at least 3 but found %d",
+			len(elems))
 	}
 
 	// Validators

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -166,7 +166,7 @@ type receipt struct {
 	BlockHash         types.Hash     `json:"blockHash"`
 	BlockNumber       argUint64      `json:"blockNumber"`
 	GasUsed           argUint64      `json:"gasUsed"`
-	ContractAddress   types.Address  `json:"contractAddress"`
+	ContractAddress   *types.Address `json:"contractAddress"`
 	FromAddr          types.Address  `json:"from"`
 	ToAddr            *types.Address `json:"to"`
 }

--- a/state/executor.go
+++ b/state/executor.go
@@ -228,7 +228,7 @@ func (t *Transition) WriteFailedReceipt(txn *types.Transaction) error {
 	t.receipts = append(t.receipts, receipt)
 
 	if txn.To == nil {
-		receipt.ContractAddress = crypto.CreateAddress(txn.From, txn.Nonce)
+		receipt.ContractAddress = crypto.CreateAddress(txn.From, txn.Nonce).Ptr()
 	}
 
 	return nil
@@ -287,7 +287,7 @@ func (t *Transition) Write(txn *types.Transaction) error {
 
 	// if the transaction created a contract, store the creation address in the receipt.
 	if msg.To == nil {
-		receipt.ContractAddress = crypto.CreateAddress(msg.From, txn.Nonce)
+		receipt.ContractAddress = crypto.CreateAddress(msg.From, txn.Nonce).Ptr()
 	}
 
 	// handle cross bridge logs from|to dogecoin blockchain

--- a/state/state.go
+++ b/state/state.go
@@ -64,8 +64,9 @@ func (a *Account) UnmarshalRlp(b []byte) error {
 		return err
 	}
 
-	if len(elems) != 4 {
-		return fmt.Errorf("bad")
+	if len(elems) < 4 {
+		return fmt.Errorf("incorrect number of elements to decode account, expected at least 4 but found %d",
+			len(elems))
 	}
 
 	// nonce

--- a/types/receipt.go
+++ b/types/receipt.go
@@ -30,12 +30,16 @@ type Receipt struct {
 
 	// context fields
 	GasUsed         uint64
-	ContractAddress Address
+	ContractAddress *Address
 	TxHash          Hash
 }
 
 func (r *Receipt) SetStatus(s ReceiptStatus) {
 	r.Status = &s
+}
+
+func (r *Receipt) SetContractAddress(contractAddress Address) {
+	r.ContractAddress = &contractAddress
 }
 
 type Log struct {

--- a/types/rlp_encoding_test.go
+++ b/types/rlp_encoding_test.go
@@ -79,7 +79,7 @@ func TestRLPStorage_Marshall_And_Unmarshall_Receipt(t *testing.T) {
 			&Receipt{
 				CumulativeGasUsed: 10,
 				GasUsed:           100,
-				ContractAddress:   addr,
+				ContractAddress:   &addr,
 				TxHash:            hash,
 			},
 			true,
@@ -90,7 +90,7 @@ func TestRLPStorage_Marshall_And_Unmarshall_Receipt(t *testing.T) {
 				Root:              hash,
 				CumulativeGasUsed: 10,
 				GasUsed:           100,
-				ContractAddress:   addr,
+				ContractAddress:   &addr,
 				TxHash:            hash,
 			},
 			false,

--- a/types/rlp_marshal_storage.go
+++ b/types/rlp_marshal_storage.go
@@ -71,7 +71,7 @@ func (r *Receipt) MarshalStoreRLPWith(a *fastrlp.Arena) *fastrlp.Value {
 	vv := a.NewArray()
 	vv.Set(r.MarshalRLPWith(a))
 
-	if r.ContractAddress == ZeroAddress {
+	if r.ContractAddress == nil {
 		vv.Set(a.NewNull())
 	} else {
 		vv.Set(a.NewBytes(r.ContractAddress.Bytes()))

--- a/types/rlp_unmarshal.go
+++ b/types/rlp_unmarshal.go
@@ -44,8 +44,9 @@ func (b *Block) UnmarshalRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) error {
 		return err
 	}
 
-	if num := len(elems); num != 3 {
-		return fmt.Errorf("not enough elements to decode block, expected 3 but found %d", num)
+	if len(elems) < 3 {
+		return fmt.Errorf("incorrect number of elements to decode block, expected at least 3 but found %d",
+			len(elems))
 	}
 
 	// header
@@ -97,8 +98,9 @@ func (h *Header) UnmarshalRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) error {
 		return err
 	}
 
-	if num := len(elems); num != 15 {
-		return fmt.Errorf("not enough elements to decode header, expected 15 but found %d", num)
+	if len(elems) < 15 {
+		return fmt.Errorf("incorrect number of elements to decode header, expected at least 15 but found %d",
+			len(elems))
 	}
 
 	// parentHash
@@ -204,8 +206,9 @@ func (r *Receipt) UnmarshalRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) error {
 		return err
 	}
 
-	if len(elems) != 4 {
-		return fmt.Errorf("expected 4 elements")
+	if len(elems) < 4 {
+		return fmt.Errorf("incorrect number of elements to decode receipt, expected at least 4 but found %d",
+			len(elems))
 	}
 
 	// root or status
@@ -258,8 +261,9 @@ func (l *Log) UnmarshalRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) error {
 		return err
 	}
 
-	if len(elems) != 3 {
-		return fmt.Errorf("bad elems")
+	if len(elems) < 3 {
+		return fmt.Errorf("incorrect number of elements to decode log, expected at least 3 but found %d",
+			len(elems))
 	}
 
 	// address
@@ -299,8 +303,9 @@ func (t *Transaction) UnmarshalRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) erro
 		return err
 	}
 
-	if num := len(elems); num != 9 {
-		return fmt.Errorf("not enough elements to decode transaction, expected 9 but found %d", num)
+	if len(elems) < 9 {
+		return fmt.Errorf("incorrect number of elements to decode transaction, expected at least 9 but found %d",
+			len(elems))
 	}
 
 	p.Hash(t.Hash[:0], v)

--- a/types/rlp_unmarshal_storage.go
+++ b/types/rlp_unmarshal_storage.go
@@ -20,8 +20,9 @@ func (b *Body) UnmarshalRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) error {
 		return err
 	}
 
-	if len(tuple) != 2 {
-		return fmt.Errorf("not enough elements to decode header, expected 15 but found %d", len(tuple))
+	if len(tuple) < 2 {
+		return fmt.Errorf("incorrect number of elements to decode body, expected at least 2 but found %d",
+			len(tuple))
 	}
 
 	// transactions
@@ -67,8 +68,9 @@ func (t *Transaction) UnmarshalStoreRLPFrom(p *fastrlp.Parser, v *fastrlp.Value)
 		return err
 	}
 
-	if len(elems) != 2 {
-		return fmt.Errorf("expected 2 elements")
+	if len(elems) < 2 {
+		return fmt.Errorf("incorrect number of elements to decode transaction, expected at least 2 but found %d",
+			len(elems))
 	}
 
 	// consensus part
@@ -116,7 +118,8 @@ func (r *Receipt) UnmarshalStoreRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) err
 	}
 
 	if len(elems) < 3 {
-		return fmt.Errorf("expected at least 3 elements")
+		return fmt.Errorf("incorrect number of elements to decode receipt, expected at least 3 but found %d",
+			len(elems))
 	}
 
 	if err := r.UnmarshalRLPFrom(p, elems[0]); err != nil {
@@ -131,7 +134,7 @@ func (r *Receipt) UnmarshalStoreRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) err
 
 	if len(vv) == 20 {
 		// address
-		r.ContractAddress = BytesToAddress(vv)
+		r.SetContractAddress(BytesToAddress(vv))
 	}
 
 	// gas used

--- a/types/types.go
+++ b/types/types.go
@@ -95,6 +95,10 @@ func (a Address) checksumEncode() string {
 	return "0x" + string(result)
 }
 
+func (a Address) Ptr() *Address {
+	return &a
+}
+
 func (a Address) String() string {
 	return a.checksumEncode()
 }


### PR DESCRIPTION
# Description

Native tx and calling contract methods should not have ContractAddress field set to 0x0 address.

This PR set it to `null`.

Merging from [Polygon Edge PR 546](https://github.com/0xPolygon/polygon-edge/pull/546)

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

The older version client could not `Unmarshal` this new version client receipt.

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
