### PR TITLE
Use block-gas-target flag in building block

### DIFF
--- a/command/server/params.go
+++ b/command/server/params.go
@@ -142,8 +142,15 @@ func (p *serverParams) setRawJSONRPCAddress(jsonRPCAddress string) {
 }
 
 func (p *serverParams) generateConfig() *server.Config {
+	chainCfg := p.genesisConfig
+
+	// Replace block gas limit
+	if p.blockGasTarget > 0 {
+		chainCfg.Params.BlockGasTarget = p.blockGasTarget
+	}
+
 	return &server.Config{
-		Chain: p.genesisConfig,
+		Chain: chainCfg,
 		JSONRPC: &server.JSONRPC{
 			JSONRPCAddr:              p.jsonRPCAddress,
 			AccessControlAllowOrigin: p.corsAllowedOrigins,


### PR DESCRIPTION
# Description

The server  flag `block-gas-target` is not used when building block, which is a little confusing.

This flag set the flag in server chain param, and make the block gas dynamically change as the documentation describes.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

* Setup a `genesis.json`, which use `10000` block gas  limit.
* Setup a local debug node in IDE, which use `50000` block gas  limit in Genesis Block.
* Send enough transactions to fill the `txpool`, make sure each block could be fullfilled.
* Watching the blocks built by the node, we should see the block transaction count grown more and more.