### PR TITLE
Fix/protocol test failure

### DIFF
--- a/protocol/service_v1.go
+++ b/protocol/service_v1.go
@@ -58,7 +58,6 @@ func (s *serviceV1) Notify(ctx context.Context, req *proto.NotifyReq) (*empty.Em
 	}
 
 	status, err := fromProto(req.Status)
-
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -48,6 +48,12 @@ type SyncPeer struct {
 	conn   *grpc.ClientConn
 	client proto.V1Client
 
+	// Peer status might not be the latest block due to its asynchronous broadcast
+	// mechanism. The goroutine would makes the sequence unpredictable.
+	// So do not rely on its status for step by step watching syncing, especially
+	// in a bad network status.
+	// We would rather evolve the syncing protocol instead of patching too much for
+	// v1 protocol.
 	status     *Status
 	statusLock sync.RWMutex
 

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -163,15 +163,15 @@ func (s *SyncPeer) updateStatus(status *Status) {
 	s.statusLock.Lock()
 	defer s.statusLock.Unlock()
 
-	// // compare current status, would only update until new height meet or fork happens
-	// switch {
-	// case status.Number < s.status.Number:
-	// 	return
-	// case status.Number == s.status.Number:
-	// 	if status.Hash == s.status.Hash {
-	// 		return
-	// 	}
-	// }
+	// compare current status, would only update until new height meet or fork happens
+	switch {
+	case status.Number < s.status.Number:
+		return
+	case status.Number == s.status.Number:
+		if status.Hash == s.status.Hash {
+			return
+		}
+	}
 
 	s.status = status
 }
@@ -296,9 +296,7 @@ func (s *Syncer) syncCurrentStatus() {
 				Number:     evnt.NewChain[0].Number,
 			}
 
-			s.statusLock.Lock()
-			s.status = status
-			s.statusLock.Unlock()
+			s.updateStatus(status)
 
 		case <-s.stopCh:
 			sub.Close()
@@ -306,6 +304,25 @@ func (s *Syncer) syncCurrentStatus() {
 			return
 		}
 	}
+}
+
+func (s *Syncer) updateStatus(status *Status) {
+	s.statusLock.Lock()
+	defer s.statusLock.Unlock()
+
+	// compare current status, would only update until new height meet or fork happens
+	switch {
+	case status.Number < s.status.Number:
+		return
+	case status.Number == s.status.Number:
+		if status.Hash == s.status.Hash {
+			return
+		}
+	}
+
+	s.logger.Debug("update syncer status", "status", status)
+
+	s.status = status
 }
 
 const syncerV1 = "/syncer/0.1"


### PR DESCRIPTION
# Description

The PR fixes the unit test failure till PR #69 merged. `TestBroadcast` and `TestWatchSyncWithPeer` would failed after changing block broadcast from synchronous to asynchronous. 

The PR use sorting and status update filtering when handling receiving block broadcast from its peers.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually