### PR TITLE
[Blockchain] Simplify block verification

### DIFF
--- a/archive/restore.go
+++ b/archive/restore.go
@@ -19,6 +19,7 @@ type blockchainInterface interface {
 	GetBlockByNumber(uint64, bool) (*types.Block, bool)
 	GetHashByNumber(uint64) types.Hash
 	WriteBlock(*types.Block) error
+	VerifyFinalizedBlock(*types.Block) error
 }
 
 // RestoreChain reads blocks from the archive and write to the chain
@@ -73,6 +74,10 @@ func importBlocks(chain blockchainInterface, blockStream *blockStream, progressi
 	nextBlock := firstBlock
 
 	for {
+		if err := chain.VerifyFinalizedBlock(nextBlock); err != nil {
+			return err
+		}
+
 		if err := chain.WriteBlock(nextBlock); err != nil {
 			return err
 		}

--- a/archive/restore_test.go
+++ b/archive/restore_test.go
@@ -55,6 +55,10 @@ func (m *mockChain) WriteBlock(block *types.Block) error {
 	return nil
 }
 
+func (m *mockChain) VerifyFinalizedBlock(block *types.Block) error {
+	return nil
+}
+
 func (m *mockChain) SubscribeEvents() blockchain.Subscription {
 	return protocol.NewMockSubscription()
 }

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -658,6 +658,14 @@ func (b *Blockchain) WriteHeadersWithBodies(headers []*types.Header) error {
 	return nil
 }
 
+// VerifyPotentialBlock does the minimal block verification without consulting the
+// consensus layer. Should only be used if consensus checks are done
+// outside the method call
+func (b *Blockchain) VerifyPotentialBlock(block *types.Block) error {
+	// Do just the initial block verification
+	return b.verifyBlock(block)
+}
+
 // VerifyFinalizedBlock verifies that the block is valid by performing a series of checks.
 // It is assumed that the block status is sealed (committed)
 func (b *Blockchain) VerifyFinalizedBlock(block *types.Block) error {

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -608,6 +608,10 @@ func (b *Blockchain) WriteHeadersWithBodies(headers []*types.Header) error {
 	return nil
 }
 
+func (b *Blockchain) VerifyFinalizedBlock(block *types.Block) error {
+	return nil
+}
+
 // WriteBlock writes a single block
 func (b *Blockchain) WriteBlock(block *types.Block) error {
 	// Check the param

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -56,7 +56,7 @@ type gasPriceAverage struct {
 }
 
 type Verifier interface {
-	VerifyHeader(parent, header *types.Header) error
+	VerifyHeader(header *types.Header) error
 	ProcessHeaders(headers []*types.Header) error
 	GetBlockCreator(header *types.Header) (types.Address, error)
 	PreStateCommit(header *types.Header, txn *state.Transition) error
@@ -658,7 +658,7 @@ func (b *Blockchain) WriteBlock(block *types.Block) error {
 	}
 
 	// Verify the header
-	if err := b.consensus.VerifyHeader(parent, block.Header); err != nil {
+	if err := b.consensus.VerifyHeader(block.Header); err != nil {
 		return fmt.Errorf("failed to verify the header: %w", err)
 	}
 

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dogechain-lab/dogechain/blockchain/storage"
 	"github.com/dogechain-lab/dogechain/blockchain/storage/memory"
 	"github.com/dogechain-lab/dogechain/chain"
+	"github.com/dogechain-lab/dogechain/state"
 	"github.com/dogechain-lab/dogechain/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -604,11 +605,22 @@ func TestCalculateGasLimit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := NewTestBlockchain(t, nil)
-			err := b.writeGenesis(&chain.Genesis{
-				GasLimit: tt.parentGasLimit,
+			storageCallback := func(storage *storage.MockStorage) {
+				storage.HookReadHeader(func(hash types.Hash) (*types.Header, error) {
+					return &types.Header{
+						// This is going to be the parent block header
+						GasLimit: tt.parentGasLimit,
+					}, nil
+				})
+			}
+
+			b, blockchainErr := NewMockBlockchain(map[TestCallbackType]interface{}{
+				StorageCallback: storageCallback,
 			})
-			assert.NoError(t, err, "failed to write genesis")
+			if blockchainErr != nil {
+				t.Fatalf("unable to construct the blockchain, %v", blockchainErr)
+			}
+
 			b.config.Params = &chain.Params{
 				BlockGasTarget: tt.blockGasTarget,
 			}
@@ -679,4 +691,308 @@ func TestGasPriceAverage(t *testing.T) {
 			assert.Equal(t, testCase.expectedNewAverage.String(), blockchain.gpAverage.price.String())
 		})
 	}
+}
+
+// TestBlockchain_VerifyBlockParent verifies that parent block verification
+// errors are handled correctly
+func TestBlockchain_VerifyBlockParent(t *testing.T) {
+	t.Parallel()
+
+	emptyHeader := &types.Header{
+		Hash:       types.ZeroHash,
+		ParentHash: types.ZeroHash,
+	}
+	emptyHeader.ComputeHash()
+
+	t.Run("Missing parent block", func(t *testing.T) {
+		t.Parallel()
+
+		// Set up the storage callback
+		storageCallback := func(storage *storage.MockStorage) {
+			storage.HookReadHeader(func(hash types.Hash) (*types.Header, error) {
+				return nil, errors.New("not found")
+			})
+		}
+
+		blockchain, err := NewMockBlockchain(map[TestCallbackType]interface{}{
+			StorageCallback: storageCallback,
+		})
+		if err != nil {
+			t.Fatalf("unable to instantiate new blockchain, %v", err)
+		}
+
+		// Create a dummy block
+		block := &types.Block{
+			Header: &types.Header{
+				ParentHash: types.ZeroHash,
+			},
+		}
+
+		assert.ErrorIs(t, blockchain.verifyBlockParent(block), ErrParentNotFound)
+	})
+
+	t.Run("Parent hash mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		// Set up the storage callback
+		storageCallback := func(storage *storage.MockStorage) {
+			storage.HookReadHeader(func(hash types.Hash) (*types.Header, error) {
+				return emptyHeader, nil
+			})
+		}
+
+		blockchain, err := NewMockBlockchain(map[TestCallbackType]interface{}{
+			StorageCallback: storageCallback,
+		})
+		if err != nil {
+			t.Fatalf("unable to instantiate new blockchain, %v", err)
+		}
+
+		// Create a dummy block whose parent hash will
+		// not match the computed parent hash
+		block := &types.Block{
+			Header: emptyHeader,
+		}
+
+		assert.ErrorIs(t, blockchain.verifyBlockParent(block), ErrParentHashMismatch)
+	})
+
+	t.Run("Invalid block sequence", func(t *testing.T) {
+		t.Parallel()
+
+		// Set up the storage callback
+		storageCallback := func(storage *storage.MockStorage) {
+			storage.HookReadHeader(func(hash types.Hash) (*types.Header, error) {
+				return emptyHeader, nil
+			})
+		}
+
+		blockchain, err := NewMockBlockchain(map[TestCallbackType]interface{}{
+			StorageCallback: storageCallback,
+		})
+		if err != nil {
+			t.Fatalf("unable to instantiate new blockchain, %v", err)
+		}
+
+		// Create a dummy block with a number much higher than the parent
+		block := &types.Block{
+			Header: &types.Header{
+				Number: 10,
+			},
+		}
+
+		assert.ErrorIs(t, blockchain.verifyBlockParent(block), ErrParentHashMismatch)
+	})
+
+	t.Run("Invalid block sequence", func(t *testing.T) {
+		t.Parallel()
+
+		// Set up the storage callback
+		storageCallback := func(storage *storage.MockStorage) {
+			storage.HookReadHeader(func(hash types.Hash) (*types.Header, error) {
+				return emptyHeader, nil
+			})
+		}
+
+		blockchain, err := NewMockBlockchain(map[TestCallbackType]interface{}{
+			StorageCallback: storageCallback,
+		})
+		if err != nil {
+			t.Fatalf("unable to instantiate new blockchain, %v", err)
+		}
+
+		// Create a dummy block with a number much higher than the parent
+		block := &types.Block{
+			Header: &types.Header{
+				Number:     10,
+				ParentHash: emptyHeader.Hash,
+			},
+		}
+
+		assert.ErrorIs(t, blockchain.verifyBlockParent(block), ErrInvalidBlockSequence)
+	})
+
+	t.Run("Invalid block gas limit", func(t *testing.T) {
+		t.Parallel()
+
+		parentHeader := emptyHeader.Copy()
+		parentHeader.GasLimit = 5000
+
+		// Set up the storage callback
+		storageCallback := func(storage *storage.MockStorage) {
+			storage.HookReadHeader(func(hash types.Hash) (*types.Header, error) {
+				return emptyHeader, nil
+			})
+		}
+
+		blockchain, err := NewMockBlockchain(map[TestCallbackType]interface{}{
+			StorageCallback: storageCallback,
+		})
+		if err != nil {
+			t.Fatalf("unable to instantiate new blockchain, %v", err)
+		}
+
+		// Create a dummy block with a number much higher than the parent
+		block := &types.Block{
+			Header: &types.Header{
+				Number:     1,
+				ParentHash: parentHeader.Hash,
+				GasLimit:   parentHeader.GasLimit + 1000, // The gas limit is greater than the allowed rate
+			},
+		}
+
+		assert.Error(t, blockchain.verifyBlockParent(block))
+	})
+}
+
+// TestBlockchain_VerifyBlockBody makes sure that the block body is verified correctly
+func TestBlockchain_VerifyBlockBody(t *testing.T) {
+	t.Parallel()
+
+	emptyHeader := &types.Header{
+		Hash:       types.ZeroHash,
+		ParentHash: types.ZeroHash,
+	}
+
+	t.Run("Invalid SHA3 Uncles root", func(t *testing.T) {
+		t.Parallel()
+
+		blockchain, err := NewMockBlockchain(nil)
+		if err != nil {
+			t.Fatalf("unable to instantiate new blockchain, %v", err)
+		}
+
+		block := &types.Block{
+			Header: &types.Header{
+				Sha3Uncles: types.ZeroHash,
+			},
+		}
+
+		assert.ErrorIs(t, blockchain.verifyBlockBody(block), ErrInvalidSha3Uncles)
+	})
+
+	t.Run("Invalid Transactions root", func(t *testing.T) {
+		t.Parallel()
+
+		blockchain, err := NewMockBlockchain(nil)
+		if err != nil {
+			t.Fatalf("unable to instantiate new blockchain, %v", err)
+		}
+
+		block := &types.Block{
+			Header: &types.Header{
+				Sha3Uncles: types.EmptyUncleHash,
+			},
+		}
+
+		assert.ErrorIs(t, blockchain.verifyBlockBody(block), ErrInvalidTxRoot)
+	})
+
+	t.Run("Invalid execution result - missing parent", func(t *testing.T) {
+		t.Parallel()
+
+		// Set up the storage callback
+		storageCallback := func(storage *storage.MockStorage) {
+			storage.HookReadHeader(func(hash types.Hash) (*types.Header, error) {
+				return nil, errors.New("not found")
+			})
+		}
+
+		blockchain, err := NewMockBlockchain(map[TestCallbackType]interface{}{
+			StorageCallback: storageCallback,
+		})
+		if err != nil {
+			t.Fatalf("unable to instantiate new blockchain, %v", err)
+		}
+
+		block := &types.Block{
+			Header: &types.Header{
+				Sha3Uncles: types.EmptyUncleHash,
+				TxRoot:     types.EmptyRootHash,
+			},
+		}
+
+		assert.ErrorIs(t, blockchain.verifyBlockBody(block), ErrParentNotFound)
+	})
+
+	t.Run("Invalid execution result - unable to fetch block creator", func(t *testing.T) {
+		t.Parallel()
+
+		errBlockCreatorNotFound := errors.New("not found")
+
+		// Set up the storage callback
+		storageCallback := func(storage *storage.MockStorage) {
+			// This is used for parent fetching
+			storage.HookReadHeader(func(hash types.Hash) (*types.Header, error) {
+				return emptyHeader, nil
+			})
+		}
+
+		// Set up the verifier callback
+		verifierCallback := func(verifier *MockVerifier) {
+			// This is used for error-ing out on the block creator fetch
+			verifier.HookGetBlockCreator(func(t *types.Header) (types.Address, error) {
+				return types.ZeroAddress, errBlockCreatorNotFound
+			})
+		}
+
+		blockchain, err := NewMockBlockchain(map[TestCallbackType]interface{}{
+			StorageCallback:  storageCallback,
+			VerifierCallback: verifierCallback,
+		})
+		if err != nil {
+			t.Fatalf("unable to instantiate new blockchain, %v", err)
+		}
+
+		block := &types.Block{
+			Header: &types.Header{
+				Sha3Uncles: types.EmptyUncleHash,
+				TxRoot:     types.EmptyRootHash,
+			},
+		}
+
+		assert.ErrorIs(t, blockchain.verifyBlockBody(block), errBlockCreatorNotFound)
+	})
+
+	t.Run("Invalid execution result - unable to execute transactions", func(t *testing.T) {
+		t.Parallel()
+
+		errUnableToExecute := errors.New("unable to execute transactions")
+
+		// Set up the storage callback
+		storageCallback := func(storage *storage.MockStorage) {
+			// This is used for parent fetching
+			storage.HookReadHeader(func(hash types.Hash) (*types.Header, error) {
+				return emptyHeader, nil
+			})
+		}
+
+		executorCallback := func(executor *mockExecutor) {
+			// This is executor processing
+			executor.HookProcessBlock(func(
+				hash types.Hash,
+				block *types.Block,
+				address types.Address,
+			) (*state.Transition, error) {
+				return nil, errUnableToExecute
+			})
+		}
+
+		blockchain, err := NewMockBlockchain(map[TestCallbackType]interface{}{
+			StorageCallback:  storageCallback,
+			ExecutorCallback: executorCallback,
+		})
+		if err != nil {
+			t.Fatalf("unable to instantiate new blockchain, %v", err)
+		}
+
+		block := &types.Block{
+			Header: &types.Header{
+				Sha3Uncles: types.EmptyUncleHash,
+				TxRoot:     types.EmptyRootHash,
+			},
+		}
+
+		assert.ErrorIs(t, blockchain.verifyBlockBody(block), errUnableToExecute)
+	})
 }

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -522,7 +522,7 @@ func TestInsertHeaders(t *testing.T) {
 	}
 }
 
-func TestForkUnkwonParents(t *testing.T) {
+func TestForkUnknownParents(t *testing.T) {
 	b := NewTestBlockchain(t, nil)
 
 	h0 := NewTestHeaderChain(10)

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -525,7 +525,7 @@ func TestInsertHeaders(t *testing.T) {
 func TestForkUnknownParents(t *testing.T) {
 	b := NewTestBlockchain(t, nil)
 
-	h0 := NewTestHeaderChain(10)
+	h0 := NewTestHeaders(10)
 	h1 := NewTestHeaderFromChain(h0[:5], 10)
 
 	// Write genesis

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -526,7 +526,7 @@ func TestForkUnknownParents(t *testing.T) {
 	b := NewTestBlockchain(t, nil)
 
 	h0 := NewTestHeaders(10)
-	h1 := NewTestHeaderFromChain(h0[:5], 10)
+	h1 := AppendNewTestHeaders(h0[:5], 10)
 
 	// Write genesis
 	_, err := b.advanceHead(h0[0])

--- a/blockchain/storage/testing.go
+++ b/blockchain/storage/testing.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type MockStorage func(t *testing.T) (Storage, func())
+type PlaceholderStorage func(t *testing.T) (Storage, func())
 
 var (
 	addr1 = types.StringToAddress("1")
@@ -22,7 +22,7 @@ var (
 )
 
 // TestStorage tests a set of tests on a storage
-func TestStorage(t *testing.T, m MockStorage) {
+func TestStorage(t *testing.T, m PlaceholderStorage) {
 	t.Helper()
 
 	t.Run("", func(t *testing.T) {
@@ -51,7 +51,7 @@ func TestStorage(t *testing.T, m MockStorage) {
 	})
 }
 
-func testCanonicalChain(t *testing.T, m MockStorage) {
+func testCanonicalChain(t *testing.T, m PlaceholderStorage) {
 	t.Helper()
 
 	s, closeFn := m(t)
@@ -104,7 +104,7 @@ func testCanonicalChain(t *testing.T, m MockStorage) {
 	}
 }
 
-func testDifficulty(t *testing.T, m MockStorage) {
+func testDifficulty(t *testing.T, m PlaceholderStorage) {
 	t.Helper()
 
 	s, closeFn := m(t)
@@ -151,7 +151,7 @@ func testDifficulty(t *testing.T, m MockStorage) {
 	}
 }
 
-func testHead(t *testing.T, m MockStorage) {
+func testHead(t *testing.T, m PlaceholderStorage) {
 	t.Helper()
 
 	s, closeFn := m(t)
@@ -196,7 +196,7 @@ func testHead(t *testing.T, m MockStorage) {
 	}
 }
 
-func testForks(t *testing.T, m MockStorage) {
+func testForks(t *testing.T, m PlaceholderStorage) {
 	t.Helper()
 
 	s, closeFn := m(t)
@@ -223,7 +223,7 @@ func testForks(t *testing.T, m MockStorage) {
 	}
 }
 
-func testHeader(t *testing.T, m MockStorage) {
+func testHeader(t *testing.T, m PlaceholderStorage) {
 	t.Helper()
 
 	s, closeFn := m(t)
@@ -252,7 +252,7 @@ func testHeader(t *testing.T, m MockStorage) {
 	}
 }
 
-func testBody(t *testing.T, m MockStorage) {
+func testBody(t *testing.T, m PlaceholderStorage) {
 	t.Helper()
 
 	s, closeFn := m(t)
@@ -319,7 +319,7 @@ func testBody(t *testing.T, m MockStorage) {
 	}
 }
 
-func testReceipts(t *testing.T, m MockStorage) {
+func testReceipts(t *testing.T, m PlaceholderStorage) {
 	t.Helper()
 
 	s, closeFn := m(t)
@@ -395,7 +395,7 @@ func testReceipts(t *testing.T, m MockStorage) {
 	assert.True(t, reflect.DeepEqual(receipts, found))
 }
 
-func testWriteCanonicalHeader(t *testing.T, m MockStorage) {
+func testWriteCanonicalHeader(t *testing.T, m PlaceholderStorage) {
 	t.Helper()
 
 	s, closeFn := m(t)
@@ -451,4 +451,322 @@ func testWriteCanonicalHeader(t *testing.T, m MockStorage) {
 	if canHash != h.Hash {
 		t.Fatal("canonical hash not correct")
 	}
+}
+
+// Storage delegators
+
+type readCanonicalHashDelegate func(uint64) (types.Hash, bool)
+type writeCanonicalHashDelegate func(uint64, types.Hash) error
+type readHeadHashDelegate func() (types.Hash, bool)
+type readHeadNumberDelegate func() (uint64, bool)
+type writeHeadHashDelegate func(types.Hash) error
+type writeHeadNumberDelegate func(uint64) error
+type writeForksDelegate func([]types.Hash) error
+type readForksDelegate func() ([]types.Hash, error)
+type writeTotalDifficultyDelegate func(types.Hash, *big.Int) error
+type readTotalDifficultyDelegate func(types.Hash) (*big.Int, bool)
+type writeHeaderDelegate func(*types.Header) error
+type readHeaderDelegate func(types.Hash) (*types.Header, error)
+type writeCanonicalHeaderDelegate func(*types.Header, *big.Int) error
+type writeBodyDelegate func(types.Hash, *types.Body) error
+type readBodyDelegate func(types.Hash) (*types.Body, error)
+type writeSnapshotDelegate func(types.Hash, []byte) error
+type readSnapshotDelegate func(types.Hash) ([]byte, bool)
+type writeReceiptsDelegate func(types.Hash, []*types.Receipt) error
+type readReceiptsDelegate func(types.Hash) ([]*types.Receipt, error)
+type writeTxLookupDelegate func(types.Hash, types.Hash) error
+type readTxLookupDelegate func(types.Hash) (types.Hash, bool)
+type closeDelegate func() error
+
+type MockStorage struct {
+	readCanonicalHashFn    readCanonicalHashDelegate
+	writeCanonicalHashFn   writeCanonicalHashDelegate
+	readHeadHashFn         readHeadHashDelegate
+	readHeadNumberFn       readHeadNumberDelegate
+	writeHeadHashFn        writeHeadHashDelegate
+	writeHeadNumberFn      writeHeadNumberDelegate
+	writeForksFn           writeForksDelegate
+	readForksFn            readForksDelegate
+	writeTotalDifficultyFn writeTotalDifficultyDelegate
+	readTotalDifficultyFn  readTotalDifficultyDelegate
+	writeHeaderFn          writeHeaderDelegate
+	readHeaderFn           readHeaderDelegate
+	writeCanonicalHeaderFn writeCanonicalHeaderDelegate
+	writeBodyFn            writeBodyDelegate
+	readBodyFn             readBodyDelegate
+	writeSnapshotFn        writeSnapshotDelegate
+	readSnapshotFn         readSnapshotDelegate
+	writeReceiptsFn        writeReceiptsDelegate
+	readReceiptsFn         readReceiptsDelegate
+	writeTxLookupFn        writeTxLookupDelegate
+	readTxLookupFn         readTxLookupDelegate
+	closeFn                closeDelegate
+}
+
+func NewMockStorage() *MockStorage {
+	return &MockStorage{}
+}
+
+func (m *MockStorage) ReadCanonicalHash(n uint64) (types.Hash, bool) {
+	if m.readCanonicalHashFn != nil {
+		return m.readCanonicalHashFn(n)
+	}
+
+	return types.Hash{}, true
+}
+
+func (m *MockStorage) HookReadCanonicalHash(fn readCanonicalHashDelegate) {
+	m.readCanonicalHashFn = fn
+}
+
+func (m *MockStorage) WriteCanonicalHash(n uint64, hash types.Hash) error {
+	if m.writeCanonicalHashFn != nil {
+		return m.writeCanonicalHashFn(n, hash)
+	}
+
+	return nil
+}
+
+func (m *MockStorage) HookWriteCanonicalHash(fn writeCanonicalHashDelegate) {
+	m.writeCanonicalHashFn = fn
+}
+
+func (m *MockStorage) ReadHeadHash() (types.Hash, bool) {
+	if m.readHeadHashFn != nil {
+		return m.readHeadHashFn()
+	}
+
+	return types.Hash{}, true
+}
+
+func (m *MockStorage) HookReadHeadHash(fn readHeadHashDelegate) {
+	m.readHeadHashFn = fn
+}
+
+func (m *MockStorage) ReadHeadNumber() (uint64, bool) {
+	if m.readHeadNumberFn != nil {
+		return m.readHeadNumberFn()
+	}
+
+	return 0, true
+}
+
+func (m *MockStorage) HookReadHeadNumber(fn readHeadNumberDelegate) {
+	m.readHeadNumberFn = fn
+}
+
+func (m *MockStorage) WriteHeadHash(h types.Hash) error {
+	if m.writeHeadHashFn != nil {
+		return m.writeHeadHashFn(h)
+	}
+
+	return nil
+}
+
+func (m *MockStorage) HookWriteHeadHash(fn writeHeadHashDelegate) {
+	m.writeHeadHashFn = fn
+}
+
+func (m *MockStorage) WriteHeadNumber(n uint64) error {
+	if m.writeHeadNumberFn != nil {
+		return m.writeHeadNumberFn(n)
+	}
+
+	return nil
+}
+
+func (m *MockStorage) HookWriteHeadNumber(fn writeHeadNumberDelegate) {
+	m.writeHeadNumberFn = fn
+}
+
+func (m *MockStorage) WriteForks(forks []types.Hash) error {
+	if m.writeForksFn != nil {
+		return m.writeForksFn(forks)
+	}
+
+	return nil
+}
+
+func (m *MockStorage) HookWriteForks(fn writeForksDelegate) {
+	m.writeForksFn = fn
+}
+
+func (m *MockStorage) ReadForks() ([]types.Hash, error) {
+	if m.readForksFn != nil {
+		return m.readForksFn()
+	}
+
+	return []types.Hash{}, nil
+}
+
+func (m *MockStorage) HookReadForks(fn readForksDelegate) {
+	m.readForksFn = fn
+}
+
+func (m *MockStorage) WriteTotalDifficulty(hash types.Hash, diff *big.Int) error {
+	if m.writeTotalDifficultyFn != nil {
+		return m.writeTotalDifficultyFn(hash, diff)
+	}
+
+	return nil
+}
+
+func (m *MockStorage) HookWriteTotalDifficulty(fn writeTotalDifficultyDelegate) {
+	m.writeTotalDifficultyFn = fn
+}
+
+func (m *MockStorage) ReadTotalDifficulty(hash types.Hash) (*big.Int, bool) {
+	if m.readTotalDifficultyFn != nil {
+		return m.readTotalDifficultyFn(hash)
+	}
+
+	return big.NewInt(0), true
+}
+
+func (m *MockStorage) HookReadTotalDifficulty(fn readTotalDifficultyDelegate) {
+	m.readTotalDifficultyFn = fn
+}
+
+func (m *MockStorage) WriteHeader(h *types.Header) error {
+	if m.writeHeaderFn != nil {
+		return m.writeHeaderFn(h)
+	}
+
+	return nil
+}
+
+func (m *MockStorage) HookWriteHeader(fn writeHeaderDelegate) {
+	m.writeHeaderFn = fn
+}
+
+func (m *MockStorage) ReadHeader(hash types.Hash) (*types.Header, error) {
+	if m.readHeaderFn != nil {
+		return m.readHeaderFn(hash)
+	}
+
+	return &types.Header{}, nil
+}
+
+func (m *MockStorage) HookReadHeader(fn readHeaderDelegate) {
+	m.readHeaderFn = fn
+}
+
+func (m *MockStorage) WriteCanonicalHeader(h *types.Header, diff *big.Int) error {
+	if m.writeCanonicalHeaderFn != nil {
+		return m.writeCanonicalHeaderFn(h, diff)
+	}
+
+	return nil
+}
+
+func (m *MockStorage) HookWriteCanonicalHeader(fn writeCanonicalHeaderDelegate) {
+	m.writeCanonicalHeaderFn = fn
+}
+
+func (m *MockStorage) WriteBody(hash types.Hash, body *types.Body) error {
+	if m.writeBodyFn != nil {
+		return m.writeBodyFn(hash, body)
+	}
+
+	return nil
+}
+
+func (m *MockStorage) HookWriteBody(fn writeBodyDelegate) {
+	m.writeBodyFn = fn
+}
+
+func (m *MockStorage) ReadBody(hash types.Hash) (*types.Body, error) {
+	if m.readBodyFn != nil {
+		return m.readBodyFn(hash)
+	}
+
+	return &types.Body{}, nil
+}
+
+func (m *MockStorage) HookReadBody(fn readBodyDelegate) {
+	m.readBodyFn = fn
+}
+
+func (m *MockStorage) WriteSnapshot(hash types.Hash, blob []byte) error {
+	if m.writeSnapshotFn != nil {
+		return m.writeSnapshotFn(hash, blob)
+	}
+
+	return nil
+}
+
+func (m *MockStorage) HookWriteSnapshot(fn writeSnapshotDelegate) {
+	m.writeSnapshotFn = fn
+}
+
+func (m *MockStorage) ReadSnapshot(hash types.Hash) ([]byte, bool) {
+	if m.readSnapshotFn != nil {
+		return m.readSnapshotFn(hash)
+	}
+
+	return []byte{}, true
+}
+
+func (m *MockStorage) HookReadSnapshot(fn readSnapshotDelegate) {
+	m.readSnapshotFn = fn
+}
+
+func (m *MockStorage) WriteReceipts(hash types.Hash, receipts []*types.Receipt) error {
+	if m.writeReceiptsFn != nil {
+		return m.writeReceiptsFn(hash, receipts)
+	}
+
+	return nil
+}
+
+func (m *MockStorage) HookWriteReceipts(fn writeReceiptsDelegate) {
+	m.writeReceiptsFn = fn
+}
+
+func (m *MockStorage) ReadReceipts(hash types.Hash) ([]*types.Receipt, error) {
+	if m.readReceiptsFn != nil {
+		return m.readReceiptsFn(hash)
+	}
+
+	return []*types.Receipt{}, nil
+}
+
+func (m *MockStorage) HookReadReceipts(fn readReceiptsDelegate) {
+	m.readReceiptsFn = fn
+}
+
+func (m *MockStorage) WriteTxLookup(hash types.Hash, blockHash types.Hash) error {
+	if m.writeTxLookupFn != nil {
+		return m.writeTxLookupFn(hash, blockHash)
+	}
+
+	return nil
+}
+
+func (m *MockStorage) HookWriteTxLookup(fn writeTxLookupDelegate) {
+	m.writeTxLookupFn = fn
+}
+
+func (m *MockStorage) ReadTxLookup(hash types.Hash) (types.Hash, bool) {
+	if m.readTxLookupFn != nil {
+		return m.readTxLookupFn(hash)
+	}
+
+	return types.Hash{}, true
+}
+
+func (m *MockStorage) HookReadTxLookup(fn readTxLookupDelegate) {
+	m.readTxLookupFn = fn
+}
+
+func (m *MockStorage) Close() error {
+	if m.closeFn != nil {
+		return m.closeFn()
+	}
+
+	return nil
+}
+
+func (m *MockStorage) HookClose(fn closeDelegate) {
+	m.closeFn = fn
 }

--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -274,7 +274,11 @@ func (m *MockVerifier) HookPreStateCommit(fn preStateCommitDelegate) {
 	m.preStateCommitFn = fn
 }
 
+// Executor delegators
+type processBlockDelegate func(types.Hash, *types.Block, types.Address) (*state.Transition, error)
+
 type mockExecutor struct {
+	processBlockFn processBlockDelegate
 }
 
 func (m *mockExecutor) ProcessBlock(
@@ -282,7 +286,15 @@ func (m *mockExecutor) ProcessBlock(
 	block *types.Block,
 	blockCreator types.Address,
 ) (*state.Transition, error) {
+	if m.processBlockFn != nil {
+		return m.processBlockFn(parentRoot, block, blockCreator)
+	}
+
 	return nil, nil
+}
+
+func (m *mockExecutor) HookProcessBlock(fn processBlockDelegate) {
+	m.processBlockFn = fn
 }
 
 func TestBlockchain(t *testing.T, genesis *chain.Genesis) *Blockchain {

--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -1,21 +1,26 @@
 package blockchain
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"testing"
 
+	"github.com/dogechain-lab/dogechain/blockchain/storage"
 	"github.com/dogechain-lab/dogechain/chain"
 	"github.com/dogechain-lab/dogechain/state"
 	itrie "github.com/dogechain-lab/dogechain/state/immutable-trie"
-	"github.com/hashicorp/go-hclog"
-
 	"github.com/dogechain-lab/dogechain/types"
+	"github.com/hashicorp/go-hclog"
 )
 
 var (
 	// defaultBlockGasTarget is the default value for the block gas target for new blocks
 	defaultBlockGasTarget uint64 = 8000000
+)
+
+var (
+	errInvalidTypeAssertion = errors.New("invalid type assertion")
 )
 
 // NewTestHeadersWithSeed creates a new chain with a seed factor

--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -19,8 +19,8 @@ var (
 	defaultBlockGasTarget uint64 = 8000000
 )
 
-// NewTestHeaderChainWithSeed creates a new chain with a seed factor
-func NewTestHeaderChainWithSeed(genesis *types.Header, n int, seed uint64) []*types.Header {
+// NewTestHeadersWithSeed creates a new chain with a seed factor
+func NewTestHeadersWithSeed(genesis *types.Header, n int, seed uint64) []*types.Header {
 	head := func(i int64) *types.Header {
 		return &types.Header{
 			Number:       uint64(i),
@@ -51,9 +51,9 @@ func NewTestHeaderChainWithSeed(genesis *types.Header, n int, seed uint64) []*ty
 	return headers
 }
 
-// NewTestHeaderChain creates a chain of valid headers
-func NewTestHeaderChain(n int) []*types.Header {
-	return NewTestHeaderChainWithSeed(nil, n, 0)
+// NewTestHeaders creates a chain of valid headers
+func NewTestHeaders(n int) []*types.Header {
+	return NewTestHeadersWithSeed(nil, n, 0)
 }
 
 // NewTestHeaderFromChain creates n new headers from an already existing chain
@@ -64,7 +64,7 @@ func NewTestHeaderFromChain(headers []*types.Header, n int) []*types.Header {
 // NewTestHeaderFromChainWithSeed creates n new headers from an already existing chain
 func NewTestHeaderFromChainWithSeed(headers []*types.Header, n int, seed uint64) []*types.Header {
 	// We do +1 because the first header will be the genesis we supplied
-	newHeaders := NewTestHeaderChainWithSeed(headers[len(headers)-1], n+1, seed)
+	newHeaders := NewTestHeadersWithSeed(headers[len(headers)-1], n+1, seed)
 
 	preHeaders := make([]*types.Header, len(headers))
 	copy(preHeaders, headers)

--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -2,7 +2,6 @@ package blockchain
 
 import (
 	"fmt"
-	"math/big"
 	"testing"
 
 	"github.com/dogechain-lab/dogechain/chain"
@@ -11,7 +10,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/dogechain-lab/dogechain/types"
-	"github.com/dogechain-lab/dogechain/types/buildroot"
 )
 
 var (
@@ -79,74 +77,6 @@ func HeadersToBlocks(headers []*types.Header) []*types.Block {
 	}
 
 	return blocks
-}
-
-// NewTestBodyChain creates a test blockchain with headers, body and receipts
-func NewTestBodyChain(n int) ([]*types.Header, []*types.Block, [][]*types.Receipt) {
-	genesis := &types.Block{
-		Header: &types.Header{
-			Number:   0,
-			GasLimit: uint64(0),
-		},
-	}
-	genesis.Header.ComputeHash()
-
-	blocks := []*types.Block{genesis}
-	receipts := [][]*types.Receipt{nil} // genesis does not have tx
-
-	for i := 1; i < n; i++ {
-		header := &types.Header{
-			ParentHash: blocks[i-1].Hash(),
-			Number:     uint64(i),
-			Difficulty: uint64(i),
-			ExtraData:  []byte{},
-		}
-		header.ComputeHash()
-
-		// -- txs ---
-
-		addr0 := types.StringToAddress("00")
-		t0 := &types.Transaction{
-			Nonce:    uint64(i),
-			To:       &addr0,
-			Value:    big.NewInt(0),
-			Gas:      0,
-			GasPrice: big.NewInt(0),
-			Input:    header.Hash.Bytes(),
-			V:        big.NewInt(27),
-		}
-		t0.ComputeHash()
-
-		txs := []*types.Transaction{t0}
-
-		// -- receipts --
-		r0 := &types.Receipt{
-			GasUsed: uint64(i),
-			//TxHash:            t0.Hash,
-			CumulativeGasUsed: uint64(i), // this value changes the rlpHash
-		}
-		localReceipts := []*types.Receipt{r0}
-
-		header.TxRoot = buildroot.CalculateTransactionsRoot(txs)
-		header.ReceiptsRoot = buildroot.CalculateReceiptsRoot(localReceipts)
-		header.LogsBloom = types.CreateBloom(localReceipts)
-		header.Sha3Uncles = types.EmptyUncleHash
-
-		block := &types.Block{
-			Header:       header,
-			Transactions: txs,
-		}
-
-		blocks = append(blocks, block)
-		receipts = append(receipts, localReceipts)
-	}
-
-	headers := []*types.Header{}
-	for _, block := range blocks {
-		headers = append(headers, block.Header)
-	}
-
-	return headers, blocks, receipts
 }
 
 // NewTestBlockchain creates a new dummy blockchain for testing

--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -60,13 +60,13 @@ func NewTestHeaders(n int) []*types.Header {
 	return NewTestHeadersWithSeed(nil, n, 0)
 }
 
-// NewTestHeaderFromChain creates n new headers from an already existing chain
-func NewTestHeaderFromChain(headers []*types.Header, n int) []*types.Header {
-	return NewTestHeaderFromChainWithSeed(headers, n, 0)
+// AppendNewTestHeaders creates n new headers from an already existing chain
+func AppendNewTestHeaders(headers []*types.Header, n int) []*types.Header {
+	return AppendNewTestheadersWithSeed(headers, n, 0)
 }
 
-// NewTestHeaderFromChainWithSeed creates n new headers from an already existing chain
-func NewTestHeaderFromChainWithSeed(headers []*types.Header, n int, seed uint64) []*types.Header {
+// AppendNewTestheadersWithSeed creates n new headers from an already existing chain
+func AppendNewTestheadersWithSeed(headers []*types.Header, n int, seed uint64) []*types.Header {
 	// We do +1 because the first header will be the genesis we supplied
 	newHeaders := NewTestHeadersWithSeed(headers[len(headers)-1], n+1, seed)
 

--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -190,11 +190,22 @@ func NewTestBlockchain(t *testing.T, headers []*types.Header) *Blockchain {
 	return b
 }
 
+type verifyHeaderDelegate func(*types.Header) error
+
 type MockVerifier struct {
+	verifyHeaderFn verifyHeaderDelegate
 }
 
-func (m *MockVerifier) VerifyHeader(parent, header *types.Header) error {
+func (m *MockVerifier) VerifyHeader(header *types.Header) error {
+	if m.verifyHeaderFn != nil {
+		return m.verifyHeaderFn(header)
+	}
+
 	return nil
+}
+
+func (m *MockVerifier) HookVerifyHeader(fn verifyHeaderDelegate) {
+	m.verifyHeaderFn = fn
 }
 
 func (m *MockVerifier) ProcessHeaders(headers []*types.Header) error {

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -20,7 +20,7 @@ import (
 // Each consensus mechanism must implement this interface in order to be valid
 type Consensus interface {
 	// VerifyHeader verifies the header is correct
-	VerifyHeader(parent, header *types.Header) error
+	VerifyHeader(header *types.Header) error
 
 	// ProcessHeaders updates the snapshot based on the verified headers
 	ProcessHeaders(headers []*types.Header) error

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -206,7 +206,7 @@ func (d *Dev) writeNewBlock(parent *types.Header) error {
 
 // REQUIRED BASE INTERFACE METHODS //
 
-func (d *Dev) VerifyHeader(parent *types.Header, header *types.Header) error {
+func (d *Dev) VerifyHeader(header *types.Header) error {
 	// All blocks are valid
 	return nil
 }

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -192,6 +192,10 @@ func (d *Dev) writeNewBlock(parent *types.Header) error {
 		Receipts: transition.Receipts(),
 	})
 
+	if err := d.blockchain.VerifyFinalizedBlock(block); err != nil {
+		return err
+	}
+
 	// Write the block to the blockchain
 	if err := d.blockchain.WriteBlock(block); err != nil {
 		return err

--- a/consensus/dummy/dummy.go
+++ b/consensus/dummy/dummy.go
@@ -47,7 +47,7 @@ func (d *Dummy) Start() error {
 	return nil
 }
 
-func (d *Dummy) VerifyHeader(parent *types.Header, header *types.Header) error {
+func (d *Dummy) VerifyHeader(header *types.Header) error {
 	// All blocks are valid
 	return nil
 }

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -857,7 +857,7 @@ func (i *Ibft) runAcceptState() { // start new round
 		} else {
 			// since it's a new block, we have to verify it first
 			if err := i.verifyHeaderImpl(snap, parent, block.Header); err != nil {
-				i.logger.Error("block verification failed", "err", err)
+				i.logger.Error("block header verification failed", "err", err)
 				i.handleStateErr(errBlockVerificationFailed)
 
 				continue

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -1300,7 +1300,7 @@ func (i *Ibft) VerifyHeader(header *types.Header) error {
 			header.Number,
 		)
 	}
-	
+
 	snap, err := i.getSnapshot(parent.Number)
 	if err != nil {
 		return err

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -1292,7 +1292,15 @@ func (i *Ibft) verifyHeaderImpl(snap *Snapshot, parent, header *types.Header) er
 }
 
 // VerifyHeader wrapper for verifying headers
-func (i *Ibft) VerifyHeader(parent, header *types.Header) error {
+func (i *Ibft) VerifyHeader(header *types.Header) error {
+	parent, ok := i.blockchain.GetHeaderByNumber(header.Number - 1)
+	if !ok {
+		return fmt.Errorf(
+			"unable to get parent header for block number %d",
+			header.Number,
+		)
+	}
+	
 	snap, err := i.getSnapshot(parent.Number)
 	if err != nil {
 		return err

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -839,10 +839,6 @@ func (m *mockIbft) VerifyPotentialBlock(block *types.Block) error {
 	return nil
 }
 
-func (m *mockIbft) VerifyFinalizedBlock(block *types.Block) error {
-	return nil
-}
-
 func (m *mockIbft) emitMsg(msg *proto.MessageReq) {
 	// convert the address from the address pool
 	from := m.pool.get(msg.From).Address()

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -835,6 +835,10 @@ func (m *mockIbft) WriteBlock(block *types.Block) error {
 	return nil
 }
 
+func (m *mockIbft) VerifyFinalizedBlock(block *types.Block) error {
+	return nil
+}
+
 func (m *mockIbft) emitMsg(msg *proto.MessageReq) {
 	// convert the address from the address pool
 	from := m.pool.get(msg.From).Address()

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -835,6 +835,10 @@ func (m *mockIbft) WriteBlock(block *types.Block) error {
 	return nil
 }
 
+func (m *mockIbft) VerifyPotentialBlock(block *types.Block) error {
+	return nil
+}
+
 func (m *mockIbft) VerifyFinalizedBlock(block *types.Block) error {
 	return nil
 }

--- a/consensus/noproof.go
+++ b/consensus/noproof.go
@@ -12,7 +12,7 @@ type NoProof struct {
 }
 
 // VerifyHeader verifies the header is correct
-func (n *NoProof) VerifyHeader(parent, header *types.Header, uncle, seal bool) error {
+func (n *NoProof) VerifyHeader(header *types.Header, uncle, seal bool) error {
 	return nil
 }
 

--- a/protocol/blockchain.go
+++ b/protocol/blockchain.go
@@ -21,5 +21,6 @@ type blockchainShim interface {
 
 	// advance chain methods
 	WriteBlock(block *types.Block) error
+	VerifyFinalizedBlock(block *types.Block) error
 	CalculateGasLimit(number uint64) (uint64, error)
 }

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -612,6 +612,12 @@ func (s *Syncer) WatchSyncWithPeer(p *SyncPeer, handler func(b *types.Block) boo
 			break
 		}
 
+		if err := s.blockchain.VerifyFinalizedBlock(b); err != nil {
+			s.logger.Error("unable to verify block, %w", err)
+
+			return
+		}
+
 		if err := s.blockchain.WriteBlock(b); err != nil {
 			s.logger.Error("failed to write block", "err", err)
 
@@ -687,8 +693,12 @@ func (s *Syncer) BulkSyncWithPeer(p *SyncPeer, newBlockHandler func(block *types
 			// sync the data
 			for _, slot := range sk.slots {
 				for _, block := range slot.blocks {
+					if err := s.blockchain.VerifyFinalizedBlock(block); err != nil {
+						return fmt.Errorf("unable to verify block, %w", err)
+					}
+
 					if err := s.blockchain.WriteBlock(block); err != nil {
-						return fmt.Errorf("failed to write bulk sync blocks: %w", err)
+						return fmt.Errorf("failed to write bulk sync block: %w", err)
 					}
 
 					newBlockHandler(block)

--- a/protocol/syncer_test.go
+++ b/protocol/syncer_test.go
@@ -117,6 +117,7 @@ func TestBroadcast(t *testing.T) {
 			newBlocks := GenerateNewBlocks(t, peerSyncer.blockchain, tt.numNewBlocks)
 
 			for _, newBlock := range newBlocks {
+				assert.NoError(t, peerSyncer.blockchain.VerifyFinalizedBlock(newBlock))
 				assert.NoError(t, peerSyncer.blockchain.WriteBlock(newBlock))
 			}
 
@@ -285,6 +286,7 @@ func TestWatchSyncWithPeer(t *testing.T) {
 			newBlocks := GenerateNewBlocks(t, peerChain, tt.numNewBlocks)
 
 			for _, newBlock := range newBlocks {
+				assert.NoError(t, peerSyncer.blockchain.VerifyFinalizedBlock(newBlock))
 				assert.NoError(t, peerSyncer.blockchain.WriteBlock(newBlock))
 			}
 
@@ -350,6 +352,7 @@ func TestNilPointerAttackFromFaultyPeer(t *testing.T) {
 			newBlocks := GenerateNewBlocks(t, peerChain, tt.numNewBlocks)
 
 			for _, newBlock := range newBlocks {
+				assert.NoError(t, peerSyncer.blockchain.VerifyFinalizedBlock(newBlock))
 				assert.NoError(t, peerSyncer.blockchain.WriteBlock(newBlock))
 			}
 

--- a/protocol/syncer_test.go
+++ b/protocol/syncer_test.go
@@ -102,8 +102,8 @@ func TestBroadcast(t *testing.T) {
 	}{
 		{
 			name:          "syncer should receive new block in peer",
-			syncerHeaders: blockchain.NewTestHeaderChainWithSeed(nil, 5, 0),
-			peerHeaders:   blockchain.NewTestHeaderChainWithSeed(nil, 10, 0),
+			syncerHeaders: blockchain.NewTestHeadersWithSeed(nil, 5, 0),
+			peerHeaders:   blockchain.NewTestHeadersWithSeed(nil, 10, 0),
 			numNewBlocks:  5,
 		},
 	}
@@ -206,8 +206,8 @@ func TestFindCommonAncestor(t *testing.T) {
 	}{
 		{
 			name:          "should find common ancestor",
-			syncerHeaders: blockchain.NewTestHeaderChainWithSeed(nil, 10, 0),
-			peerHeaders:   blockchain.NewTestHeaderChainWithSeed(nil, 20, 0),
+			syncerHeaders: blockchain.NewTestHeadersWithSeed(nil, 10, 0),
+			peerHeaders:   blockchain.NewTestHeadersWithSeed(nil, 20, 0),
 			found:         true,
 			headerIndex:   9,
 			forkIndex:     10,
@@ -215,8 +215,8 @@ func TestFindCommonAncestor(t *testing.T) {
 		},
 		{
 			name:          "should return error if there is no fork",
-			syncerHeaders: blockchain.NewTestHeaderChainWithSeed(nil, 11, 0),
-			peerHeaders:   blockchain.NewTestHeaderChainWithSeed(nil, 10, 0),
+			syncerHeaders: blockchain.NewTestHeadersWithSeed(nil, 11, 0),
+			peerHeaders:   blockchain.NewTestHeadersWithSeed(nil, 10, 0),
 			found:         false,
 			err:           errors.New("fork not found"),
 		},
@@ -259,16 +259,16 @@ func TestWatchSyncWithPeer(t *testing.T) {
 	}{
 		{
 			name:           "should sync until peer's latest block",
-			headers:        blockchain.NewTestHeaderChainWithSeed(nil, 10, 0),
-			peerHeaders:    blockchain.NewTestHeaderChainWithSeed(nil, 1, 0),
+			headers:        blockchain.NewTestHeadersWithSeed(nil, 10, 0),
+			peerHeaders:    blockchain.NewTestHeadersWithSeed(nil, 1, 0),
 			numNewBlocks:   15,
 			shouldSync:     true,
 			expectedHeight: 15,
 		},
 		{
 			name:           "shouldn't sync",
-			headers:        blockchain.NewTestHeaderChainWithSeed(nil, 10, 0),
-			peerHeaders:    blockchain.NewTestHeaderChainWithSeed(nil, 1, 0),
+			headers:        blockchain.NewTestHeadersWithSeed(nil, 10, 0),
+			peerHeaders:    blockchain.NewTestHeadersWithSeed(nil, 1, 0),
 			numNewBlocks:   9,
 			shouldSync:     false,
 			expectedHeight: 9,
@@ -326,15 +326,15 @@ func TestNilPointerAttackFromFaultyPeer(t *testing.T) {
 	}{
 		{
 			name:              "should not crash even notify raw data is nil",
-			headers:           blockchain.NewTestHeaderChainWithSeed(nil, 3, 0),
-			peerHeaders:       blockchain.NewTestHeaderChainWithSeed(nil, 1, 0),
+			headers:           blockchain.NewTestHeadersWithSeed(nil, 3, 0),
+			peerHeaders:       blockchain.NewTestHeadersWithSeed(nil, 1, 0),
 			numNewBlocks:      1,
 			testBroadcastFunc: broadcastNilRawData,
 		},
 		{
 			name:              "should not crash even notify status is nil",
-			headers:           blockchain.NewTestHeaderChainWithSeed(nil, 5, 0),
-			peerHeaders:       blockchain.NewTestHeaderChainWithSeed(nil, 1, 0),
+			headers:           blockchain.NewTestHeadersWithSeed(nil, 5, 0),
+			peerHeaders:       blockchain.NewTestHeadersWithSeed(nil, 1, 0),
 			numNewBlocks:      1,
 			testBroadcastFunc: broadcastNilStatusData,
 		},
@@ -421,16 +421,16 @@ func TestBulkSyncWithPeer(t *testing.T) {
 	}{
 		{
 			name:          "should sync until peer's latest block",
-			headers:       blockchain.NewTestHeaderChainWithSeed(nil, 10, 0),
-			peerHeaders:   blockchain.NewTestHeaderChainWithSeed(nil, 30, 0),
+			headers:       blockchain.NewTestHeadersWithSeed(nil, 10, 0),
+			peerHeaders:   blockchain.NewTestHeadersWithSeed(nil, 30, 0),
 			shouldSync:    true,
 			syncFromBlock: 10,
 			err:           nil,
 		},
 		{
 			name:          "shouldn't sync if peer's latest block is behind",
-			headers:       blockchain.NewTestHeaderChainWithSeed(nil, 20, 0),
-			peerHeaders:   blockchain.NewTestHeaderChainWithSeed(nil, 10, 0),
+			headers:       blockchain.NewTestHeadersWithSeed(nil, 20, 0),
+			peerHeaders:   blockchain.NewTestHeadersWithSeed(nil, 10, 0),
 			shouldSync:    false,
 			syncFromBlock: 0,
 			err:           errors.New("fork not found"),
@@ -473,11 +473,11 @@ func TestSyncer_GetSyncProgression(t *testing.T) {
 	initialChainSize := 10
 	targetChainSize := 1000
 
-	existingChain := blockchain.NewTestHeaderChainWithSeed(nil, initialChainSize, 0)
+	existingChain := blockchain.NewTestHeadersWithSeed(nil, initialChainSize, 0)
 	syncerChain := NewMockBlockchain(existingChain)
 	syncer := CreateSyncer(t, syncerChain, nil)
 
-	syncHeaders := blockchain.NewTestHeaderChainWithSeed(nil, targetChainSize, 0)
+	syncHeaders := blockchain.NewTestHeadersWithSeed(nil, targetChainSize, 0)
 	syncBlocks := blockchain.HeadersToBlocks(syncHeaders)
 
 	syncer.syncProgression.StartProgression(uint64(initialChainSize), syncerChain.SubscribeEvents())

--- a/protocol/syncer_test.go
+++ b/protocol/syncer_test.go
@@ -586,6 +586,10 @@ func (m *mockBlockStore) WriteBlock(block *types.Block) error {
 	return nil
 }
 
+func (m *mockBlockStore) VerifyFinalizedBlock(block *types.Block) error {
+	return nil
+}
+
 func (m *mockBlockStore) CurrentTD() *big.Int {
 	return m.td
 }

--- a/protocol/testing.go
+++ b/protocol/testing.go
@@ -330,7 +330,7 @@ func (b *mockBlockchain) WriteBlock(block *types.Block) error {
 	return nil
 }
 
-func (m *mockBlockchain) VerifyFinalizedBlock(block *types.Block) error {
+func (b *mockBlockchain) VerifyFinalizedBlock(block *types.Block) error {
 	return nil
 }
 

--- a/protocol/testing.go
+++ b/protocol/testing.go
@@ -330,6 +330,10 @@ func (b *mockBlockchain) WriteBlock(block *types.Block) error {
 	return nil
 }
 
+func (m *mockBlockchain) VerifyFinalizedBlock(block *types.Block) error {
+	return nil
+}
+
 func (b *mockBlockchain) WriteBlocks(blocks []*types.Block) error {
 	for _, block := range blocks {
 		if writeErr := b.WriteBlock(block); writeErr != nil {

--- a/protocol/testing.go
+++ b/protocol/testing.go
@@ -185,7 +185,7 @@ func GenerateNewBlocks(t *testing.T, chain blockchainShim, num int) []*types.Blo
 		assert.Truef(t, ok, "chain should have header at %d, but empty", i)
 	}
 
-	headers := blockchain.NewTestHeaderFromChain(oldHeaders, num)
+	headers := blockchain.AppendNewTestHeaders(oldHeaders, num)
 
 	return blockchain.HeadersToBlocks(headers[currentHeight+1:])
 }

--- a/protocol/testing.go
+++ b/protocol/testing.go
@@ -137,7 +137,7 @@ func NewRandomChain(t *testing.T, height int) blockchainShim {
 
 	return blockchain.NewTestBlockchain(
 		t,
-		blockchain.NewTestHeaderChainWithSeed(
+		blockchain.NewTestHeadersWithSeed(
 			nil,
 			height,
 			randNum.Uint64(),


### PR DESCRIPTION
# Description

This PR aims to separate out block insertion and block verification.
There are 2 kinds of block verifications that can occur:

* Node wants to verify a previously sealed block (from a different node)
* Node wants to verify a proposed block (from a different node)

It also refactors the way the blockchain module is tested.

The PR is merging from Polygon Edge [PR 544](https://github.com/0xPolygon/polygon-edge/pull/544).

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
