### PR TITLE
Feature/unlock proposed block after bulk sync

### DIFF
--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -275,7 +275,7 @@ func TestTransition_AcceptState_Validator_LockWrong(t *testing.T) {
 		sequence: 1,
 		state:    RoundChangeState,
 		locked:   true,
-		err:      errIncorrectBlockLocked,
+		err:      errIncorrectBlockHeight,
 	})
 }
 


### PR DESCRIPTION
# Description

This PR fixes the issue that a validator will not unlock the proposed block if it's left at past height for some reason.

And this PR adds safe check to the correctness of proposing block height because validator can propose block with wrong height by setting wrong view in `pre-prepare` message.

The PR is merging from Polygon Edge [PR 581](https://github.com/0xPolygon/polygon-edge/pull/581)

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
