### PR TITLE
add GraphQL feature

### DIFF
--- a/command/default.go
+++ b/command/default.go
@@ -16,9 +16,10 @@ const (
 )
 
 const (
-	JSONOutputFlag  = "json"
-	GRPCAddressFlag = "grpc-address"
-	JSONRPCFlag     = "jsonrpc"
+	JSONOutputFlag     = "json"
+	GRPCAddressFlag    = "grpc-address"
+	JSONRPCFlag        = "jsonrpc"
+	GraphQLAddressFlag = "graphql-address"
 )
 
 // Legacy flag that needs to be present to preserve backwards

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -163,6 +163,11 @@ func GetJSONRPCAddress(cmd *cobra.Command) string {
 	return cmd.Flag(command.JSONRPCFlag).Value.String()
 }
 
+// GetGraphQLAddress extracts the set GraphQL address
+func GetGraphQLAddress(cmd *cobra.Command) string {
+	return cmd.Flag(command.GraphQLAddressFlag).Value.String()
+}
+
 // RegisterJSONOutputFlag registers the --json output setting for all child commands
 func RegisterJSONOutputFlag(cmd *cobra.Command) {
 	cmd.PersistentFlags().Bool(
@@ -210,6 +215,20 @@ func RegisterJSONRPCFlag(cmd *cobra.Command) {
 // ParseJSONRPCAddress parses the passed in JSONRPC address
 func ParseJSONRPCAddress(jsonrpcAddress string) (*url.URL, error) {
 	return url.ParseRequestURI(jsonrpcAddress)
+}
+
+// RegisterGraphQLFlag registers the base GraphQL address flag for all child commands
+func RegisterGraphQLFlag(cmd *cobra.Command) {
+	cmd.PersistentFlags().String(
+		command.GraphQLAddressFlag,
+		fmt.Sprintf("%s:%d", LocalHostBinding, server.DefaultGraphQLPort),
+		"the GraphQL interface",
+	)
+}
+
+// ParseGraphQLAddress parses the passed in GraphQL address
+func ParseGraphQLAddress(graphqlAddress string) (*url.URL, error) {
+	return url.ParseRequestURI(graphqlAddress)
 }
 
 // ResolveAddr resolves the passed in TCP address

--- a/command/loadbot/loadbot_command.go
+++ b/command/loadbot/loadbot_command.go
@@ -151,6 +151,12 @@ func runPreRun(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	if _, err := helper.ParseGraphQLAddress(
+		helper.GetGraphQLAddress(cmd),
+	); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -29,6 +29,8 @@ type Config struct {
 	BlockTime         uint64     `json:"block_time_s"`
 	Headers           *Headers   `json:"headers"`
 	LogFilePath       string     `json:"log_to"`
+	EnableGraphQL     bool       `json:"enable_graphql"`
+	GraphQLAddr       string     `json:"graphql_addr"`
 }
 
 // Telemetry holds the config details for metric services.
@@ -89,7 +91,8 @@ func DefaultConfig() *Config {
 		Headers: &Headers{
 			AccessControlAllowOrigins: []string{"*"},
 		},
-		LogFilePath: "",
+		LogFilePath:   "",
+		EnableGraphQL: false,
 	}
 }
 

--- a/command/server/init.go
+++ b/command/server/init.go
@@ -204,6 +204,10 @@ func (p *serverParams) initAddresses() error {
 		return err
 	}
 
+	if err := p.initGraphQLAddress(); err != nil {
+		return err
+	}
+
 	return p.initGRPCAddress()
 }
 
@@ -273,6 +277,19 @@ func (p *serverParams) initJSONRPCAddress() error {
 	if p.jsonRPCAddress, parseErr = helper.ResolveAddr(
 		p.rawConfig.JSONRPCAddr,
 		helper.AllInterfacesBinding,
+	); parseErr != nil {
+		return parseErr
+	}
+
+	return nil
+}
+
+func (p *serverParams) initGraphQLAddress() error {
+	var parseErr error
+
+	if p.graphqlAddress, parseErr = helper.ResolveAddr(
+		p.rawConfig.GraphQLAddr,
+		helper.LocalHostBinding,
 	); parseErr != nil {
 		return parseErr
 	}

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -37,6 +37,7 @@ const (
 	corsOriginFlag          = "access-control-allow-origins"
 	daemonFlag              = "daemon"
 	logFileLocationFlag     = "log-to"
+	enableGraphQLFlag       = "enable-graphql"
 )
 
 const (
@@ -68,6 +69,7 @@ type serverParams struct {
 	dnsAddress        multiaddr.Multiaddr
 	grpcAddress       *net.TCPAddr
 	jsonRPCAddress    *net.TCPAddr
+	graphqlAddress    *net.TCPAddr
 
 	blockGasTarget uint64
 	devInterval    uint64
@@ -141,6 +143,10 @@ func (p *serverParams) setRawJSONRPCAddress(jsonRPCAddress string) {
 	p.rawConfig.JSONRPCAddr = jsonRPCAddress
 }
 
+func (p *serverParams) setRawGraphQLAddress(graphqlAddress string) {
+	p.rawConfig.GraphQLAddr = graphqlAddress
+}
+
 func (p *serverParams) generateConfig() *server.Config {
 	chainCfg := p.genesisConfig
 
@@ -153,6 +159,11 @@ func (p *serverParams) generateConfig() *server.Config {
 		Chain: chainCfg,
 		JSONRPC: &server.JSONRPC{
 			JSONRPCAddr:              p.jsonRPCAddress,
+			AccessControlAllowOrigin: p.corsAllowedOrigins,
+		},
+		EnableGraphQL: p.rawConfig.EnableGraphQL,
+		GraphQL: &server.GraphQL{
+			GraphQLAddr:              p.graphqlAddress,
 			AccessControlAllowOrigin: p.corsAllowedOrigins,
 		},
 		GRPCAddr:   p.grpcAddress,

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -31,6 +31,7 @@ func GetCommand() *cobra.Command {
 	helper.RegisterGRPCAddressFlag(serverCmd)
 	helper.RegisterLegacyGRPCAddressFlag(serverCmd)
 	helper.RegisterJSONRPCFlag(serverCmd)
+	helper.RegisterGraphQLFlag(serverCmd)
 
 	setFlags(serverCmd)
 
@@ -212,6 +213,13 @@ func setFlags(cmd *cobra.Command) {
 		"write all logs to the file at specified location instead of writing them to console",
 	)
 
+	cmd.Flags().BoolVar(
+		&params.rawConfig.EnableGraphQL,
+		enableGraphQLFlag,
+		false,
+		"the flag indicating that node enable graphql service",
+	)
+
 	setDevFlags(cmd)
 }
 
@@ -236,10 +244,11 @@ func setDevFlags(cmd *cobra.Command) {
 }
 
 func runPreRun(cmd *cobra.Command, _ []string) error {
-	// Set the grpc and json ip:port bindings
+	// Set the grpc, json and graphql ip:port bindings
 	// The config file will have precedence over --flag
 	params.setRawGRPCAddress(helper.GetGRPCAddress(cmd))
 	params.setRawJSONRPCAddress(helper.GetJSONRPCAddress(cmd))
+	params.setRawGraphQLAddress(helper.GetGraphQLAddress(cmd))
 
 	// Check if the config file has been specified
 	// Config file settings will override JSON-RPC and GRPC address values

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/godbus/dbus/v5 v5.0.6 // indirect
-	github.com/graph-gophers/graphql-go v1.4.0 // indirect
+	github.com/graph-gophers/graphql-go v1.4.0
 	github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef
 	github.com/ipfs/go-cid v0.1.0 // indirect
 	github.com/klauspost/compress v1.14.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/godbus/dbus/v5 v5.0.6 // indirect
+	github.com/graph-gophers/graphql-go v1.4.0 // indirect
 	github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef
 	github.com/ipfs/go-cid v0.1.0 // indirect
 	github.com/klauspost/compress v1.14.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/klauspost/compress v1.14.2 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
+	github.com/umbracle/fastrlp v0.0.0-20220527094140-59d5dd30e722 // indirect
 	github.com/valyala/fastjson v1.6.3 // indirect
 	go.uber.org/zap v1.20.0 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.sum
+++ b/go.sum
@@ -1072,6 +1072,8 @@ github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3C
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/umbracle/fastrlp v0.0.0-20211229195328-c1416904ae17 h1:ZZy8Rj2SqGcZn1hTcoLdwFBROzrf5KiuRwhp8G4nnfA=
 github.com/umbracle/fastrlp v0.0.0-20211229195328-c1416904ae17/go.mod h1:c8J0h9aULj2i3umrfyestM6jCq0LK0U6ly6bWy96nd4=
+github.com/umbracle/fastrlp v0.0.0-20220527094140-59d5dd30e722 h1:10Nbw6cACsnQm7r34zlpJky+IzxVLRk6MKTS2d3Vp0E=
+github.com/umbracle/fastrlp v0.0.0-20220527094140-59d5dd30e722/go.mod h1:c8J0h9aULj2i3umrfyestM6jCq0LK0U6ly6bWy96nd4=
 github.com/umbracle/go-eth-bn256 v0.0.0-20190607160430-b36caf4e0f6b h1:t3nz9xXkLZJz+ZlTGFT3ixsCGO5AHx1Yift2EAfjnnc=
 github.com/umbracle/go-eth-bn256 v0.0.0-20190607160430-b36caf4e0f6b/go.mod h1:B2zj4f3YmUPeyCNSlAEgOf6tuGzeYKvIxAZzwy9PxPA=
 github.com/umbracle/go-web3 v0.0.0-20220224145938-aaa1038c1b69 h1:SrIRL9SlfBp4nOUEnWGBAS/lX9UgF6myH/rzHgdj1rE=

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,9 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -329,6 +332,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -366,6 +370,8 @@ github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
+github.com/graph-gophers/graphql-go v1.4.0 h1:JE9wveRTSXwJyjdRd6bOQ7Ob5bewTUQ58Jv4OiVdpdE=
+github.com/graph-gophers/graphql-go v1.4.0/go.mod h1:YtmJZDLbF1YYNrlNAuiO5zAStUWc3XZT07iGsVqe1Os=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
@@ -1114,6 +1120,8 @@ go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
+go.opentelemetry.io/otel v1.6.3/go.mod h1:7BgNga5fNlF/iZjG06hM3yofffp0ofKCDwSXx1GC4dI=
+go.opentelemetry.io/otel/trace v1.6.3/go.mod h1:GNJQusJlUgZl9/TQBPKU/Y/ty+0iVB5fjhKeJGZPGFs=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -451,8 +451,6 @@ github.com/hashicorp/vault/api v1.3.1 h1:pkDkcgTh47PRjY1NEFeofqR4W/HkNUi9qIakESO
 github.com/hashicorp/vault/api v1.3.1/go.mod h1:QeJoWxMFt+MsuWcYhmwRLwKEXrjwAFFywzhptMsTIUw=
 github.com/hashicorp/vault/sdk v0.3.0 h1:kR3dpxNkhh/wr6ycaJYqp6AFT/i2xaftbfnwZduTKEY=
 github.com/hashicorp/vault/sdk v0.3.0/go.mod h1:aZ3fNuL5VNydQk8GcLJ2TV8YCRVvyaakYkhZRoVuhj0=
-github.com/hashicorp/vault/sdk v0.4.1 h1:3SaHOJY687jY1fnB61PtL0cOkKItphrbLmux7T92HBo=
-github.com/hashicorp/vault/sdk v0.4.1/go.mod h1:aZ3fNuL5VNydQk8GcLJ2TV8YCRVvyaakYkhZRoVuhj0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef h1:A9HsByNhogrvm9cWb28sjiS3i7tcKCkflWFEkHfuAgM=
@@ -1070,7 +1068,6 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
-github.com/umbracle/fastrlp v0.0.0-20211229195328-c1416904ae17 h1:ZZy8Rj2SqGcZn1hTcoLdwFBROzrf5KiuRwhp8G4nnfA=
 github.com/umbracle/fastrlp v0.0.0-20211229195328-c1416904ae17/go.mod h1:c8J0h9aULj2i3umrfyestM6jCq0LK0U6ly6bWy96nd4=
 github.com/umbracle/fastrlp v0.0.0-20220527094140-59d5dd30e722 h1:10Nbw6cACsnQm7r34zlpJky+IzxVLRk6MKTS2d3Vp0E=
 github.com/umbracle/fastrlp v0.0.0-20220527094140-59d5dd30e722/go.mod h1:c8J0h9aULj2i3umrfyestM6jCq0LK0U6ly6bWy96nd4=

--- a/graphql/argtype/types.go
+++ b/graphql/argtype/types.go
@@ -1,0 +1,149 @@
+package argtype
+
+import (
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"github.com/dogechain-lab/dogechain/helper/hex"
+	"github.com/dogechain-lab/dogechain/types"
+)
+
+type Long int64
+
+// ImplementsGraphQLType returns true if Long implements the provided GraphQL type.
+func (b Long) ImplementsGraphQLType(name string) bool { return name == "Long" }
+
+// UnmarshalGraphQL unmarshals the provided GraphQL query data.
+func (b *Long) UnmarshalGraphQL(input interface{}) error {
+	var err error
+	switch input := input.(type) {
+	case string:
+		// uncomment to support hex values
+		value, err := strconv.ParseInt(input, 10, 64)
+		*b = Long(value)
+
+		return err
+		//}
+	case int32:
+		*b = Long(input)
+	case int64:
+		*b = Long(input)
+	case float64:
+		*b = Long(input)
+	default:
+		err = fmt.Errorf("unexpected type %T for Long", input)
+	}
+
+	return err
+}
+
+type Big big.Int
+
+func ArgBigPtr(b *big.Int) *Big {
+	v := Big(*b)
+
+	return &v
+}
+
+func (a *Big) UnmarshalText(input []byte) error {
+	buf, err := DecodeToHex(input)
+	if err != nil {
+		return err
+	}
+
+	b := new(big.Int)
+	b.SetBytes(buf)
+	*a = Big(*b)
+
+	return nil
+}
+
+func (a Big) MarshalText() ([]byte, error) {
+	b := (*big.Int)(&a)
+
+	return []byte("0x" + b.Text(16)), nil
+}
+
+func AddrPtr(a types.Address) *types.Address {
+	return &a
+}
+
+func HashPtr(h types.Hash) *types.Hash {
+	return &h
+}
+
+type Uint64 uint64
+
+func UintPtr(n uint64) *Uint64 {
+	v := Uint64(n)
+
+	return &v
+}
+
+func (u Uint64) MarshalText() ([]byte, error) {
+	buf := make([]byte, 2, 10)
+	copy(buf, `0x`)
+	buf = strconv.AppendUint(buf, uint64(u), 16)
+
+	return buf, nil
+}
+
+func (u *Uint64) UnmarshalText(input []byte) error {
+	str := strings.TrimPrefix(string(input), "0x")
+	num, err := strconv.ParseUint(str, 16, 64)
+
+	if err != nil {
+		return err
+	}
+
+	*u = Uint64(num)
+
+	return nil
+}
+
+type Bytes []byte
+
+func BytesPtr(b []byte) *Bytes {
+	bb := Bytes(b)
+
+	return &bb
+}
+
+func (b Bytes) MarshalText() ([]byte, error) {
+	return EncodeToHex(b), nil
+}
+
+func (b *Bytes) UnmarshalText(input []byte) error {
+	hh, err := DecodeToHex(input)
+	if err != nil {
+		return nil
+	}
+
+	aux := make([]byte, len(hh))
+	copy(aux[:], hh[:])
+	*b = aux
+
+	return nil
+}
+
+func DecodeToHex(b []byte) ([]byte, error) {
+	str := string(b)
+	str = strings.TrimPrefix(str, "0x")
+
+	if len(str)%2 != 0 {
+		str = "0" + str
+	}
+
+	return hex.DecodeString(str)
+}
+
+func EncodeToHex(b []byte) []byte {
+	str := hex.EncodeToString(b)
+	if len(str)%2 != 0 {
+		str = "0" + str
+	}
+
+	return []byte("0x" + str)
+}

--- a/graphql/argtype/types.go
+++ b/graphql/argtype/types.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/dogechain-lab/dogechain/helper/hex"
+	rpc "github.com/dogechain-lab/dogechain/jsonrpc"
 	"github.com/dogechain-lab/dogechain/types"
 )
 
@@ -209,4 +210,30 @@ func encodeToHex(b []byte) []byte {
 	}
 
 	return []byte("0x" + str)
+}
+
+type Log struct {
+	Address     types.Address `json:"address"`
+	Topics      []types.Hash  `json:"topics"`
+	Data        Bytes         `json:"data"`
+	BlockNumber Uint64        `json:"blockNumber"`
+	TxHash      types.Hash    `json:"transactionHash"`
+	TxIndex     Uint64        `json:"transactionIndex"`
+	BlockHash   types.Hash    `json:"blockHash"`
+	LogIndex    Uint64        `json:"logIndex"`
+	Removed     bool          `json:"removed"`
+}
+
+func FromRPCLog(log *rpc.Log) *Log {
+	return &Log{
+		Address:     log.Address,
+		Topics:      log.Topics,
+		Data:        Bytes(log.Data),
+		BlockNumber: Uint64(log.BlockNumber),
+		TxHash:      log.TxHash,
+		TxIndex:     Uint64(log.TxIndex),
+		BlockHash:   log.BlockHash,
+		LogIndex:    Uint64(log.LogIndex),
+		Removed:     log.Removed,
+	}
 }

--- a/graphql/argtype/types_test.go
+++ b/graphql/argtype/types_test.go
@@ -1,0 +1,42 @@
+package argtype
+
+import (
+	"encoding/json"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasicTypes_Encode(t *testing.T) {
+	// decode basic types
+	cases := []struct {
+		obj interface{}
+		dec interface{}
+		res string
+	}{
+		{
+			Big(*big.NewInt(10)),
+			&Big{},
+			"0xa",
+		},
+		{
+			Uint64(10),
+			UintPtr(0),
+			"0xa",
+		},
+		{
+			Bytes([]byte{0x1, 0x2}),
+			&Bytes{},
+			"0x0102",
+		},
+	}
+
+	for _, c := range cases {
+		res, err := json.Marshal(c.obj)
+		assert.NoError(t, err)
+		assert.Equal(t, strings.Trim(string(res), "\""), c.res)
+		assert.NoError(t, json.Unmarshal(res, c.dec))
+	}
+}

--- a/graphql/endpoints.go
+++ b/graphql/endpoints.go
@@ -1,0 +1,89 @@
+package graphql
+
+import (
+	"math/big"
+
+	"github.com/dogechain-lab/dogechain/chain"
+	"github.com/dogechain-lab/dogechain/helper/progress"
+	"github.com/dogechain-lab/dogechain/state"
+	"github.com/dogechain-lab/dogechain/state/runtime"
+	"github.com/dogechain-lab/dogechain/types"
+)
+
+type ethTxPoolStore interface {
+	// GetNonce returns the next nonce for this address
+	GetNonce(addr types.Address) uint64
+
+	// AddTx adds a new transaction to the tx pool
+	AddTx(tx *types.Transaction) error
+
+	// GetPendingTx gets the pending transaction from the transaction pool, if it's present
+	GetPendingTx(txHash types.Hash) (*types.Transaction, bool)
+}
+
+type ethStateStore interface {
+	GetAccount(root types.Hash, addr types.Address) (*state.Account, error)
+	GetStorage(root types.Hash, addr types.Address, slot types.Hash) ([]byte, error)
+	GetForksInTime(blockNumber uint64) chain.ForksInTime
+	GetCode(hash types.Hash) ([]byte, error)
+}
+
+type ethBlockchainStore interface {
+	// Header returns the current header of the chain (genesis if empty)
+	Header() *types.Header
+
+	// GetHeaderByNumber returns the header by number
+	GetHeaderByNumber(block uint64) (*types.Header, bool)
+
+	// GetBlockByHash gets a block using the provided hash
+	GetBlockByHash(hash types.Hash, full bool) (*types.Block, bool)
+
+	// GetBlockByNumber returns a block using the provided number
+	GetBlockByNumber(num uint64, full bool) (*types.Block, bool)
+
+	// ReadTxLookup returns a block hash in which a given txn was mined
+	ReadTxLookup(txnHash types.Hash) (types.Hash, bool)
+
+	// GetReceiptsByHash returns the receipts for a block hash
+	GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error)
+
+	// GetAvgGasPrice returns the average gas price
+	GetAvgGasPrice() *big.Int
+
+	// ApplyTxn applies a transaction object to the blockchain
+	ApplyTxn(header *types.Header, txn *types.Transaction) (*runtime.ExecutionResult, error)
+
+	// GetSyncProgression retrieves the current sync progression, if any
+	GetSyncProgression() *progress.Progression
+}
+
+// ethStore provides access to the methods needed by eth query
+type ethStore interface {
+	ethTxPoolStore
+	ethStateStore
+	ethBlockchainStore
+}
+
+// txPoolStore provides access to the methods needed for txpool query
+type txPoolStore interface {
+	// GetTxs gets tx pool transactions currently pending for inclusion and currently queued for validation
+	GetTxs(inclQueued bool) (map[types.Address][]*types.Transaction, map[types.Address][]*types.Transaction)
+
+	// GetCapacity returns the current and max capacity of the pool in slots
+	GetCapacity() (uint64, uint64)
+}
+
+// filterManagerStore provides methods required by FilterManager
+type filterManagerStore interface {
+	// Header returns the current header of the chain (genesis if empty)
+	Header() *types.Header
+
+	// GetReceiptsByHash returns the receipts for a block hash
+	GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error)
+
+	// GetBlockByHash returns the block using the block hash
+	GetBlockByHash(hash types.Hash, full bool) (*types.Block, bool)
+
+	// GetBlockByNumber returns a block using the provided number
+	GetBlockByNumber(num uint64, full bool) (*types.Block, bool)
+}

--- a/graphql/endpoints.go
+++ b/graphql/endpoints.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"math/big"
 
+	"github.com/dogechain-lab/dogechain/blockchain"
 	"github.com/dogechain-lab/dogechain/chain"
 	"github.com/dogechain-lab/dogechain/helper/progress"
 	"github.com/dogechain-lab/dogechain/state"
@@ -34,6 +35,9 @@ type ethBlockchainStore interface {
 
 	// GetHeaderByNumber returns the header by number
 	GetHeaderByNumber(block uint64) (*types.Header, bool)
+
+	// GetHeaderByHash returns the header by hash
+	GetHeaderByHash(hash types.Hash) (*types.Header, bool)
 
 	// GetBlockByHash gets a block using the provided hash
 	GetBlockByHash(hash types.Hash, full bool) (*types.Block, bool)
@@ -77,6 +81,9 @@ type txPoolStore interface {
 type filterManagerStore interface {
 	// Header returns the current header of the chain (genesis if empty)
 	Header() *types.Header
+
+	// SubscribeEvents subscribes for chain head events
+	SubscribeEvents() blockchain.Subscription
 
 	// GetReceiptsByHash returns the receipts for a block hash
 	GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error)

--- a/graphql/graphiql.go
+++ b/graphql/graphiql.go
@@ -1,0 +1,127 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2016 Muhammed Thanish
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package graphql
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+)
+
+// GraphiQL is an in-browser IDE for exploring GraphiQL APIs.
+// This handler returns GraphiQL when requested.
+//
+// For more information, see https://github.com/graphql/graphiql.
+type GraphiQL struct{}
+
+func respond(w http.ResponseWriter, body []byte, code int) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(code)
+	_, _ = w.Write(body)
+}
+
+func errorJSON(msg string) []byte {
+	buf := bytes.Buffer{}
+	fmt.Fprintf(&buf, `{"error": "%s"}`, msg)
+
+	return buf.Bytes()
+}
+
+func (h GraphiQL) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		respond(w, errorJSON("only GET requests are supported"), http.StatusMethodNotAllowed)
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+
+	if _, err := w.Write(graphiql); err != nil {
+		respond(w, errorJSON(fmt.Sprintf("graphql ui load failed: %v", err)), http.StatusBadGateway)
+	}
+}
+
+// nolint: lll
+var graphiql = []byte(`
+<!DOCTYPE html>
+<html>
+	<head>
+		<link
+                rel="icon"
+                type="image/png"
+                href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAAlwSFlzAAALEwAACxMBAJqcGAAAActpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx4bXA6Q3JlYXRvclRvb2w+QWRvYmUgSW1hZ2VSZWFkeTwveG1wOkNyZWF0b3JUb29sPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KKS7NPQAAB5FJREFUWAm1FmtsnEdxdr/vfC8/mpgEfHYa6gaUJqAihfhVO7UprSokHsn5jKgKiKLGIIEEbSlpJdQLIJw+UFFQUSuBWir1z9nnpEmgCUnkcxPSmDRCgkKpGoJpfXdxHSc4ftzr2x1m9rvPPQdDDSgrfd/O7szOe2YX4H8cGEtY3tFK2Nu7pjMCChbgzVfD11h4XLKAibahL6dbBv+SaRl6LUsw78XBxTG80mEsWSkxu1oM9qmJlkR7UPhPWSDJCzSISw5zXZGxvpMezUp5GmtWQszunpiAKiPPZ20KyCqY1/ncgs4v+IUPwLJvYhzTVIbmvXgvqwAxkImKJHt1yzM+AQLXvdKXy3QevB4R+3O6wIYHSUCIlABEtTO9bf86pmFa7B6xPeHMi3l668p5SQjInbRGQQw0E3FMH4FHaFPoP8USVaveEo9aaH3LsdRh2vsYKqwhMhRBKw82vGbNQbcC9ePL1+PDmwf7iix0N+xmPoafq4TgDDaRYxmLCrBwD5HpSK4vKRVeP9b3ZyaaaE18UaL4KYE5x5afsWxoBgefFfX+jX6pMH9RvSnX2v1YxPP4D3UAHG2hgm80vRp7ns9nWxOb8kIt3HD6C+O8rpRVoYCxHDOtQwOg4QHS1kIb9oHGVQJlN0h8qPF07FFmkG4byouAjEdSO/bwOntr8kGt8EeNJ3uN27O37fse5PT3lVIjUsrL6MB2IVCThMcbx3ofIt7sZeMFExeTubSR3Zq4tVoEdhHSJs30WqjbIS1Zk6/VqzzhmdbBpyn5p1g4W8LMGkajj9GUSfcM/4IVaji+/QdOa7hehKz69xEPsllLkFZY+HdlWhOdLNxrXm5iTK1xPSHEeo4KxTFPzEsFLHH8D914rG+GGWe2Dd9UJav6ZbW1k9ep7rgF3SnTEUXA3hko2fdkowc2M27dk3deomgfLBIPYlJytC4QLzKLZdAoy3QzNTVqksT2y6Oz+YVL1TK4Oo9FYAVIkRFzgH8F/bOiD0cjv4m+hEA9IdXn8HaC4Mjxzx7OdCZH8R14mra6eB9sfUKTj4SCQLUvCHMqN235rKMGV5ZpPCAoSzGOcs2JaFZYVuc8FF5XQl8uCHV75FT0ZT6Q6Ry+02fZ3b7agLF+MGbYmF/Mg+vE14NY1Xnhjv2fZkTkWO+R2VXqc1BrLczp/OtULV0fOLXjHS5LlvkuhzL05oZf+xnMbtv3BLXZIwyPQNx4iRLvrXRXci/vcV/guXJ4dZ/elnwqfctQlnFxoGyhkY2+eCbTlnyCYU8GwzzcHHBhmKl7261X1CEBaIT0QNxJdyQfpLRdHblt4wNMeuhsVpWPvDulqAXQKH5i9f0Ut7pMT/LhOEWc96hfkBEYYnhDU3DJ2SUKMAEPIagRoTSJObF9uF5oHAC/uF/ENxeRrPcai0vt/k1mE+6GeE9eVIlvQwF+yGfL/KiNuMpUnmF4WQUYwX3AEEzjXmqi5yOp6DO8hrM7TeIZ+Orf2X6DY1oU+FeY1D8xJLh8G2bcsgpQ3vqoAU1P3nWouQaDd8mQdS8Tj1B/Z0sZXm6QyxbvAFlj3Us95e7Jbx6/EYScpnP/kjfMwy3DMre6mXVGIVTqiqi1mtVk8blZR78UOdGbQqDLheLMjWc54Yt7KSAaUvRwTyrdMXREvFF6VtRZfgrALNOcm8ixZxe9uOgBLsMPnftUIdM+tBFKcLtwxCeJ7GbdHDJlJ6DHYetX8gHfSTTEB4P9WNBb5JRq0VrfwbxZRuVN61pMt56ICz3elWxAB18OS//Nep4MKeowTOU/zMwo8RaV5fVKhs4WN1DzCjkzJV1jBT9K1TB6oWN4bR89arDMz7iTa1ikepxsy+CXqmXol1fUfJ4qwUfeptsXL1JNTFNWXkfmO5ydi8KXBIMWvCYnmbOWmKXr5zpZhHotSbQGp9YO+qkb3h05E3vBk+nmwJopw5SSdVxRsOjiCGhEXSMCMFdTrAdbPikul35PvWAN1adPgqAGz8Kk1FLTX2hlCyF9pHSIQlwnp+x6/yb1t9zu8LgFszJHt5v0K+TakuPmbFnmog2cXBzfbFtyj1b6O4SQ4BP76Zr1k1Etwoe7Ir+N/dwcfo8f3QnbsYR7yAO/kxICdAH1En+km/WxhtPRXZ4sZrOoQBk2npjcmmwu2ipMz6s/MlG6JflVqrC9pN8VqLK+1nhix4u8/3Z7YjXPRHeJ52z3vm7Mq6eISa0UeF/DK7FB3r/w8eGP0Htg4f1noud5TXgy1g1lpQIGQelGyLjbQk3J7TZr8yT7uxzwSfu+oiwdIL//gTKc+4MUltxL/lpPFn+ebvqByFhswAjid+VgTLNnXcGcyHGuY7PmvWUHZ2hlqXgXDRNfbD/YSE+2MeeWYzjZMmw+p+MYpnuSJy/FjtZ5DCvPuI9SFv5/DI4buZxfwZBuH7pnpu0QprcOztM3N9v2K8x2DH+FcZktB/nSWeJZ3v93Y8VasRubmqBoGKF4g6oBwjIQoi/MMDrqHOMamnMFmv6ziw0T97diTb0zHB7OEe4ZlCjf5X2U8vGm09HnKrPbo78mMwu6mjFn9tV713TtvWpZSCX83wr9J1EKd8CrhC26AAAAAElFTkSuQmCC"
+        />
+        <link
+                rel="stylesheet"
+                href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.13.0/graphiql.css"
+                integrity="sha384-Qua2xoKBxcHOg1ivsKWo98zSI5KD/UuBpzMIg8coBd4/jGYoxeozCYFI9fesatT0"
+                crossorigin="anonymous"
+        />
+        <script
+                src="https://cdnjs.cloudflare.com/ajax/libs/fetch/3.0.0/fetch.min.js"
+                integrity="sha384-5B8/4F9AQqp/HCHReGLSOWbyAOwnJsPrvx6C0+VPUr44Olzi99zYT1xbVh+ZanQJ"
+                crossorigin="anonymous"
+        ></script>
+        <script
+                src="https://cdnjs.cloudflare.com/ajax/libs/react/16.8.5/umd/react.production.min.js"
+                integrity="sha384-dOCiLz3nZfHiJj//EWxjwSKSC6Z1IJtyIEK/b/xlHVNdVLXDYSesoxiZb94bbuGE"
+                crossorigin="anonymous"
+        ></script>
+        <script
+                src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.8.5/umd/react-dom.production.min.js"
+                integrity="sha384-QI+ql5f+khgo3mMdCktQ3E7wUKbIpuQo8S5rA/3i1jg2rMsloCNyiZclI7sFQUGN"
+                crossorigin="anonymous"
+        ></script>
+        <script
+                src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.13.0/graphiql.min.js"
+                integrity="sha384-roSmzNmO4zJK9X4lwggDi4/oVy+9V4nlS1+MN8Taj7tftJy1GvMWyAhTNXdC/fFR"
+                crossorigin="anonymous"
+        ></script>
+	</head>
+	<body style="width: 100%; height: 100%; margin: 0; overflow: hidden;">
+		<div id="graphiql" style="height: 100vh;">Loading...</div>
+		<script>
+			function fetchGQL(params) {
+				return fetch("/graphql", {
+					method: "post",
+					body: JSON.stringify(params),
+					credentials: "include",
+				}).then(function (resp) {
+					return resp.text();
+				}).then(function (body) {
+					try {
+						return JSON.parse(body);
+					} catch (error) {
+						return body;
+					}
+				});
+			}
+			ReactDOM.render(
+				React.createElement(GraphiQL, {fetcher: fetchGQL}),
+				document.getElementById("graphiql")
+			)
+		</script>
+	</body>
+</html>
+`)

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -276,13 +276,19 @@ func (t *Transaction) findSealedTx(hash types.Hash) bool {
 		return false
 	}
 
+	blockNum := rpc.BlockNumber(block.Header.Number)
+
 	t.block = &Block{
 		backend:       t.backend,
 		signer:        t.signer,
 		filterManager: t.filterManager,
 		numberOrHash: &rpc.BlockNumberOrHash{
-			BlockHash: &hash,
+			BlockNumber: &blockNum,
+			BlockHash: &blockHash,
 		},
+		hash: blockHash,
+		header: block.Header,
+		block: block,
 	}
 
 	// Find the transaction within the block

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1,0 +1,394 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/dogechain-lab/dogechain/graphql/argtype"
+	rpc "github.com/dogechain-lab/dogechain/jsonrpc"
+	"github.com/dogechain-lab/dogechain/types"
+)
+
+// Account represents an Dogechain account at a particular block.
+type Account struct {
+	backend       GraphQLStore
+	address       types.Address
+	blockNrOrHash rpc.BlockNumberOrHash
+}
+
+func (a *Account) Address(ctx context.Context) (types.Address, error) {
+	return a.address, nil
+}
+
+func (a *Account) Balance(ctx context.Context) (argtype.Big, error) {
+	return argtype.Big{}, nil
+}
+
+func (a *Account) TransactionCount(ctx context.Context) (argtype.Uint64, error) {
+	return 0, nil
+}
+
+func (a *Account) Code(ctx context.Context) (argtype.Bytes, error) {
+	return argtype.Bytes{}, nil
+}
+
+func (a *Account) Storage(ctx context.Context, args struct{ Slot types.Hash }) (types.Hash, error) {
+	return types.Hash{}, nil
+}
+
+// Log represents an individual log message. All arguments are mandatory.
+type Log struct {
+	backend     GraphQLStore
+	transaction *Transaction
+	log         *types.Log
+}
+
+func (l *Log) Transaction(ctx context.Context) *Transaction {
+	return l.transaction
+}
+
+func (l *Log) Account(ctx context.Context, args BlockNumberArgs) *Account {
+	return &Account{
+		backend:       l.backend,
+		address:       l.log.Address,
+		blockNrOrHash: args.NumberOrLatest(),
+	}
+}
+
+func (l *Log) Index(ctx context.Context) int32 {
+	return int32(0)
+}
+
+func (l *Log) Topics(ctx context.Context) []types.Hash {
+	return l.log.Topics
+}
+
+func (l *Log) Data(ctx context.Context) argtype.Bytes {
+	return l.log.Data
+}
+
+// Transaction represents an Dogechain transaction.
+// backend and hash are mandatory; all others will be fetched when required.
+type Transaction struct {
+	// backend GraphQLStore
+	hash types.Hash
+	// tx   *types.Transaction
+	// block   *Block
+	// index   uint64
+}
+
+// // resolve returns the internal transaction object, fetching it if needed.
+// func (t *Transaction) resolve(ctx context.Context) (*types.Transaction, error) {
+// 	return t.tx, nil
+// }
+
+func (t *Transaction) Hash(ctx context.Context) types.Hash {
+	return t.hash
+}
+
+func (t *Transaction) InputData(ctx context.Context) (argtype.Bytes, error) {
+	return argtype.Bytes{}, nil
+}
+
+func (t *Transaction) Gas(ctx context.Context) (argtype.Uint64, error) {
+	return argtype.Uint64(0), nil
+}
+
+func (t *Transaction) GasPrice(ctx context.Context) (argtype.Big, error) {
+	return argtype.Big{}, nil
+}
+
+func (t *Transaction) Value(ctx context.Context) (argtype.Big, error) {
+	return argtype.Big{}, nil
+}
+
+func (t *Transaction) Nonce(ctx context.Context) (argtype.Uint64, error) {
+	return argtype.Uint64(0), nil
+}
+
+func (t *Transaction) To(ctx context.Context, args BlockNumberArgs) (*Account, error) {
+	return &Account{}, nil
+}
+
+func (t *Transaction) From(ctx context.Context, args BlockNumberArgs) (*Account, error) {
+	return &Account{}, nil
+}
+
+func (t *Transaction) Block(ctx context.Context) (*Block, error) {
+	return &Block{}, nil
+}
+
+func (t *Transaction) Index(ctx context.Context) (*int32, error) {
+	var index = int32(0)
+
+	return &index, nil
+}
+
+// // getReceipt returns the receipt associated with this transaction, if any.
+// func (t *Transaction) getReceipt(ctx context.Context) (*types.Receipt, error) {
+// 	return &types.Receipt{}, nil
+// }
+
+func (t *Transaction) Status(ctx context.Context) (*argtype.Long, error) {
+	var status = argtype.Long(0)
+
+	return &status, nil
+}
+
+func (t *Transaction) GasUsed(ctx context.Context) (*argtype.Long, error) {
+	var gasUsed = argtype.Long(0)
+
+	return &gasUsed, nil
+}
+
+func (t *Transaction) CumulativeGasUsed(ctx context.Context) (*argtype.Long, error) {
+	var cumulativeGasUsed = argtype.Long(0)
+
+	return &cumulativeGasUsed, nil
+}
+
+func (t *Transaction) CreatedContract(ctx context.Context, args BlockNumberArgs) (*Account, error) {
+	return &Account{}, nil
+}
+
+func (t *Transaction) Logs(ctx context.Context) (*[]*Log, error) {
+	var logs = make([]*Log, 0)
+
+	return &logs, nil
+}
+
+func (t *Transaction) R(ctx context.Context) (argtype.Big, error) {
+	return argtype.Big{}, nil
+}
+
+func (t *Transaction) S(ctx context.Context) (argtype.Big, error) {
+	return argtype.Big{}, nil
+}
+
+func (t *Transaction) V(ctx context.Context) (argtype.Big, error) {
+	return argtype.Big{}, nil
+}
+
+func (t *Transaction) Raw(ctx context.Context) (argtype.Bytes, error) {
+	return argtype.Bytes{}, nil
+}
+
+func (t *Transaction) RawReceipt(ctx context.Context) (argtype.Bytes, error) {
+	return argtype.Bytes{}, nil
+}
+
+// Block represents an Dogechain block.
+// backend, and numberOrHash are mandatory. All other fields are lazily fetched
+// when required.
+type Block struct {
+	// numberOrHash *rpc.BlockNumberOrHash
+	// hash         types.Hash
+	// header       *types.Header
+	// block        *types.Block
+	// receipts     []*types.Receipt
+}
+
+// // resolve returns the internal Block object representing this block, fetching
+// // it if necessary.
+// func (b *Block) resolve(ctx context.Context) (*types.Block, error) {
+// 	return &types.Block{}, nil
+// }
+
+// // resolveHeader returns the internal Header object for this block, fetching it
+// // if necessary. Call this function instead of `resolve` unless you need the
+// // additional data (transactions and uncles).
+// func (b *Block) resolveHeader(ctx context.Context) (*types.Header, error) {
+// 	return &types.Header{}, nil
+// }
+
+// // resolveReceipts returns the list of receipts for this block, fetching them
+// // if necessary.
+// func (b *Block) resolveReceipts(ctx context.Context) ([]*types.Receipt, error) {
+// 	return []*types.Receipt{}, nil
+// }
+
+func (b *Block) Number(ctx context.Context) (argtype.Long, error) {
+	return argtype.Long(0), nil
+}
+
+func (b *Block) Hash(ctx context.Context) (types.Hash, error) {
+	return types.Hash{}, nil
+}
+
+func (b *Block) GasLimit(ctx context.Context) (argtype.Long, error) {
+	return argtype.Long(0), nil
+}
+
+func (b *Block) GasUsed(ctx context.Context) (argtype.Long, error) {
+	return argtype.Long(0), nil
+}
+
+func (b *Block) Parent(ctx context.Context) (*Block, error) {
+	return &Block{}, nil
+}
+
+func (b *Block) Difficulty(ctx context.Context) (argtype.Big, error) {
+	return argtype.Big{}, nil
+}
+
+func (b *Block) Timestamp(ctx context.Context) (argtype.Uint64, error) {
+	return argtype.Uint64(0), nil
+}
+
+func (b *Block) Nonce(ctx context.Context) (argtype.Bytes, error) {
+	return argtype.Bytes{}, nil
+}
+
+func (b *Block) MixHash(ctx context.Context) (types.Hash, error) {
+	return types.Hash{}, nil
+}
+
+func (b *Block) TransactionsRoot(ctx context.Context) (types.Hash, error) {
+	return types.Hash{}, nil
+}
+
+func (b *Block) StateRoot(ctx context.Context) (types.Hash, error) {
+	return types.Hash{}, nil
+}
+
+func (b *Block) ReceiptsRoot(ctx context.Context) (types.Hash, error) {
+	return types.Hash{}, nil
+}
+
+func (b *Block) ExtraData(ctx context.Context) (argtype.Bytes, error) {
+	return argtype.Bytes{}, nil
+}
+
+func (b *Block) LogsBloom(ctx context.Context) (argtype.Bytes, error) {
+	return argtype.Bytes{}, nil
+}
+
+func (b *Block) TotalDifficulty(ctx context.Context) (argtype.Big, error) {
+	return argtype.Big{}, nil
+}
+
+func (b *Block) RawHeader(ctx context.Context) (argtype.Bytes, error) {
+	return argtype.Bytes{}, nil
+}
+
+func (b *Block) Raw(ctx context.Context) (argtype.Bytes, error) {
+	return argtype.Bytes{}, nil
+}
+
+// BlockNumberArgs encapsulates arguments to accessors that specify a block number.
+type BlockNumberArgs struct {
+	// TODO: Ideally we could use input unions to allow the query to specify the
+	// block parameter by hash, block number, or tag but input unions aren't part of the
+	// standard GraphQL schema SDL yet, see: https://github.com/graphql/graphql-spec/issues/488
+	Block *argtype.Uint64
+}
+
+// NumberOr returns the provided block number argument, or the "current" block number or hash if none
+// was provided.
+func (a BlockNumberArgs) NumberOr(current rpc.BlockNumberOrHash) rpc.BlockNumberOrHash {
+	return rpc.BlockNumberOrHash{}
+}
+
+// NumberOrLatest returns the provided block number argument, or the "latest" block number if none
+// was provided.
+func (a BlockNumberArgs) NumberOrLatest() rpc.BlockNumberOrHash {
+	return rpc.BlockNumberOrHash{}
+}
+
+func (b *Block) Miner(ctx context.Context, args BlockNumberArgs) (*Account, error) {
+	return &Account{}, nil
+}
+
+func (b *Block) TransactionCount(ctx context.Context) (*int32, error) {
+	var count = int32(0)
+
+	return &count, nil
+}
+
+func (b *Block) Transactions(ctx context.Context) (*[]*Transaction, error) {
+	return &[]*Transaction{}, nil
+}
+
+// BlockFilterCriteria encapsulates criteria passed to a `logs` accessor inside
+// a block.
+type BlockFilterCriteria struct {
+	Addresses *[]types.Address // restricts matches to events created by specific contracts
+
+	// The Topic list restricts matches to particular event topics. Each event has a list
+	// of topics. Topics matches a prefix of that list. An empty element slice matches any
+	// topic. Non-empty elements represent an alternative that matches any of the
+	// contained topics.
+	//
+	// Examples:
+	// {} or nil          matches any topic list
+	// {{A}}              matches topic A in first position
+	// {{}, {B}}          matches any topic in first position, B in second position
+	// {{A}, {B}}         matches topic A in first position, B in second position
+	// {{A, B}}, {C, D}}  matches topic (A OR B) in first position, (C OR D) in second position
+	Topics *[][]types.Hash
+}
+
+func (b *Block) Logs(ctx context.Context, args struct{ Filter BlockFilterCriteria }) ([]*Log, error) {
+	return []*Log{}, nil
+}
+
+func (b *Block) Account(ctx context.Context, args struct {
+	Address types.Address
+}) (*Account, error) {
+	return &Account{}, nil
+}
+
+// Resolver is the top-level object in the GraphQL hierarchy.
+type Resolver struct {
+	backend GraphQLStore
+	chainID argtype.Big
+}
+
+func (r *Resolver) Block(ctx context.Context, args struct {
+	Number *argtype.Long
+	Hash   *types.Hash
+}) (*Block, error) {
+	return &Block{}, nil
+}
+
+func (r *Resolver) Blocks(ctx context.Context, args struct {
+	From *argtype.Long
+	To   *argtype.Long
+}) ([]*Block, error) {
+	return []*Block{}, nil
+}
+
+func (r *Resolver) Transaction(ctx context.Context, args struct{ Hash types.Hash }) (*Transaction, error) {
+	return &Transaction{}, nil
+}
+
+// FilterCriteria encapsulates the arguments to `logs` on the root resolver object.
+type FilterCriteria struct {
+	FromBlock *argtype.Uint64  // beginning of the queried range, nil means genesis block
+	ToBlock   *argtype.Uint64  // end of the range, nil means latest block
+	Addresses *[]types.Address // restricts matches to events created by specific contracts
+
+	// The Topic list restricts matches to particular event topics. Each event has a list
+	// of topics. Topics matches a prefix of that list. An empty element slice matches any
+	// topic. Non-empty elements represent an alternative that matches any of the
+	// contained topics.
+	//
+	// Examples:
+	// {} or nil          matches any topic list
+	// {{A}}              matches topic A in first position
+	// {{}, {B}}          matches any topic in first position, B in second position
+	// {{A}, {B}}         matches topic A in first position, B in second position
+	// {{A, B}}, {C, D}}  matches topic (A OR B) in first position, (C OR D) in second position
+	Topics *[][]types.Hash
+}
+
+func (r *Resolver) Logs(ctx context.Context, args struct{ Filter FilterCriteria }) ([]*Log, error) {
+	return []*Log{}, nil
+}
+
+func (r *Resolver) GasPrice(ctx context.Context) (argtype.Big, error) {
+	return argtype.Big{}, nil
+}
+
+func (r *Resolver) ChainID(ctx context.Context) (argtype.Big, error) {
+	return r.chainID, nil
+}

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -11,7 +11,7 @@ import (
 	"github.com/dogechain-lab/dogechain/graphql/argtype"
 	rpc "github.com/dogechain-lab/dogechain/jsonrpc"
 	"github.com/dogechain-lab/dogechain/types"
-	"github.com/umbracle/fastrlp"
+	"github.com/dogechain-lab/fastrlp"
 )
 
 var (

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1167,7 +1167,7 @@ func (r *Resolver) Logs(ctx context.Context, args struct{ Filter FilterCriteria 
 		end = rpc.BlockNumber(*args.Filter.ToBlock)
 	}
 
-	if begin < end {
+	if end < begin {
 		return nil, errBlockInvalidRange
 	}
 

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -17,7 +17,6 @@ const schema string = `
 
     schema {
         query: Query
-        mutation: Mutation
     }
 
     # Account is an Dogechain account at a particular block.

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -1,0 +1,220 @@
+package graphql
+
+const schema string = `
+    # Bytes32 is a 32 byte binary string, represented as 0x-prefixed hexadecimal.
+    scalar Bytes32
+    # Address is a 20 byte Dogechain address, represented as 0x-prefixed hexadecimal.
+    scalar Address
+    # Bytes is an arbitrary length binary string, represented as 0x-prefixed hexadecimal.
+    # An empty byte string is represented as '0x'. Byte strings must have an even number of hexadecimal nybbles.
+    scalar Bytes
+    # BigInt is a large integer. Input is accepted as either a JSON number or as a string.
+    # Strings may be either decimal or 0x-prefixed hexadecimal. Output values are all
+    # 0x-prefixed hexadecimal.
+    scalar BigInt
+    # Long is a 64 bit unsigned integer.
+    scalar Long
+
+    schema {
+        query: Query
+        mutation: Mutation
+    }
+
+    # Account is an Dogechain account at a particular block.
+    type Account {
+        # Address is the address owning the account.
+        address: Address!
+        # Balance is the balance of the account, in wei.
+        balance: BigInt!
+        # TransactionCount is the number of transactions sent from this account,
+        # or in the case of a contract, the number of contracts created. Otherwise
+        # known as the nonce.
+        transactionCount: Long!
+        # Code contains the smart contract code for this account, if the account
+        # is a (non-self-destructed) contract.
+        code: Bytes!
+        # Storage provides access to the storage of a contract account, indexed
+        # by its 32 byte slot identifier.
+        storage(slot: Bytes32!): Bytes32!
+    }
+
+    # Log is an Dogechain event log.
+    type Log {
+        # Index is the index of this log in the block.
+        index: Int!
+        # Account is the account which generated this log - this will always
+        # be a contract account.
+        account(block: Long): Account!
+        # Topics is a list of 0-4 indexed topics for the log.
+        topics: [Bytes32!]!
+        # Data is unindexed data for this log.
+        data: Bytes!
+        # Transaction is the transaction that generated this log entry.
+        transaction: Transaction!
+    }
+
+    # Transaction is an Dogechain transaction.
+    type Transaction {
+        # Hash is the hash of this transaction.
+        hash: Bytes32!
+        # Nonce is the nonce of the account this transaction was generated with.
+        nonce: Long!
+        # Index is the index of this transaction in the parent block. This will
+        # be null if the transaction has not yet been mined.
+        index: Int
+        # From is the account that sent this transaction - this will always be
+        # an externally owned account.
+        from(block: Long): Account!
+        # To is the account the transaction was sent to. This is null for
+        # contract-creating transactions.
+        to(block: Long): Account
+        # Value is the value, in wei, sent along with this transaction.
+        value: BigInt!
+        # GasPrice is the price offered to miners for gas, in wei per unit.
+        gasPrice: BigInt!
+        # Gas is the maximum amount of gas this transaction can consume.
+        gas: Long!
+        # InputData is the data supplied to the target of the transaction.
+        inputData: Bytes!
+        # Block is the block this transaction was mined in. This will be null if
+        # the transaction has not yet been mined.
+        block: Block
+
+        # Status is the return status of the transaction. This will be 1 if the
+        # transaction succeeded, or 0 if it failed (due to a revert, or due to
+        # running out of gas). If the transaction has not yet been mined, this
+        # field will be null.
+        status: Long
+        # GasUsed is the amount of gas that was used processing this transaction.
+        # If the transaction has not yet been mined, this field will be null.
+        gasUsed: Long
+        # CumulativeGasUsed is the total gas used in the block up to and including
+        # this transaction. If the transaction has not yet been mined, this field
+        # will be null.
+        cumulativeGasUsed: Long
+        # CreatedContract is the account that was created by a contract creation
+        # transaction. If the transaction was not a contract creation transaction,
+        # or it has not yet been mined, this field will be null.
+        createdContract(block: Long): Account
+        # Logs is a list of log entries emitted by this transaction. If the
+        # transaction has not yet been mined, this field will be null.
+        logs: [Log!]
+        r: BigInt!
+        s: BigInt!
+        v: BigInt!
+        # Raw is the canonical encoding of the transaction, which returns the RLP encoding.
+        raw: Bytes!
+        # RawReceipt is the canonical encoding of the receipt.
+        rawReceipt: Bytes!
+    }
+
+    # BlockFilterCriteria encapsulates log filter criteria for a filter applied
+    # to a single block.
+    input BlockFilterCriteria {
+        # Addresses is list of addresses that are of interest. If this list is
+        # empty, results will not be filtered by address.
+        addresses: [Address!]
+        # Topics list restricts matches to particular event topics. Each event has a list
+      # of topics. Topics matches a prefix of that list. An empty element array matches any
+      # topic. Non-empty elements represent an alternative that matches any of the
+      # contained topics.
+      #
+      # Examples:
+      #  - [] or nil          matches any topic list
+      #  - [[A]]              matches topic A in first position
+      #  - [[], [B]]          matches any topic in first position, B in second position
+      #  - [[A], [B]]         matches topic A in first position, B in second position
+      #  - [[A, B]], [C, D]]  matches topic (A OR B) in first position, (C OR D) in second position
+        topics: [[Bytes32!]!]
+    }
+
+    # Block is an Dogechain block.
+    type Block {
+        # Number is the number of this block, starting at 0 for the genesis block.
+        number: Long!
+        # Hash is the block hash of this block.
+        hash: Bytes32!
+        # Parent is the parent block of this block.
+        parent: Block
+        # Nonce is the block nonce, an 8 byte sequence determined by the miner.
+        nonce: Bytes!
+        # TransactionsRoot is the keccak256 hash of the root of the trie of transactions in this block.
+        transactionsRoot: Bytes32!
+        # TransactionCount is the number of transactions in this block. if
+        # transactions are not available for this block, this field will be null.
+        transactionCount: Int
+        # StateRoot is the keccak256 hash of the state trie after this block was processed.
+        stateRoot: Bytes32!
+        # ReceiptsRoot is the keccak256 hash of the trie of transaction receipts in this block.
+        receiptsRoot: Bytes32!
+        # Miner is the account that mined this block, which is also proposer of the block.
+        miner(block: Long): Account!
+        # ExtraData is an arbitrary data field supplied by the miner.
+        extraData: Bytes!
+        # GasLimit is the maximum amount of gas that was available to transactions in this block.
+        gasLimit: Long!
+        # GasUsed is the amount of gas that was used executing transactions in this block.
+        gasUsed: Long!
+        # Timestamp is the unix timestamp at which this block was mined.
+        timestamp: Long!
+        # LogsBloom is a bloom filter that can be used to check if a block may
+        # contain log entries matching a filter.
+        logsBloom: Bytes!
+        # MixHash is the hash that was used as an input to the PoW process.
+        mixHash: Bytes32!
+        # Difficulty is a measure of the difficulty of mining this block.
+        difficulty: BigInt!
+        # TotalDifficulty is the sum of all difficulty values up to and including
+        # this block.
+        totalDifficulty: BigInt!
+        # Account fetches an Dogechain account at the current block's state.
+        account(address: Address!): Account!
+        # RawHeader is the RLP encoding of the block's header.
+        rawHeader: Bytes!
+        # Raw is the RLP encoding of the block.
+        raw: Bytes!
+    }
+
+    # FilterCriteria encapsulates log filter criteria for searching log entries.
+    input FilterCriteria {
+        # FromBlock is the block at which to start searching, inclusive. Defaults
+        # to the latest block if not supplied.
+        fromBlock: Long
+        # ToBlock is the block at which to stop searching, inclusive. Defaults
+        # to the latest block if not supplied.
+        toBlock: Long
+        # Addresses is a list of addresses that are of interest. If this list is
+        # empty, results will not be filtered by address.
+        addresses: [Address!]
+        # Topics list restricts matches to particular event topics. Each event has a list
+      # of topics. Topics matches a prefix of that list. An empty element array matches any
+      # topic. Non-empty elements represent an alternative that matches any of the
+      # contained topics.
+      #
+      # Examples:
+      #  - [] or nil          matches any topic list
+      #  - [[A]]              matches topic A in first position
+      #  - [[], [B]]          matches any topic in first position, B in second position
+      #  - [[A], [B]]         matches topic A in first position, B in second position
+      #  - [[A, B]], [C, D]]  matches topic (A OR B) in first position, (C OR D) in second position
+        topics: [[Bytes32!]!]
+    }
+
+    type Query {
+        # Block fetches an Dogechain block by number or by hash. If neither is
+        # supplied, the most recent known block is returned.
+        block(number: Long, hash: Bytes32): Block
+        # Blocks returns all the blocks between two numbers, inclusive. If
+        # to is not supplied, it defaults to the most recent known block.
+        blocks(from: Long, to: Long): [Block!]!
+        # Transaction returns a transaction specified by its hash.
+        transaction(hash: Bytes32!): Transaction
+        # Logs returns log entries matching the provided filter.
+        logs(filter: FilterCriteria!): [Log!]!
+        # GasPrice returns the node's estimate of a gas price sufficient to
+        # ensure a transaction is mined in a timely fashion.
+        gasPrice: BigInt!
+        # ChainID returns the current chain ID for transaction replay protection.
+        chainID: BigInt!
+    }
+`

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -163,9 +163,15 @@ const schema string = `
         mixHash: Bytes32!
         # Difficulty is a measure of the difficulty of mining this block.
         difficulty: BigInt!
-        # TotalDifficulty is the sum of all difficulty values up to and including
-        # this block.
-        totalDifficulty: BigInt!
+        # Transactions is a list of transactions associated with this block. If
+        # transactions are unavailable for this block, this field will be null.
+        transactions: [Transaction!]
+        # TransactionAt returns the transaction at the specified index. If
+        # transactions are unavailable for this block, or if the index is out of
+        # bounds, this field will be null.
+        transactionAt(index: Int!): Transaction
+        # Logs returns a filtered set of logs from this block.
+        logs(filter: BlockFilterCriteria!): [Log!]!
         # Account fetches an Dogechain account at the current block's state.
         account(address: Address!): Account!
         # RawHeader is the RLP encoding of the block's header.

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -39,7 +39,7 @@ type GraphQLStore interface {
 func NewGraphQLService(logger hclog.Logger, config *Config) (*GraphQLService, error) {
 	q := Resolver{
 		backend:       config.Store,
-		chainID:       uint64(config.ChainID),
+		chainID:       config.ChainID,
 		filterManager: rpc.NewFilterManager(hclog.NewNullLogger(), config.Store),
 	}
 

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -3,13 +3,10 @@ package graphql
 import (
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"net"
 	"net/http"
 
 	"github.com/dogechain-lab/dogechain/chain"
-	"github.com/dogechain-lab/dogechain/crypto"
-	"github.com/dogechain-lab/dogechain/graphql/argtype"
 	rpc "github.com/dogechain-lab/dogechain/jsonrpc"
 	"github.com/graph-gophers/graphql-go"
 	"github.com/hashicorp/go-hclog"
@@ -25,7 +22,7 @@ type GraphQLService struct {
 type Config struct {
 	Store                    GraphQLStore
 	Addr                     *net.TCPAddr
-	ForksInTime              chain.ForksInTime
+	Forks                    chain.Forks
 	ChainID                  uint64
 	AccessControlAllowOrigin []string
 }
@@ -40,14 +37,10 @@ type GraphQLStore interface {
 
 // NewJSONRPC returns the JSONRPC http server
 func NewGraphQLService(logger hclog.Logger, config *Config) (*GraphQLService, error) {
-	chainID := big.NewInt(int64(config.ChainID))
-
 	q := Resolver{
 		backend:       config.Store,
-		chainID:       argtype.Big(*chainID),
-		forksInTime:   config.ForksInTime,
+		chainID:       uint64(config.ChainID),
 		filterManager: rpc.NewFilterManager(hclog.NewNullLogger(), config.Store),
-		signer:        crypto.NewSigner(config.ForksInTime, config.ChainID),
 	}
 
 	s, err := graphql.ParseSchema(schema, &q)

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -1,0 +1,153 @@
+package graphql
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+
+	"github.com/dogechain-lab/dogechain/graphql/argtype"
+	"github.com/graph-gophers/graphql-go"
+	"github.com/hashicorp/go-hclog"
+)
+
+type GraphQLService struct {
+	logger  hclog.Logger
+	config  *Config
+	ui      *GraphiQL
+	handler *handler
+}
+
+type Config struct {
+	Store                    GraphQLStore
+	Addr                     *net.TCPAddr
+	ChainID                  uint64
+	AccessControlAllowOrigin []string
+}
+
+// GraphQLStore defines all the methods required
+// by all the JSON RPC endpoints
+type GraphQLStore interface {
+	ethStore
+	txPoolStore
+	filterManagerStore
+}
+
+// NewJSONRPC returns the JSONRPC http server
+func NewGraphQLService(logger hclog.Logger, config *Config) (*GraphQLService, error) {
+	chainID := big.NewInt(int64(config.ChainID))
+	q := Resolver{config.Store, argtype.Big(*chainID)}
+
+	s, err := graphql.ParseSchema(schema, &q)
+	if err != nil {
+		return nil, err
+	}
+
+	srv := &GraphQLService{
+		logger:  logger.Named("graphql"),
+		config:  config,
+		ui:      &GraphiQL{},
+		handler: &handler{Schema: s},
+	}
+
+	// start http server
+	if err := srv.setupHTTP(); err != nil {
+		return nil, err
+	}
+
+	return srv, nil
+}
+
+func (svc *GraphQLService) setupHTTP() error {
+	svc.logger.Info("graphql server started", "addr", svc.config.Addr.String())
+
+	lis, err := net.Listen("tcp", svc.config.Addr.String())
+	if err != nil {
+		return err
+	}
+
+	mux := http.DefaultServeMux
+
+	// The middleware factory returns a handler, so we need to wrap the handler function properly.
+	graphQLHandler := http.HandlerFunc(svc.handler.ServeHTTP)
+	mux.Handle("/graphql/ui", middlewareFactory(svc.config)(http.HandlerFunc(svc.ui.ServeHTTP)))
+	mux.Handle("/graphql", middlewareFactory(svc.config)(graphQLHandler))
+	mux.Handle("/graphql/", middlewareFactory(svc.config)(graphQLHandler))
+
+	srv := http.Server{
+		Handler: mux,
+	}
+
+	go func() {
+		if err := srv.Serve(lis); err != nil {
+			svc.logger.Error("closed http connection", "err", err)
+		}
+	}()
+
+	return nil
+}
+
+type handler struct {
+	Schema *graphql.Schema
+}
+
+func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var params struct {
+		Query         string                 `json:"query"`
+		OperationName string                 `json:"operationName"`
+		Variables     map[string]interface{} `json:"variables"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	// exec schema query
+	response := h.Schema.Exec(r.Context(), params.Query, params.OperationName, params.Variables)
+
+	// marshal response
+	responseJSON, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	if len(response.Errors) > 0 {
+		w.WriteHeader(http.StatusBadRequest)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	_, err = w.Write(responseJSON)
+	if err != nil {
+		respond(w, errorJSON(fmt.Sprintf("graphql response write failed: %v", err)), http.StatusBadRequest)
+	}
+}
+
+// The middlewareFactory builds a middleware which enables CORS using the provided config.
+func middlewareFactory(config *Config) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+
+			for _, allowedOrigin := range config.AccessControlAllowOrigin {
+				if allowedOrigin == "*" {
+					w.Header().Set("Access-Control-Allow-Origin", "*")
+
+					break
+				}
+
+				if allowedOrigin == origin {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+
+					break
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -70,10 +70,10 @@ func (svc *GraphQLService) setupHTTP() error {
 	mux := http.DefaultServeMux
 
 	// The middleware factory returns a handler, so we need to wrap the handler function properly.
-	graphQLHandler := http.HandlerFunc(svc.handler.ServeHTTP)
+	graphqlHandler := http.HandlerFunc(svc.handler.ServeHTTP)
 	mux.Handle("/graphql/ui", middlewareFactory(svc.config)(http.HandlerFunc(svc.ui.ServeHTTP)))
-	mux.Handle("/graphql", middlewareFactory(svc.config)(graphQLHandler))
-	mux.Handle("/graphql/", middlewareFactory(svc.config)(graphQLHandler))
+	mux.Handle("/graphql", middlewareFactory(svc.config)(graphqlHandler))
+	mux.Handle("/graphql/", middlewareFactory(svc.config)(graphqlHandler))
 
 	srv := http.Server{
 		Handler: mux,

--- a/jsonrpc/codec.go
+++ b/jsonrpc/codec.go
@@ -120,7 +120,7 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 
 	err := json.Unmarshal(data, &placeholder)
 	if err != nil {
-		number, err := stringToBlockNumber(string(data))
+		number, err := StringToBlockNumber(string(data))
 		if err != nil {
 			return err
 		}
@@ -141,7 +141,7 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func stringToBlockNumber(str string) (BlockNumber, error) {
+func StringToBlockNumber(str string) (BlockNumber, error) {
 	if str == "" {
 		return 0, fmt.Errorf("value is empty")
 	}
@@ -164,8 +164,8 @@ func stringToBlockNumber(str string) (BlockNumber, error) {
 	return BlockNumber(n), nil
 }
 
-func createBlockNumberPointer(str string) (*BlockNumber, error) {
-	blockNumber, err := stringToBlockNumber(str)
+func CreateBlockNumberPointer(str string) (*BlockNumber, error) {
+	blockNumber, err := StringToBlockNumber(str)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func createBlockNumberPointer(str string) (*BlockNumber, error) {
 
 // UnmarshalJSON automatically decodes the user input for the block number, when a JSON RPC method is called
 func (b *BlockNumber) UnmarshalJSON(buffer []byte) error {
-	num, err := stringToBlockNumber(string(buffer))
+	num, err := StringToBlockNumber(string(buffer))
 	if err != nil {
 		return err
 	}

--- a/jsonrpc/codec.go
+++ b/jsonrpc/codec.go
@@ -94,6 +94,12 @@ func (e *ObjectError) Error() string {
 }
 
 const (
+	PendingBlockFlag  = "pending"
+	LatestBlockFlag   = "latest"
+	EarliestBlockFlag = "earliest"
+)
+
+const (
 	PendingBlockNumber  = BlockNumber(-3)
 	LatestBlockNumber   = BlockNumber(-2)
 	EarliestBlockNumber = BlockNumber(-1)
@@ -148,11 +154,11 @@ func StringToBlockNumber(str string) (BlockNumber, error) {
 
 	str = strings.Trim(str, "\"")
 	switch str {
-	case "pending":
+	case PendingBlockFlag:
 		return PendingBlockNumber, nil
-	case "latest":
+	case LatestBlockFlag:
 		return LatestBlockNumber, nil
-	case "earliest":
+	case EarliestBlockFlag:
 		return EarliestBlockNumber, nil
 	}
 

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -249,7 +249,7 @@ func TestDispatcherFuncDecode(t *testing.T) {
 		{
 			"filter",
 			`[{"fromBlock": "pending", "toBlock": "earliest"}]`,
-			LogQuery{fromBlock: PendingBlockNumber, toBlock: EarliestBlockNumber},
+			LogQuery{FromBlock: PendingBlockNumber, ToBlock: EarliestBlockNumber},
 		},
 	}
 	for _, c := range cases {

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -396,7 +396,7 @@ func (e *Eth) GetStorageAt(
 
 	// The filter is empty, use the latest block by default
 	if filter.BlockNumber == nil && filter.BlockHash == nil {
-		filter.BlockNumber, _ = CreateBlockNumberPointer("latest")
+		filter.BlockNumber, _ = CreateBlockNumberPointer(LatestBlockFlag)
 	}
 
 	header, err = e.getHeaderFromBlockNumberOrHash(&filter)
@@ -455,7 +455,7 @@ func (e *Eth) Call(arg *txnArgs, filter BlockNumberOrHash) (interface{}, error) 
 
 	// The filter is empty, use the latest block by default
 	if filter.BlockNumber == nil && filter.BlockHash == nil {
-		filter.BlockNumber, _ = CreateBlockNumberPointer("latest")
+		filter.BlockNumber, _ = CreateBlockNumberPointer(LatestBlockFlag)
 	}
 
 	header, err = e.getHeaderFromBlockNumberOrHash(&filter)
@@ -703,7 +703,7 @@ func (e *Eth) GetBalance(address types.Address, filter BlockNumberOrHash) (inter
 
 	// The filter is empty, use the latest block by default
 	if filter.BlockNumber == nil && filter.BlockHash == nil {
-		filter.BlockNumber, _ = CreateBlockNumberPointer("latest")
+		filter.BlockNumber, _ = CreateBlockNumberPointer(LatestBlockFlag)
 	}
 
 	header, err = e.getHeaderFromBlockNumberOrHash(&filter)
@@ -733,7 +733,7 @@ func (e *Eth) GetTransactionCount(address types.Address, filter BlockNumberOrHas
 
 	// The filter is empty, use the latest block by default
 	if filter.BlockNumber == nil && filter.BlockHash == nil {
-		filter.BlockNumber, _ = CreateBlockNumberPointer("latest")
+		filter.BlockNumber, _ = CreateBlockNumberPointer(LatestBlockFlag)
 	}
 
 	if filter.BlockNumber == nil {
@@ -768,7 +768,7 @@ func (e *Eth) GetCode(address types.Address, filter BlockNumberOrHash) (interfac
 
 	// The filter is empty, use the latest block by default
 	if filter.BlockNumber == nil && filter.BlockHash == nil {
-		filter.BlockNumber, _ = CreateBlockNumberPointer("latest")
+		filter.BlockNumber, _ = CreateBlockNumberPointer(LatestBlockFlag)
 	}
 
 	header, err = e.getHeaderFromBlockNumberOrHash(&filter)

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -396,7 +396,7 @@ func (e *Eth) GetStorageAt(
 
 	// The filter is empty, use the latest block by default
 	if filter.BlockNumber == nil && filter.BlockHash == nil {
-		filter.BlockNumber, _ = createBlockNumberPointer("latest")
+		filter.BlockNumber, _ = CreateBlockNumberPointer("latest")
 	}
 
 	header, err = e.getHeaderFromBlockNumberOrHash(&filter)
@@ -455,7 +455,7 @@ func (e *Eth) Call(arg *txnArgs, filter BlockNumberOrHash) (interface{}, error) 
 
 	// The filter is empty, use the latest block by default
 	if filter.BlockNumber == nil && filter.BlockHash == nil {
-		filter.BlockNumber, _ = createBlockNumberPointer("latest")
+		filter.BlockNumber, _ = CreateBlockNumberPointer("latest")
 	}
 
 	header, err = e.getHeaderFromBlockNumberOrHash(&filter)
@@ -703,7 +703,7 @@ func (e *Eth) GetBalance(address types.Address, filter BlockNumberOrHash) (inter
 
 	// The filter is empty, use the latest block by default
 	if filter.BlockNumber == nil && filter.BlockHash == nil {
-		filter.BlockNumber, _ = createBlockNumberPointer("latest")
+		filter.BlockNumber, _ = CreateBlockNumberPointer("latest")
 	}
 
 	header, err = e.getHeaderFromBlockNumberOrHash(&filter)
@@ -733,7 +733,7 @@ func (e *Eth) GetTransactionCount(address types.Address, filter BlockNumberOrHas
 
 	// The filter is empty, use the latest block by default
 	if filter.BlockNumber == nil && filter.BlockHash == nil {
-		filter.BlockNumber, _ = createBlockNumberPointer("latest")
+		filter.BlockNumber, _ = CreateBlockNumberPointer("latest")
 	}
 
 	if filter.BlockNumber == nil {
@@ -768,7 +768,7 @@ func (e *Eth) GetCode(address types.Address, filter BlockNumberOrHash) (interfac
 
 	// The filter is empty, use the latest block by default
 	if filter.BlockNumber == nil && filter.BlockHash == nil {
-		filter.BlockNumber, _ = createBlockNumberPointer("latest")
+		filter.BlockNumber, _ = CreateBlockNumberPointer("latest")
 	}
 
 	header, err = e.getHeaderFromBlockNumberOrHash(&filter)

--- a/jsonrpc/filter_manager.go
+++ b/jsonrpc/filter_manager.go
@@ -403,12 +403,12 @@ func (f *FilterManager) getLogsFromBlocks(query *LogQuery) ([]*Log, error) {
 		return uint64(num), nil
 	}
 
-	from, err := resolveNum(query.fromBlock)
+	from, err := resolveNum(query.FromBlock)
 	if err != nil {
 		return nil, err
 	}
 
-	to, err := resolveNum(query.toBlock)
+	to, err := resolveNum(query.ToBlock)
 	if err != nil {
 		return nil, err
 	}

--- a/jsonrpc/filter_manager_test.go
+++ b/jsonrpc/filter_manager_test.go
@@ -187,8 +187,8 @@ func Test_GetLogsForQuery(t *testing.T) {
 		{
 			"Found matching logs, fromBlock < toBlock",
 			&LogQuery{
-				fromBlock: 1,
-				toBlock:   3,
+				FromBlock: 1,
+				ToBlock:   3,
 				Topics:    topics,
 			},
 			3,
@@ -197,8 +197,8 @@ func Test_GetLogsForQuery(t *testing.T) {
 		{
 			"Found matching logs, fromBlock == toBlock",
 			&LogQuery{
-				fromBlock: 2,
-				toBlock:   2,
+				FromBlock: 2,
+				ToBlock:   2,
 				Topics:    topics,
 			},
 			1,
@@ -216,8 +216,8 @@ func Test_GetLogsForQuery(t *testing.T) {
 		{
 			"No logs found",
 			&LogQuery{
-				fromBlock: 4,
-				toBlock:   5,
+				FromBlock: 4,
+				ToBlock:   5,
 				Topics:    topics,
 			},
 			0,
@@ -226,8 +226,8 @@ func Test_GetLogsForQuery(t *testing.T) {
 		{
 			"Invalid block range",
 			&LogQuery{
-				fromBlock: 10,
-				toBlock:   5,
+				FromBlock: 10,
+				ToBlock:   5,
 				Topics:    topics,
 			},
 			0,
@@ -268,8 +268,8 @@ func Test_GetLogFilterFromID(t *testing.T) {
 
 	logFilter := &LogQuery{
 		Addresses: []types.Address{addr1},
-		toBlock:   10,
-		fromBlock: 0,
+		ToBlock:   10,
+		FromBlock: 0,
 	}
 
 	retrivedLogFilter, err := m.GetLogFilterFromID(

--- a/jsonrpc/query.go
+++ b/jsonrpc/query.go
@@ -93,7 +93,7 @@ func (q *LogQuery) UnmarshalJSON(data []byte) error {
 	if obj.FromBlock == "" {
 		q.fromBlock = LatestBlockNumber
 	} else {
-		if q.fromBlock, err = stringToBlockNumber(obj.FromBlock); err != nil {
+		if q.fromBlock, err = StringToBlockNumber(obj.FromBlock); err != nil {
 			return err
 		}
 	}
@@ -101,7 +101,7 @@ func (q *LogQuery) UnmarshalJSON(data []byte) error {
 	if obj.ToBlock == "" {
 		q.toBlock = LatestBlockNumber
 	} else {
-		if q.toBlock, err = stringToBlockNumber(obj.ToBlock); err != nil {
+		if q.toBlock, err = StringToBlockNumber(obj.ToBlock); err != nil {
 			return err
 		}
 	}

--- a/jsonrpc/query.go
+++ b/jsonrpc/query.go
@@ -11,8 +11,8 @@ import (
 type LogQuery struct {
 	BlockHash *types.Hash
 
-	fromBlock BlockNumber
-	toBlock   BlockNumber
+	FromBlock BlockNumber
+	ToBlock   BlockNumber
 
 	Addresses []types.Address
 	Topics    [][]types.Hash
@@ -91,17 +91,17 @@ func (q *LogQuery) UnmarshalJSON(data []byte) error {
 	q.BlockHash = obj.BlockHash
 
 	if obj.FromBlock == "" {
-		q.fromBlock = LatestBlockNumber
+		q.FromBlock = LatestBlockNumber
 	} else {
-		if q.fromBlock, err = StringToBlockNumber(obj.FromBlock); err != nil {
+		if q.FromBlock, err = StringToBlockNumber(obj.FromBlock); err != nil {
 			return err
 		}
 	}
 
 	if obj.ToBlock == "" {
-		q.toBlock = LatestBlockNumber
+		q.ToBlock = LatestBlockNumber
 	} else {
-		if q.toBlock, err = StringToBlockNumber(obj.ToBlock); err != nil {
+		if q.ToBlock, err = StringToBlockNumber(obj.ToBlock); err != nil {
 			return err
 		}
 	}

--- a/jsonrpc/query_test.go
+++ b/jsonrpc/query_test.go
@@ -25,8 +25,8 @@ func TestFilterDecode(t *testing.T) {
 		{
 			`{}`,
 			&LogQuery{
-				fromBlock: LatestBlockNumber,
-				toBlock:   LatestBlockNumber,
+				FromBlock: LatestBlockNumber,
+				ToBlock:   LatestBlockNumber,
 			},
 		},
 		{
@@ -40,8 +40,8 @@ func TestFilterDecode(t *testing.T) {
 				"address": "` + addr1.String() + `"
 			}`,
 			&LogQuery{
-				fromBlock: LatestBlockNumber,
-				toBlock:   LatestBlockNumber,
+				FromBlock: LatestBlockNumber,
+				ToBlock:   LatestBlockNumber,
 				Addresses: []types.Address{
 					addr1,
 				},
@@ -55,8 +55,8 @@ func TestFilterDecode(t *testing.T) {
 				]
 			}`,
 			&LogQuery{
-				fromBlock: LatestBlockNumber,
-				toBlock:   LatestBlockNumber,
+				FromBlock: LatestBlockNumber,
+				ToBlock:   LatestBlockNumber,
 				Addresses: []types.Address{
 					addr1,
 					addr2,
@@ -79,8 +79,8 @@ func TestFilterDecode(t *testing.T) {
 				]
 			}`,
 			&LogQuery{
-				fromBlock: LatestBlockNumber,
-				toBlock:   LatestBlockNumber,
+				FromBlock: LatestBlockNumber,
+				ToBlock:   LatestBlockNumber,
 				Topics: [][]types.Hash{
 					{
 						hash1,
@@ -105,8 +105,8 @@ func TestFilterDecode(t *testing.T) {
 				"toBlock": "earliest"
 			}`,
 			&LogQuery{
-				fromBlock: PendingBlockNumber,
-				toBlock:   EarliestBlockNumber,
+				FromBlock: PendingBlockNumber,
+				ToBlock:   EarliestBlockNumber,
 			},
 		},
 		{
@@ -115,8 +115,8 @@ func TestFilterDecode(t *testing.T) {
 			}`,
 			&LogQuery{
 				BlockHash: &hash1,
-				fromBlock: LatestBlockNumber,
-				toBlock:   LatestBlockNumber,
+				FromBlock: LatestBlockNumber,
+				ToBlock:   LatestBlockNumber,
 			},
 		},
 		{
@@ -125,8 +125,8 @@ func TestFilterDecode(t *testing.T) {
 				"toBlock": "1000"
 			}`,
 			&LogQuery{
-				fromBlock: 0,
-				toBlock:   1000,
+				FromBlock: 0,
+				ToBlock:   1000,
 			},
 		},
 		{
@@ -135,8 +135,8 @@ func TestFilterDecode(t *testing.T) {
 				"toBlock": "0x3e8"
 			}`,
 			&LogQuery{
-				fromBlock: 0,
-				toBlock:   1000,
+				FromBlock: 0,
+				ToBlock:   1000,
 			},
 		},
 	}

--- a/server/config.go
+++ b/server/config.go
@@ -12,14 +12,17 @@ import (
 
 const DefaultGRPCPort int = 9632
 const DefaultJSONRPCPort int = 8545
+const DefaultGraphQLPort int = 9898
 
 // Config is used to parametrize the minimal client
 type Config struct {
 	Chain *chain.Chain
 
-	JSONRPC    *JSONRPC
-	GRPCAddr   *net.TCPAddr
-	LibP2PAddr *net.TCPAddr
+	JSONRPC       *JSONRPC
+	EnableGraphQL bool
+	GraphQL       *GraphQL
+	GRPCAddr      *net.TCPAddr
+	LibP2PAddr    *net.TCPAddr
 
 	PriceLimit          uint64
 	MaxSlots            uint64
@@ -50,5 +53,10 @@ type Telemetry struct {
 // JSONRPC holds the config details for the JSON-RPC server
 type JSONRPC struct {
 	JSONRPCAddr              *net.TCPAddr
+	AccessControlAllowOrigin []string
+}
+
+type GraphQL struct {
+	GraphQLAddr              *net.TCPAddr
 	AccessControlAllowOrigin []string
 }

--- a/types/address.go
+++ b/types/address.go
@@ -109,3 +109,20 @@ func (a *Address) UnmarshalText(input []byte) error {
 func (a Address) MarshalText() ([]byte, error) {
 	return []byte(a.String()), nil
 }
+
+// ImplementsGraphQLType returns true if Hash implements the specified GraphQL type.
+func (a Address) ImplementsGraphQLType(name string) bool { return name == "Address" }
+
+// UnmarshalGraphQL unmarshals the provided GraphQL query data.
+func (a *Address) UnmarshalGraphQL(input interface{}) error {
+	var err error
+
+	switch input := input.(type) {
+	case string:
+		err = a.UnmarshalText([]byte(input))
+	default:
+		err = fmt.Errorf("unexpected type %T for Address", input)
+	}
+
+	return err
+}

--- a/types/address.go
+++ b/types/address.go
@@ -4,7 +4,6 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"strings"
 	"unicode"
 
 	"github.com/dogechain-lab/dogechain/helper/hex"
@@ -12,63 +11,12 @@ import (
 )
 
 var ZeroAddress = Address{}
-var ZeroHash = Hash{}
 
 const (
-	HashLength    = 32
 	AddressLength = 20
 )
 
-type Hash [HashLength]byte
-
 type Address [AddressLength]byte
-
-func min(i, j int) int {
-	if i < j {
-		return i
-	}
-
-	return j
-}
-
-func BytesToHash(b []byte) Hash {
-	var h Hash
-
-	size := len(b)
-	min := min(size, HashLength)
-
-	copy(h[HashLength-min:], b[len(b)-min:])
-
-	return h
-}
-
-func (h Hash) Bytes() []byte {
-	return h[:]
-}
-
-func (h Hash) String() string {
-	return hex.EncodeToHex(h[:])
-}
-
-func (h Hash) Value() (driver.Value, error) {
-	return h.String(), nil
-}
-
-func (h *Hash) Scan(src interface{}) error {
-	stringVal, ok := src.([]byte)
-	if !ok {
-		return errors.New("invalid type assert")
-	}
-
-	hh, err := hex.DecodeHex(string(stringVal))
-	if err != nil {
-		return fmt.Errorf("decode hex err: %w", err)
-	}
-
-	copy(h[:], hh[:])
-
-	return nil
-}
 
 // checksumEncode returns the checksummed address with 0x prefix, as by EIP-55
 // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md
@@ -127,10 +75,6 @@ func (a *Address) Scan(src interface{}) error {
 	return nil
 }
 
-func StringToHash(str string) Hash {
-	return BytesToHash(stringToBytes(str))
-}
-
 func StringToAddress(str string) Address {
 	return BytesToAddress(stringToBytes(str))
 }
@@ -150,24 +94,6 @@ func BytesToAddress(b []byte) Address {
 	return a
 }
 
-func stringToBytes(str string) []byte {
-	str = strings.TrimPrefix(str, "0x")
-	if len(str)%2 == 1 {
-		str = "0" + str
-	}
-
-	b, _ := hex.DecodeString(str)
-
-	return b
-}
-
-// UnmarshalText parses a hash in hex syntax.
-func (h *Hash) UnmarshalText(input []byte) error {
-	*h = BytesToHash(stringToBytes(string(input)))
-
-	return nil
-}
-
 // UnmarshalText parses an address in hex syntax.
 func (a *Address) UnmarshalText(input []byte) error {
 	buf := stringToBytes(string(input))
@@ -180,18 +106,6 @@ func (a *Address) UnmarshalText(input []byte) error {
 	return nil
 }
 
-func (h Hash) MarshalText() ([]byte, error) {
-	return []byte(h.String()), nil
-}
-
 func (a Address) MarshalText() ([]byte, error) {
 	return []byte(a.String()), nil
 }
-
-var (
-	// EmptyRootHash is the root when there are no transactions
-	EmptyRootHash = StringToHash("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
-
-	// EmptyUncleHash is the root when there are no uncles
-	EmptyUncleHash = StringToHash("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")
-)

--- a/types/address_test.go
+++ b/types/address_test.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"math/big"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,25 +54,5 @@ func TestEIP55(t *testing.T) {
 			addr := StringToAddress(c.address)
 			assert.Equal(t, c.expected, addr.String())
 		})
-	}
-}
-
-func TestTransactionCopy(t *testing.T) {
-	addrTo := StringToAddress("11")
-	txn := &Transaction{
-		Nonce:    0,
-		GasPrice: big.NewInt(11),
-		Gas:      11,
-		To:       &addrTo,
-		Value:    big.NewInt(1),
-		Input:    []byte{1, 2},
-		V:        big.NewInt(25),
-		S:        big.NewInt(26),
-		R:        big.NewInt(27),
-	}
-	newTxn := txn.Copy()
-
-	if !reflect.DeepEqual(txn, newTxn) {
-		t.Fatal("[ERROR] Copied transaction not equal base transaction")
 	}
 }

--- a/types/hash.go
+++ b/types/hash.go
@@ -78,3 +78,20 @@ func (h *Hash) UnmarshalText(input []byte) error {
 func (h Hash) MarshalText() ([]byte, error) {
 	return []byte(h.String()), nil
 }
+
+// ImplementsGraphQLType returns true if Hash implements the specified GraphQL type.
+func (h Hash) ImplementsGraphQLType(name string) bool { return name == "Bytes32" }
+
+// UnmarshalGraphQL unmarshals the provided GraphQL query data.
+func (h *Hash) UnmarshalGraphQL(input interface{}) error {
+	var err error
+
+	switch input := input.(type) {
+	case string:
+		err = h.UnmarshalText([]byte(input))
+	default:
+		err = fmt.Errorf("unexpected type %T for Hash", input)
+	}
+
+	return err
+}

--- a/types/hash.go
+++ b/types/hash.go
@@ -1,0 +1,80 @@
+package types
+
+import (
+	"database/sql/driver"
+	"errors"
+	"fmt"
+
+	"github.com/dogechain-lab/dogechain/helper/hex"
+)
+
+var (
+	// ZeroHash is all zero hash
+	ZeroHash = Hash{}
+
+	// EmptyRootHash is the root when there are no transactions
+	EmptyRootHash = StringToHash("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+
+	// EmptyUncleHash is the root when there are no uncles
+	EmptyUncleHash = StringToHash("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")
+)
+
+const (
+	HashLength = 32
+)
+
+type Hash [HashLength]byte
+
+func StringToHash(str string) Hash {
+	return BytesToHash(stringToBytes(str))
+}
+
+func BytesToHash(b []byte) Hash {
+	var h Hash
+
+	size := len(b)
+	min := min(size, HashLength)
+
+	copy(h[HashLength-min:], b[len(b)-min:])
+
+	return h
+}
+
+func (h Hash) Bytes() []byte {
+	return h[:]
+}
+
+func (h Hash) String() string {
+	return hex.EncodeToHex(h[:])
+}
+
+func (h Hash) Value() (driver.Value, error) {
+	return h.String(), nil
+}
+
+func (h *Hash) Scan(src interface{}) error {
+	stringVal, ok := src.([]byte)
+	if !ok {
+		return errors.New("invalid type assert")
+	}
+
+	hh, err := hex.DecodeHex(string(stringVal))
+	if err != nil {
+		return fmt.Errorf("decode hex err: %w", err)
+	}
+
+	copy(h[:], hh[:])
+
+	return nil
+}
+
+// UnmarshalText parses a hash in hex syntax.
+func (h *Hash) UnmarshalText(input []byte) error {
+	*h = BytesToHash(stringToBytes(string(input)))
+
+	return nil
+}
+
+func (h Hash) MarshalText() ([]byte, error) {
+	return []byte(h.String()), nil
+}

--- a/types/transaction_test.go
+++ b/types/transaction_test.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	"math/big"
+	"reflect"
+	"testing"
+)
+
+func TestTransactionCopy(t *testing.T) {
+	addrTo := StringToAddress("11")
+	txn := &Transaction{
+		Nonce:    0,
+		GasPrice: big.NewInt(11),
+		Gas:      11,
+		To:       &addrTo,
+		Value:    big.NewInt(1),
+		Input:    []byte{1, 2},
+		V:        big.NewInt(25),
+		S:        big.NewInt(26),
+		R:        big.NewInt(27),
+	}
+	newTxn := txn.Copy()
+
+	if !reflect.DeepEqual(txn, newTxn) {
+		t.Fatal("[ERROR] Copied transaction not equal base transaction")
+	}
+}

--- a/types/util.go
+++ b/types/util.go
@@ -1,0 +1,26 @@
+package types
+
+import (
+	"strings"
+
+	"github.com/dogechain-lab/dogechain/helper/hex"
+)
+
+func min(i, j int) int {
+	if i < j {
+		return i
+	}
+
+	return j
+}
+
+func stringToBytes(str string) []byte {
+	str = strings.TrimPrefix(str, "0x")
+	if len(str)%2 == 1 {
+		str = "0" + str
+	}
+
+	b, _ := hex.DecodeString(str)
+
+	return b
+}


### PR DESCRIPTION
# Description

The PR provide GraphQL service defaults bind to `127.0.0.1:9898`, together with a UI router migrated from `go-ethereum`.

The GraphQL service would not enable until set the flag `enable-graphql`.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

* Deploy a test contract.
* Send some event trigger transaction.
* Call graphql ui service locally.
* Call query in ui playground.

Example:

```solidity
# contract
pragma solidity ^0.8.0;
contract Test {
    string public name;
    event NameSet(string name);
    constructor() {
        name = 'string';
    }
    function setName(string memory _name) public {
        name = _name;
        emit NameSet(_name);
    }
}
```

```graphql
{
  logs(filter: {fromBlock: 18940, toBlock: 18952, addresses: "0x2983650C693fB66467Af4630d9a1565069B509e6"}) {
    index
    account {
      address
    }
    topics
    data
    transaction {
      hash
      block {
        number
        timestamp
      }
    }
  }
}
```

It should be OK to return all the logs data with the test contract. Return example like this:

```graphql
{
  "data": {
    "logs": [
      {
        "index": 0,
        "account": {
          "address": "0x2983650C693fB66467Af4630d9a1565069B509e6"
        },
        "topics": [
          "0x13c98778b0c1a086bb98d7f1986e15788b5d3a1ad4c492e1d78f1c4cc51c20cf"
        ],
        "data": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000033132330000000000000000000000000000000000000000000000000000000000",
        "transaction": {
          "hash": "0xe9f82c7cbec1228405e64f5ae4d6a7bdc036a74bc95185263b6e11fd9c65b322",
          "block": {
            "number": 18947,
            "timestamp": "0x62b2bd94"
          }
        }
      }
    ]
  }
}
```
