### PR TITLE
Fix block insert failed in commit state due to one marform commit message

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -1008,9 +1008,13 @@ func (i *Ibft) insertBlock(block *types.Block) error {
 		// no need to check the format of seal here because writeCommittedSeals will check
 		seal, err := hex.DecodeHex(commit.Seal)
 		if err != nil {
-			i.logger.Error("block insert, seal data decode hex err: ", err)
+			i.logger.Error(
+				fmt.Sprintf(
+					"unable to decode committed seal from %s: %v",
+					commit.From, err,
+				))
 
-			return err
+			continue
 		}
 
 		committedSeals = append(committedSeals, seal)


### PR DESCRIPTION
# Description

An evil validator could make other validators `insertBlock()` failed when in commit state, simply by posting an invalid commit  message to other nodes.

The PR fixed this.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
