### PR TITLE
[Txpool] Prune stale enqueued transactions in tick

### DIFF
--- a/command/default.go
+++ b/command/default.go
@@ -3,16 +3,18 @@ package command
 import "github.com/dogechain-lab/dogechain/server"
 
 const (
-	DefaultGenesisFileName     = "genesis.json"
-	DefaultChainName           = "dogechain"
-	DefaultChainID             = 100
-	DefaultPremineBalance      = "0x3635C9ADC5DEA00000" // 1000 ETH
-	DefaultConsensus           = server.IBFTConsensus
-	DefaultPriceLimit          = 0
-	DefaultMaxSlots            = 4096
-	DefaultMaxAccountDemotions = 10      // account demotion counter limit
-	DefaultGenesisGasUsed      = 458752  // 0x70000
-	DefaultGenesisGasLimit     = 5242880 // 0x500000
+	DefaultGenesisFileName       = "genesis.json"
+	DefaultChainName             = "dogechain"
+	DefaultChainID               = 100
+	DefaultPremineBalance        = "0x3635C9ADC5DEA00000" // 1000 ETH
+	DefaultConsensus             = server.IBFTConsensus
+	DefaultPriceLimit            = 0
+	DefaultMaxSlots              = 4096
+	DefaultMaxAccountDemotions   = 10      // account demotion counter limit
+	DefaultPruneTickSeconds      = 300     // ticker duration for pruning account future transactions
+	DefaultPromoteOutdateSeconds = 1800    // not promoted account for a long time would be pruned
+	DefaultGenesisGasUsed        = 458752  // 0x70000
+	DefaultGenesisGasLimit       = 5242880 // 0x500000
 )
 
 const (

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -51,9 +51,11 @@ type Network struct {
 
 // TxPool defines the TxPool configuration params
 type TxPool struct {
-	PriceLimit          uint64 `json:"price_limit"`
-	MaxSlots            uint64 `json:"max_slots"`
-	MaxAccountDemotions uint64 `json:"max_account_demotions"`
+	PriceLimit            uint64 `json:"price_limit"`
+	MaxSlots              uint64 `json:"max_slots"`
+	MaxAccountDemotions   uint64 `json:"max_account_demotions"`
+	PruneTickSeconds      uint64 `json:"prune_tick_seconds"`
+	PromoteOutdateSeconds uint64 `json:"promote_outdate_seconds"`
 }
 
 // Headers defines the HTTP response headers required to enable CORS.
@@ -81,9 +83,11 @@ func DefaultConfig() *Config {
 		Telemetry:  &Telemetry{},
 		ShouldSeal: false,
 		TxPool: &TxPool{
-			PriceLimit:          command.DefaultPriceLimit,
-			MaxSlots:            command.DefaultMaxSlots,
-			MaxAccountDemotions: command.DefaultMaxAccountDemotions,
+			PriceLimit:            command.DefaultPriceLimit,
+			MaxSlots:              command.DefaultMaxSlots,
+			MaxAccountDemotions:   command.DefaultMaxAccountDemotions,
+			PruneTickSeconds:      command.DefaultPruneTickSeconds,
+			PromoteOutdateSeconds: command.DefaultPromoteOutdateSeconds,
 		},
 		LogLevel:    "INFO",
 		RestoreFile: "",

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -27,7 +27,7 @@ const (
 	maxOutboundPeersFlag      = "max-outbound-peers"
 	priceLimitFlag            = "price-limit"
 	maxSlotsFlag              = "max-slots"
-	MaxAccountDemotionsFlag   = "max-account-demotions"
+	maxAccountDemotionsFlag   = "max-account-demotions"
 	pruneTickSecondsFlag      = "prune-tick-seconds"
 	promoteOutdateSecondsFlag = "promote-outdate-seconds"
 	blockGasTargetFlag        = "block-gas-target"

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -14,30 +14,32 @@ import (
 )
 
 const (
-	configFlag              = "config"
-	genesisPathFlag         = "chain"
-	dataDirFlag             = "data-dir"
-	libp2pAddressFlag       = "libp2p"
-	prometheusAddressFlag   = "prometheus"
-	natFlag                 = "nat"
-	dnsFlag                 = "dns"
-	sealFlag                = "seal"
-	maxPeersFlag            = "max-peers"
-	maxInboundPeersFlag     = "max-inbound-peers"
-	maxOutboundPeersFlag    = "max-outbound-peers"
-	priceLimitFlag          = "price-limit"
-	maxSlotsFlag            = "max-slots"
-	MaxAccountDemotionsFlag = "max-account-demotions"
-	blockGasTargetFlag      = "block-gas-target"
-	secretsConfigFlag       = "secrets-config"
-	restoreFlag             = "restore"
-	blockTimeFlag           = "block-time"
-	devIntervalFlag         = "dev-interval"
-	devFlag                 = "dev"
-	corsOriginFlag          = "access-control-allow-origins"
-	daemonFlag              = "daemon"
-	logFileLocationFlag     = "log-to"
-	enableGraphQLFlag       = "enable-graphql"
+	configFlag                = "config"
+	genesisPathFlag           = "chain"
+	dataDirFlag               = "data-dir"
+	libp2pAddressFlag         = "libp2p"
+	prometheusAddressFlag     = "prometheus"
+	natFlag                   = "nat"
+	dnsFlag                   = "dns"
+	sealFlag                  = "seal"
+	maxPeersFlag              = "max-peers"
+	maxInboundPeersFlag       = "max-inbound-peers"
+	maxOutboundPeersFlag      = "max-outbound-peers"
+	priceLimitFlag            = "price-limit"
+	maxSlotsFlag              = "max-slots"
+	MaxAccountDemotionsFlag   = "max-account-demotions"
+	pruneTickSecondsFlag      = "prune-tick-seconds"
+	promoteOutdateSecondsFlag = "promote-outdate-seconds"
+	blockGasTargetFlag        = "block-gas-target"
+	secretsConfigFlag         = "secrets-config"
+	restoreFlag               = "restore"
+	blockTimeFlag             = "block-time"
+	devIntervalFlag           = "dev-interval"
+	devFlag                   = "dev"
+	corsOriginFlag            = "access-control-allow-origins"
+	daemonFlag                = "daemon"
+	logFileLocationFlag       = "log-to"
+	enableGraphQLFlag         = "enable-graphql"
 )
 
 const (
@@ -182,17 +184,19 @@ func (p *serverParams) generateConfig() *server.Config {
 			MaxOutboundPeers: p.rawConfig.Network.MaxOutboundPeers,
 			Chain:            p.genesisConfig,
 		},
-		DataDir:             p.rawConfig.DataDir,
-		Seal:                p.rawConfig.ShouldSeal,
-		PriceLimit:          p.rawConfig.TxPool.PriceLimit,
-		MaxSlots:            p.rawConfig.TxPool.MaxSlots,
-		MaxAccountDemotions: p.rawConfig.TxPool.MaxAccountDemotions,
-		SecretsManager:      p.secretsConfig,
-		RestoreFile:         p.getRestoreFilePath(),
-		BlockTime:           p.rawConfig.BlockTime,
-		LogLevel:            hclog.LevelFromString(p.rawConfig.LogLevel),
-		LogFilePath:         p.logFileLocation,
-		Daemon:              p.isDaemon,
-		ValidatorKey:        p.validatorKey,
+		DataDir:               p.rawConfig.DataDir,
+		Seal:                  p.rawConfig.ShouldSeal,
+		PriceLimit:            p.rawConfig.TxPool.PriceLimit,
+		MaxSlots:              p.rawConfig.TxPool.MaxSlots,
+		MaxAccountDemotions:   p.rawConfig.TxPool.MaxAccountDemotions,
+		PruneTickSeconds:      p.rawConfig.TxPool.PruneTickSeconds,
+		PromoteOutdateSeconds: p.rawConfig.TxPool.PromoteOutdateSeconds,
+		SecretsManager:        p.secretsConfig,
+		RestoreFile:           p.getRestoreFilePath(),
+		BlockTime:             p.rawConfig.BlockTime,
+		LogLevel:              hclog.LevelFromString(p.rawConfig.LogLevel),
+		LogFilePath:           p.logFileLocation,
+		Daemon:                p.isDaemon,
+		ValidatorKey:          p.validatorKey,
 	}
 }

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -186,6 +186,20 @@ func setFlags(cmd *cobra.Command) {
 	)
 
 	cmd.Flags().Uint64Var(
+		&params.rawConfig.TxPool.PruneTickSeconds,
+		pruneTickSecondsFlag,
+		command.DefaultPruneTickSeconds,
+		"tick seconds for pruning account future transactions in the pool",
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.rawConfig.TxPool.PromoteOutdateSeconds,
+		promoteOutdateSecondsFlag,
+		command.DefaultPromoteOutdateSeconds,
+		"account in the pool not promoted for a long time would be pruned",
+	)
+
+	cmd.Flags().Uint64Var(
 		&params.rawConfig.BlockTime,
 		blockTimeFlag,
 		defaultConfig.BlockTime,

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -180,7 +180,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().Uint64Var(
 		&params.rawConfig.TxPool.MaxAccountDemotions,
-		MaxAccountDemotionsFlag,
+		maxAccountDemotionsFlag,
 		command.DefaultMaxAccountDemotions,
 		"maximum account demontion counter limit in the pool",
 	)

--- a/server/config.go
+++ b/server/config.go
@@ -24,10 +24,12 @@ type Config struct {
 	GRPCAddr      *net.TCPAddr
 	LibP2PAddr    *net.TCPAddr
 
-	PriceLimit          uint64
-	MaxSlots            uint64
-	BlockTime           uint64
-	MaxAccountDemotions uint64
+	PriceLimit            uint64
+	MaxSlots              uint64
+	BlockTime             uint64
+	MaxAccountDemotions   uint64
+	PruneTickSeconds      uint64
+	PromoteOutdateSeconds uint64
 
 	Telemetry *Telemetry
 	Network   *network.Config

--- a/server/server.go
+++ b/server/server.go
@@ -219,10 +219,12 @@ func NewServer(config *Config) (*Server, error) {
 			m.network,
 			m.serverMetrics.txpool,
 			&txpool.Config{
-				Sealing:             m.config.Seal,
-				MaxSlots:            m.config.MaxSlots,
-				PriceLimit:          m.config.PriceLimit,
-				MaxAccountDemotions: m.config.MaxAccountDemotions,
+				Sealing:               m.config.Seal,
+				MaxSlots:              m.config.MaxSlots,
+				PriceLimit:            m.config.PriceLimit,
+				MaxAccountDemotions:   m.config.MaxAccountDemotions,
+				PruneTickSeconds:      m.config.PruneTickSeconds,
+				PromoteOutdateSeconds: m.config.PromoteOutdateSeconds,
 			},
 		)
 		if err != nil {

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -3,8 +3,13 @@ package txpool
 import (
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/dogechain-lab/dogechain/types"
+)
+
+var (
+	maxAccountInactivity = 30 * time.Minute
 )
 
 // Thread safe map of all accounts registered by the pool.
@@ -26,6 +31,9 @@ func (m *accountsMap) initOnce(addr types.Address, nonce uint64) *account {
 
 		// set the nonce
 		newAccount.setNonce(nonce)
+
+		// set the timestamp for pruning
+		newAccount.lastPromoted = time.Now()
 
 		// update global count
 		atomic.AddUint64(&m.count, 1)
@@ -135,6 +143,32 @@ func (m *accountsMap) allTxs(includeEnqueued bool) (
 	return
 }
 
+func (m *accountsMap) pruneStaleEnqueuedTxs() []*types.Transaction {
+	pruned := make([]*types.Transaction, 0)
+
+	m.Range(func(_, value interface{}) bool {
+		account, ok := value.(*account)
+		if !ok {
+			// It shouldn't be. We just do some prevention work.
+			return false
+		}
+
+		account.enqueued.lock(true)
+		defer account.enqueued.unlock()
+
+		if time.Since(account.lastPromoted) >= maxAccountInactivity {
+			pruned = append(
+				pruned,
+				account.enqueued.clear()...,
+			)
+		}
+
+		return true
+	})
+
+	return pruned
+}
+
 // An account is the core structure for processing
 // transactions from a specific address. The nextNonce
 // field is what separates the enqueued from promoted transactions:
@@ -146,11 +180,15 @@ func (m *accountsMap) allTxs(includeEnqueued bool) (
 // a promoteRequest is signaled for this account
 // indicating the account's enqueued transaction(s)
 // are ready to be moved to the promoted queue.
+//
+// If an account is not promoted for a long time, its enqueued transactions
+// should be remove to reduce txpool stress.
 type account struct {
 	init               sync.Once
 	enqueued, promoted *accountQueue
 	nextNonce          uint64
 	demotions          uint64
+	lastPromoted       time.Time // timestamp for pruning
 }
 
 // getNonce returns the next expected nonce for this account.
@@ -277,6 +315,9 @@ func (a *account) promote() []*types.Transaction {
 	if nextNonce > currentNonce {
 		a.setNonce(nextNonce)
 	}
+
+	// update timestamp for pruning
+	a.lastPromoted = time.Now()
 
 	return promoted
 }

--- a/txpool/metrics.go
+++ b/txpool/metrics.go
@@ -11,6 +11,13 @@ import (
 type Metrics struct {
 	// Pending transactions
 	PendingTxs metrics.Gauge
+	// Enqueue transactions
+	EnqueueTxs metrics.Gauge
+}
+
+func (m *Metrics) SetDefaultValue(v float64) {
+	m.PendingTxs.Set(v)
+	m.EnqueueTxs.Set(v)
 }
 
 // GetPrometheusMetrics return the txpool metrics instance
@@ -28,6 +35,12 @@ func GetPrometheusMetrics(namespace string, labelsWithValues ...string) *Metrics
 			Name:      "pending_transactions",
 			Help:      "Pending transactions in the pool",
 		}, labels).With(labelsWithValues...),
+		EnqueueTxs: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "txpool",
+			Name:      "enqueued_transactions",
+			Help:      "Enqueued transactions in the pool",
+		}, labels).With(labelsWithValues...),
 	}
 }
 
@@ -35,5 +48,6 @@ func GetPrometheusMetrics(namespace string, labelsWithValues ...string) *Metrics
 func NilMetrics() *Metrics {
 	return &Metrics{
 		PendingTxs: discard.NewGauge(),
+		EnqueueTxs: discard.NewGauge(),
 	}
 }

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -703,6 +703,7 @@ func (p *TxPool) pruneStaleAccounts() {
 	p.gauge.decrease(slotsRequired(pruned...))
 
 	p.logger.Debug("pruned stale enqueued txs", "num", pruned)
+	p.eventManager.signalEvent(proto.EventType_PRUNED_ENQUEUED, toHash(pruned...)...)
 }
 
 // addGossipTx handles receiving transactions

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -167,6 +167,7 @@ type TxPool struct {
 	// maximum account demotion count. when reach, drop all transactions of this account
 	maxAccountDemotions uint64
 
+	// ticker for pruning account outdated transactions
 	pruneAccountTicker *time.Ticker
 }
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -250,6 +250,10 @@ func (p *TxPool) Start() {
 
 // Close shuts down the pool's main loop.
 func (p *TxPool) Close() {
+	if p.pruneAccountTicker != nil {
+		p.pruneAccountTicker.Stop()
+	}
+
 	p.eventManager.Close()
 	p.shutdownCh <- struct{}{}
 }

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -696,6 +696,9 @@ func (p *TxPool) handlePromoteRequest(req promoteRequest) {
 
 	// update metrics
 	p.metrics.PendingTxs.Add(float64(len(promoted)))
+	// do not forget to delete from enqueued guage
+	p.metrics.EnqueueTxs.Add(-1 * float64(len(promoted)))
+
 	p.eventManager.signalEvent(proto.EventType_PROMOTED, toHash(promoted...)...)
 }
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -670,6 +670,8 @@ func (p *TxPool) handleEnqueueRequest(req enqueueRequest) {
 
 	p.gauge.increase(slotsRequired(tx))
 
+	// update metrics
+	p.metrics.PendingTxs.Add(1)
 	p.eventManager.signalEvent(proto.EventType_ENQUEUED, tx.Hash)
 
 	if tx.Nonce > account.getNonce() {

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -696,7 +696,7 @@ func (p *TxPool) handlePromoteRequest(req promoteRequest) {
 
 	// update metrics
 	p.metrics.PendingTxs.Add(float64(len(promoted)))
-	// do not forget to delete from enqueued guage
+	// do not forget to delete from enqueued gauge
 	p.metrics.EnqueueTxs.Add(-1 * float64(len(promoted)))
 
 	p.eventManager.signalEvent(proto.EventType_PROMOTED, toHash(promoted...)...)

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -704,6 +704,10 @@ func (p *TxPool) handlePromoteRequest(req promoteRequest) {
 func (p *TxPool) pruneStaleAccounts() {
 	pruned := p.accounts.pruneStaleEnqueuedTxs(p.promoteOutdateDuration)
 
+	if len(pruned) == 0 {
+		return
+	}
+
 	p.index.remove(pruned...)
 	p.gauge.decrease(slotsRequired(pruned...))
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -671,7 +671,7 @@ func (p *TxPool) handleEnqueueRequest(req enqueueRequest) {
 	p.gauge.increase(slotsRequired(tx))
 
 	// update metrics
-	p.metrics.PendingTxs.Add(1)
+	p.metrics.EnqueueTxs.Add(1)
 	p.eventManager.signalEvent(proto.EventType_ENQUEUED, tx.Hash)
 
 	if tx.Nonce > account.getNonce() {

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -90,10 +90,12 @@ func newTestPoolWithSlots(maxSlots uint64, mockStore ...store) (*TxPool, error) 
 		nil,
 		nilMetrics,
 		&Config{
-			PriceLimit:          defaultPriceLimit,
-			MaxSlots:            maxSlots,
-			Sealing:             false,
-			MaxAccountDemotions: defaultMaxAccountDemotions,
+			PriceLimit:            defaultPriceLimit,
+			MaxSlots:              maxSlots,
+			Sealing:               false,
+			MaxAccountDemotions:   defaultMaxAccountDemotions,
+			PruneTickSeconds:      defaultPruneTickSeconds,
+			PromoteOutdateSeconds: defaultPromoteOutdateSeconds,
 		},
 	)
 }
@@ -1158,7 +1160,7 @@ func TestEnqueuedPruning(t *testing.T) {
 	}{
 		{
 			"prune stale tx",
-			time.Now().Add(-1 * maxAccountInactivity),
+			time.Now().Add(-time.Second * defaultPromoteOutdateSeconds),
 			0,
 			0,
 		},


### PR DESCRIPTION
# Description

This PR fixes the `txpool` not handle any transaction when full of future transactions.

The attacker would yields large nonce transactions, send them to nodes, and finally make the whole network jammed. Most importantly, it won't cost any gas, since those transactions can't be executed.

We bring the pruning policy from `Ethereum`, which is simple and elegant enough for the use case.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

* Build local binary.
* Run a dev node.
  * Set the pruning duration reasonable for debugging.
  * `./dogechain server --data-dir ./test-chain-1 --jsonrpc :15002 --dev --promote-outdate-seconds 30 --prune-tick-seconds 10 --prometheus :9999`
* Run a txpool event subscriber.
  * `./main txpool subscribe --added --enqueued --pruned-enqueued --pruned-promoted --dropped --demoted`
* Watch txpool metrics in web explorer.
* Use `MetaMask` to send some future transactions and some promotable transactions.

#### Expect results

* Several `PRUNED_ENQUEUED` events after 30 seconds or so.
* The `dogechain_txpool_enqueued_transactions` and `dogechain_txpool_pending_transactions` gauge should be right on every moment.

#### Examples

metrics

```
# HELP dogechain_txpool_enqueued_transactions Enqueued transactions in the pool
# TYPE dogechain_txpool_enqueued_transactions gauge
dogechain_txpool_enqueued_transactions{chain_id="dogechain-DarianShawn"} 0
# HELP dogechain_txpool_pending_transactions Pending transactions in the pool
# TYPE dogechain_txpool_pending_transactions gauge
dogechain_txpool_pending_transactions{chain_id="dogechain-DarianShawn"} 0
```

events

```
[TXPOOL EVENT]
TYPE = ADDED
HASH = 0xd247e04de81b66d6424af6b5702348ae2471cfc7b74e19ab2396a7985c32a95b

[TXPOOL EVENT]
TYPE = ENQUEUED
HASH = 0xd247e04de81b66d6424af6b5702348ae2471cfc7b74e19ab2396a7985c32a95b

[TXPOOL EVENT]
TYPE = PRUNED_ENQUEUED
HASH = 0xd247e04de81b66d6424af6b5702348ae2471cfc7b74e19ab2396a7985c32a95b
```