### PR TITLE
Copy slice for thread-safe txpool status endpoint access

### DIFF
--- a/txpool/account.go
+++ b/txpool/account.go
@@ -117,7 +117,9 @@ func (m *accountsMap) allTxs(includeEnqueued bool) (
 		defer account.promoted.unlock()
 
 		if account.promoted.length() != 0 {
-			allPromoted[addr] = account.promoted.queue
+			// slice is not thread safe, so copy it would be reasonable
+			allPromoted[addr] = make([]*types.Transaction, 0, account.promoted.length())
+			copy(allPromoted[addr], account.promoted.queue)
 		}
 
 		if includeEnqueued {
@@ -125,7 +127,9 @@ func (m *accountsMap) allTxs(includeEnqueued bool) (
 			defer account.enqueued.unlock()
 
 			if account.enqueued.length() != 0 {
-				allEnqueued[addr] = account.enqueued.queue
+				// slice is not thread safe, so copy it would be reasonable
+				allEnqueued[addr] = make([]*types.Transaction, 0, account.enqueued.length())
+				copy(allEnqueued[addr], account.enqueued.queue)
 			}
 		}
 


### PR DESCRIPTION
# Description

This PR fixes not `thread-safe` transaction slice access in `txpool`, which is used in JSON-RPC and GraphQL transaction pool status endpoints.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
