### PR TITLE
Fix/graphql should disable by default

### DIFF
--- a/protocol/syncer_test.go
+++ b/protocol/syncer_test.go
@@ -139,6 +139,7 @@ func TestBroadcast(t *testing.T) {
 				// time out
 				if time.Now().After(endSyncTime) {
 					ticker.Stop()
+
 					break
 				}
 				// all blocks received
@@ -346,6 +347,7 @@ func TestWatchSyncWithPeer(t *testing.T) {
 				// time out
 				if time.Now().After(endWriteBlockTime) {
 					ticker.Stop()
+
 					break
 				}
 				// all blocks received

--- a/server/server.go
+++ b/server/server.go
@@ -587,6 +587,10 @@ func (s *Server) setupJSONRPC() error {
 
 // setupGraphQL sets up the graphql server, using the set configuration
 func (s *Server) setupGraphQL() error {
+	if !s.config.EnableGraphQL {
+		return nil
+	}
+
 	hub := &jsonRPCHub{
 		state:              s.state,
 		restoreProgression: s.restoreProgression,


### PR DESCRIPTION
# Description

The GraphQL should not be enable by default, but the flag is not used yet. Then the `e2e` tests failed.
The PR fixes this.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually