### PR TITLE
Remove skeleton confusing codes

### DIFF
--- a/protocol/skeleton.go
+++ b/protocol/skeleton.go
@@ -134,7 +134,6 @@ func (s *skeleton) addSkeleton(headers []*types.Header) error {
 		slot := &slot{
 			hash:   header.Hash,
 			number: header.Number,
-			blocks: make([]*types.Block, diff),
 		}
 		s.slots[indx] = slot
 	}

--- a/protocol/skeleton.go
+++ b/protocol/skeleton.go
@@ -56,7 +56,11 @@ func (s *skeleton) build(clt proto.V1Client, ancestor types.Hash) error {
 	if err != nil {
 		return err
 	}
-	s.addSkeleton(headers) // nolint
+
+	err = s.addSkeleton(headers)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/protocol/skeleton.go
+++ b/protocol/skeleton.go
@@ -73,7 +73,8 @@ func (s *skeleton) fillSlot(indx uint64, clt proto.V1Client) error {
 		return err
 	}
 
-	slot.blocks = []*types.Block{}
+	// alloc the slice capacity once and for all
+	slot.blocks = make([]*types.Block, 0, len(resp))
 
 	for _, h := range resp {
 		slot.blocks = append(slot.blocks, &types.Block{
@@ -82,8 +83,9 @@ func (s *skeleton) fillSlot(indx uint64, clt proto.V1Client) error {
 	}
 
 	// for each header with body we request it
-	bodyHashes := []types.Hash{}
-	bodyIndex := []int{}
+	// alloc the slice capacity  once and for al
+	bodyHashes := make([]types.Hash, 0, len(resp))
+	bodyIndex := make([]int, 0, len(resp))
 
 	for indx, h := range resp {
 		if h.TxRoot != types.EmptyRootHash {


### PR DESCRIPTION
# Description

This PR removes the slice making code `make([]*types.Block, diff)` in `skeleton.build()`.

The code is a little confusing, for its purpose is only to fill span headers.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
