### PR TITLE
Fix delete workflow action not working

### DIFF
--- a/.github/workflows/delete-workflow.yml
+++ b/.github/workflows/delete-workflow.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete workflow runs
-        uses: Mattraks/delete-workflow-runs@v2.0.3
+        uses: c-hive/gha-remove-artifacts@v1
         with:
-          token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          retain_days: 45
-          keep_minimum_runs: 30
+          age: "45 days" # '<number> <unit>', e.g. 5 days, 2 years, 90 seconds, parsed by Moment.js
+          # Optional inputs
+          skip-tags: true
+          skip-recent: 30


### PR DESCRIPTION
# Description

This PR uses another workflow to cron trigger deleting outdated actions, and it skips tag actions, which is more reasonable for long term tracing.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually