### PR TITLE
[ibft] Fix block pack few due to large gas limit transaction

### DIFF
--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -126,6 +126,7 @@ func (d *Dev) writeTransactions(gasLimit uint64, transition transitionInterface)
 		if err := transition.Write(tx); err != nil {
 			d.logger.Debug("write transaction failed", "hash", tx.Hash, "from", tx.From, "nonce", tx.Nonce, "err", err)
 
+			//nolint:errorlint
 			if appErr, ok := err.(*state.GasLimitReachedTransitionApplicationError); ok && appErr.IsRecoverable {
 				// Ignore those out-of-gas transaction whose gas limit too large
 			} else if appErr, ok := err.(*state.AllGasUsedError); ok && appErr.IsRecoverable {

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -110,7 +110,7 @@ func (d *Dev) writeTransactions(gasLimit uint64, transition transitionInterface)
 	d.txpool.Prepare()
 
 	for {
-		tx := d.txpool.Peek()
+		tx := d.txpool.Pop()
 		if tx == nil {
 			break
 		}
@@ -134,7 +134,7 @@ func (d *Dev) writeTransactions(gasLimit uint64, transition transitionInterface)
 		}
 
 		// no errors, pop the tx from the pool
-		d.txpool.Pop(tx)
+		d.txpool.Remove(tx)
 
 		successful = append(successful, tx)
 	}

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -112,6 +112,8 @@ func (d *Dev) writeTransactions(gasLimit uint64, transition transitionInterface)
 	for {
 		tx := d.txpool.Pop()
 		if tx == nil {
+			d.logger.Debug("no more transactions")
+
 			break
 		}
 
@@ -122,9 +124,14 @@ func (d *Dev) writeTransactions(gasLimit uint64, transition transitionInterface)
 		}
 
 		if err := transition.Write(tx); err != nil {
-			if _, ok := err.(*state.GasLimitReachedTransitionApplicationError); ok { //nolint:errorlint
+			d.logger.Debug("write transaction failed", "hash", tx.Hash, "from", tx.From, "nonce", tx.Nonce, "err", err)
+
+			if appErr, ok := err.(*state.GasLimitReachedTransitionApplicationError); ok && appErr.IsRecoverable {
+				// Ignore those out-of-gas transaction whose gas limit too large
+			} else if appErr, ok := err.(*state.AllGasUsedError); ok && appErr.IsRecoverable {
+				// no more transaction could be packed.
 				break
-			} else if appErr, ok := err.(*state.TransitionApplicationError); ok && appErr.IsRecoverable { //nolint:errorlint
+			} else if appErr, ok := err.(*state.TransitionApplicationError); ok && appErr.IsRecoverable {
 				d.txpool.Demote(tx)
 			} else {
 				d.txpool.Drop(tx)

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -695,7 +695,7 @@ func (i *Ibft) writeTransactions(gasLimit uint64, transition transitionInterface
 		}
 
 		if err := transition.Write(tx); err != nil {
-			i.logger.Debug("write transaction", "hash", tx.Hash, "from", tx.From, "nonce", tx.Nonce, "err", err)
+			i.logger.Debug("write transaction failed", "hash", tx.Hash, "from", tx.From, "nonce", tx.Nonce, "err", err)
 
 			if appErr, ok := err.(*state.GasLimitReachedTransitionApplicationError); ok && appErr.IsRecoverable {
 				// Ignore those out-of-gas transaction whose gas limit too large

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -45,8 +45,8 @@ type blockchainInterface interface {
 type txPoolInterface interface {
 	Prepare()
 	Length() uint64
-	Peek() *types.Transaction
-	Pop(tx *types.Transaction)
+	Pop() *types.Transaction
+	Remove(tx *types.Transaction)
 	Drop(tx *types.Transaction)
 	Demote(tx *types.Transaction)
 	ResetWithHeaders(headers ...*types.Header)
@@ -670,7 +670,7 @@ func (i *Ibft) writeTransactions(gasLimit uint64, transition transitionInterface
 	i.txpool.Prepare()
 
 	for {
-		tx := i.txpool.Peek()
+		tx := i.txpool.Pop()
 		if tx == nil {
 			i.logger.Debug("no more transactions")
 
@@ -712,8 +712,8 @@ func (i *Ibft) writeTransactions(gasLimit uint64, transition transitionInterface
 			continue
 		}
 
-		// no errors, pop the tx from the pool
-		i.txpool.Pop(tx)
+		// no errors, remove the tx from the pool
+		i.txpool.Remove(tx)
 
 		successTxCount++
 

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -697,6 +697,7 @@ func (i *Ibft) writeTransactions(gasLimit uint64, transition transitionInterface
 		if err := transition.Write(tx); err != nil {
 			i.logger.Debug("write transaction failed", "hash", tx.Hash, "from", tx.From, "nonce", tx.Nonce, "err", err)
 
+			//nolint:errorlint
 			if appErr, ok := err.(*state.GasLimitReachedTransitionApplicationError); ok && appErr.IsRecoverable {
 				// Ignore those out-of-gas transaction whose gas limit too large
 			} else if appErr, ok := err.(*state.AllGasUsedError); ok && appErr.IsRecoverable {

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -697,8 +697,8 @@ func (i *Ibft) writeTransactions(gasLimit uint64, transition transitionInterface
 		if err := transition.Write(tx); err != nil {
 			i.logger.Debug("apply write block", "hash", tx.Hash, "from", tx.From, "err", err)
 
-			if _, ok := err.(*state.GasLimitReachedTransitionApplicationError); ok { // nolint:errorlint
-				break
+			if _, ok := err.(*state.GasLimitReachedTransitionApplicationError); ok { //nolint:errorlint
+				// Ignore those out-of-gas transaction whose gas limit too large
 			} else if appErr, ok := err.(*state.TransitionApplicationError); ok && appErr.IsRecoverable { //nolint:errorlint
 				i.txpool.Demote(tx)
 			} else {

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -672,6 +672,8 @@ func (i *Ibft) writeTransactions(gasLimit uint64, transition transitionInterface
 	for {
 		tx := i.txpool.Peek()
 		if tx == nil {
+			i.logger.Debug("no more transactions")
+
 			break
 		}
 
@@ -693,7 +695,9 @@ func (i *Ibft) writeTransactions(gasLimit uint64, transition transitionInterface
 		}
 
 		if err := transition.Write(tx); err != nil {
-			if _, ok := err.(*state.GasLimitReachedTransitionApplicationError); ok { //nolint:errorlint
+			i.logger.Debug("apply write block", "hash", tx.Hash, "from", tx.From, "err", err)
+
+			if _, ok := err.(*state.GasLimitReachedTransitionApplicationError); ok { // nolint:errorlint
 				break
 			} else if appErr, ok := err.(*state.TransitionApplicationError); ok && appErr.IsRecoverable { //nolint:errorlint
 				i.txpool.Demote(tx)

--- a/e2e/txpool_test.go
+++ b/e2e/txpool_test.go
@@ -715,6 +715,7 @@ func TestTxPool_GreedyPackingStrategy(t *testing.T) {
 
 	// query all transactions
 	txs := make([]*web3.Transaction, 0, len(testCase.hashes))
+
 	for _, hash := range testCase.hashes {
 		tx, err := client.Eth().GetTransactionByHash(hash)
 		if ret := assert.NoError(t, err); !ret {
@@ -743,6 +744,7 @@ func TestTxPool_GreedyPackingStrategy(t *testing.T) {
 			if i == len(testCase.sameBlockTxIndexes)-1 {
 				continue
 			}
+
 			assert.NotEqual(t, txs[index].BlockNumber, txs[testCase.sameBlockTxIndexes[i+1][0]].BlockNumber)
 		}
 	}

--- a/e2e/txpool_test.go
+++ b/e2e/txpool_test.go
@@ -559,6 +559,195 @@ func TestTxPool_RecoverableError(t *testing.T) {
 	assert.Equal(t, secondTx.BlockNumber, receipt.BlockNumber)
 }
 
+func TestTxPool_GreedyPackingStrategy(t *testing.T) {
+	// Test scenario :
+	//
+	// 0. Set the block gas limit (marked as 'Limit') to (21000 + 1000) * 3, which could only save three
+	// normal transactions. And set a long block dev interval for promising block building.
+	//
+	// 1. Create two accounts for sending multiple transactions with different gas limit.
+	//
+	// 2. Broadcast the transactions once and for all.
+	//
+	// 3. The block should include as much transactions as possible, which would skip some large gas limit
+	// transactions and try to include another account's transactions.
+	//
+	var (
+		sender1Key, sender1Address = tests.GenerateKeyAndAddr(t)
+		sender2Key, sender2Address = tests.GenerateKeyAndAddr(t)
+		_, receiverAddress         = tests.GenerateKeyAndAddr(t)
+		basicGas                   = uint64(22000)
+		gasLimit                   = uint64(22000 * 3)
+		lowGasPrice                = big.NewInt(framework.DefaultGasPrice)
+		midGasPrice                = big.NewInt(framework.DefaultGasLimit * 1.2)
+		highGasPrice               = big.NewInt(framework.DefaultGasLimit * 1.5)
+		v                          = big.NewInt(27)
+	)
+
+	testCase := struct {
+		transactions       []*types.Transaction
+		sameBlockTxIndexes [][]int
+		hashes             []web3.Hash
+	}{
+		transactions: []*types.Transaction{
+			{ // 0. first block X
+				Nonce:    0,
+				GasPrice: highGasPrice,
+				Gas:      gasLimit - 1,
+				To:       &receiverAddress,
+				Value:    oneEth,
+				V:        v,
+				From:     sender1Address,
+			},
+			{ // 1. exceeds limit, go to second block
+				Nonce:    0,
+				GasPrice: midGasPrice,
+				Gas:      gasLimit - 1,
+				To:       &receiverAddress,
+				Value:    oneEth,
+				V:        v,
+				From:     sender2Address,
+			},
+			{ // 2. first block, greedy include
+				Nonce:    1,
+				GasPrice: highGasPrice,
+				Gas:      basicGas * 2,
+				To:       &receiverAddress,
+				Value:    oneEth,
+				V:        v,
+				From:     sender1Address,
+			},
+			{ // 3. second block, greedy include
+				Nonce:    1,
+				GasPrice: midGasPrice,
+				Gas:      basicGas * 2,
+				To:       &receiverAddress,
+				Value:    oneEth,
+				V:        v,
+				From:     sender2Address,
+			},
+			{ // 4. exceeds gas limit, should be third | forth block
+				Nonce:    2,
+				GasPrice: lowGasPrice,
+				Gas:      gasLimit - 1,
+				To:       &receiverAddress,
+				Value:    oneEth,
+				V:        v,
+				From:     sender1Address,
+			},
+			{ // 5. exceeds gas limit, should be third | forth block
+				Nonce:    2,
+				GasPrice: lowGasPrice,
+				Gas:      gasLimit - 1,
+				To:       &receiverAddress,
+				Value:    oneEth,
+				V:        v,
+				From:     sender2Address,
+			},
+		},
+		sameBlockTxIndexes: [][]int{
+			{0, 2},
+			{1, 3},
+			{4},
+			{5},
+		},
+		hashes: make([]web3.Hash, 6),
+	}
+
+	// server
+	server := framework.NewTestServers(t, 1, func(config *framework.TestServerConfig) {
+		config.SetConsensus(framework.ConsensusDev)
+		config.SetSeal(true)
+		config.SetBlockLimit(gasLimit)
+		config.SetDevInterval(2)
+		config.Premine(sender1Address, framework.EthToWei(100))
+		config.Premine(sender2Address, framework.EthToWei(100))
+	})[0]
+	// client
+	client := server.JSONRPC()
+	operator := server.TxnPoolOperator()
+
+	for i, tx := range testCase.transactions {
+		var (
+			signedTx *types.Transaction
+			err      error
+		)
+		// sign different tx
+		if tx.From == sender1Address {
+			signedTx, err = signer.SignTx(tx, sender1Key)
+		} else {
+			signedTx, err = signer.SignTx(tx, sender2Key)
+		}
+		// should not be any error
+		assert.NoError(t, err)
+
+		response, err := operator.AddTxn(context.Background(), &txpoolOp.AddTxnReq{
+			Raw: &any.Any{
+				Value: signedTx.MarshalRLP(),
+			},
+			From: types.ZeroAddress.String(),
+		})
+		if ret := assert.NoError(t, err, "Unable to send transaction, %v", err); !ret {
+			t.FailNow()
+		}
+
+		txHash := web3.Hash(types.StringToHash(response.TxHash))
+		// save for later querying
+		testCase.hashes[i] = txHash
+	}
+
+	// 6 blocks at most
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+
+	// wait for the last tx to be included in a block
+	receipt, err := tests.WaitForReceipt(ctx, client.Eth(), testCase.hashes[len(testCase.hashes)-1])
+	if ret := assert.NoError(t, err); !ret {
+		t.FailNow()
+	}
+	// the receipt should not be nil
+	assert.NotNil(t, receipt)
+
+	// assert balance moved
+	balance, err := client.Eth().GetBalance(web3.Address(receiverAddress), web3.Latest)
+	assert.NoError(t, err, "failed to retrieve receiver account balance")
+	assert.Equal(t, framework.EthToWei(int64(len(testCase.transactions))).String(), balance.String())
+
+	// query all transactions
+	txs := make([]*web3.Transaction, 0, len(testCase.hashes))
+	for _, hash := range testCase.hashes {
+		tx, err := client.Eth().GetTransactionByHash(hash)
+		if ret := assert.NoError(t, err); !ret {
+			t.FailNow()
+		}
+
+		if ret := assert.NotNil(t, tx); !ret {
+			t.FailNow()
+		}
+
+		txs = append(txs, tx)
+	}
+
+	// assert block including tx match
+	for i, indexes := range testCase.sameBlockTxIndexes {
+		blockNum := txs[indexes[0]].BlockNumber
+
+		for j, index := range indexes {
+			assert.Equal(t, blockNum, txs[index].BlockNumber)
+			// compare different slice should not included in the same block
+			// skip those not the last element of inner slice
+			if j < len(indexes)-1 {
+				continue
+			}
+			// skip the last element of outter slice
+			if i == len(testCase.sameBlockTxIndexes)-1 {
+				continue
+			}
+			assert.NotEqual(t, txs[index].BlockNumber, txs[testCase.sameBlockTxIndexes[i+1][0]].BlockNumber)
+		}
+	}
+}
+
 func TestTxPool_ZeroPriceDev(t *testing.T) {
 	senderKey, senderAddress := tests.GenerateKeyAndAddr(t)
 	_, receiverAddress := tests.GenerateKeyAndAddr(t)

--- a/state/executor.go
+++ b/state/executor.go
@@ -476,6 +476,10 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 	// 6. caller has enough balance to cover asset transfer for **topmost** call
 	txn := t.state
 
+	t.logger.Debug("try to apply transaction",
+		"hash", msg.Hash, "from", msg.From, "nonce", msg.Nonce, "price", msg.GasPrice.String(),
+		"remainingGas", t.gasPool, "wantGas", msg.Gas)
+
 	// 1. the nonce of the message caller is correct
 	if err := t.nonceCheck(msg); err != nil {
 		return nil, NewTransitionApplicationError(err, true)
@@ -496,6 +500,8 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 	if err != nil {
 		return nil, NewTransitionApplicationError(err, false)
 	}
+
+	t.logger.Debug("apply transaction would uses gas", "hash", msg.Hash, "gas", intrinsicGasCost)
 
 	// 5. the purchased gas is enough to cover intrinsic usage
 	gasLeft := msg.Gas - intrinsicGasCost

--- a/state/executor.go
+++ b/state/executor.go
@@ -430,12 +430,12 @@ func (t *Transition) nonceCheck(msg *types.Transaction) error {
 // surfacing of these errors reject the transaction thus not including it in the block
 
 var (
-	ErrNonceIncorrect        = fmt.Errorf("incorrect nonce")
-	ErrNotEnoughFundsForGas  = fmt.Errorf("not enough funds to cover gas costs")
-	ErrBlockLimitReached     = fmt.Errorf("gas limit reached in the pool")
-	ErrIntrinsicGasOverflow  = fmt.Errorf("overflow in intrinsic gas calculation")
-	ErrNotEnoughIntrinsicGas = fmt.Errorf("not enough gas supplied for intrinsic gas costs")
-	ErrNotEnoughFunds        = fmt.Errorf("not enough funds for transfer with given value")
+	ErrNonceIncorrect        = errors.New("incorrect nonce")
+	ErrNotEnoughFundsForGas  = errors.New("not enough funds to cover gas costs")
+	ErrBlockLimitReached     = errors.New("gas limit reached in the pool")
+	ErrIntrinsicGasOverflow  = errors.New("overflow in intrinsic gas calculation")
+	ErrNotEnoughIntrinsicGas = errors.New("not enough gas supplied for intrinsic gas costs")
+	ErrNotEnoughFunds        = errors.New("not enough funds for transfer with given value")
 )
 
 type TransitionApplicationError struct {

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -358,6 +358,8 @@ func (p *TxPool) Pop(tx *types.Transaction) {
 	// pop the top most promoted tx
 	account.promoted.pop()
 
+	p.logger.Debug("excutables pop out the max price transaction", "hash", tx.Hash, "from", tx.From)
+
 	//	successfully popping an account resets its demotions count to 0
 	account.demotions = 0
 
@@ -369,6 +371,7 @@ func (p *TxPool) Pop(tx *types.Transaction) {
 
 	// update executables
 	if tx := account.promoted.peek(); tx != nil {
+		p.logger.Debug("excutables push in another transaction", "hash", tx.Hash, "from", tx.From)
 		p.executables.push(tx)
 	}
 }

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -332,9 +332,9 @@ func (p *TxPool) Prepare() {
 	}
 }
 
-// Peek returns the best-price selected
+// Pop returns the best-price selected
 // transaction ready for execution.
-func (p *TxPool) Peek() *types.Transaction {
+func (p *TxPool) Pop() *types.Transaction {
 	// Popping the executables queue
 	// does not remove the actual tx
 	// from the pool.
@@ -344,11 +344,11 @@ func (p *TxPool) Peek() *types.Transaction {
 	return p.executables.pop()
 }
 
-// Pop removes the given transaction from the
+// Remove removes the given transaction from the
 // associated promoted queue (account).
 // Will update executables with the next primary
 // from that account (if any).
-func (p *TxPool) Pop(tx *types.Transaction) {
+func (p *TxPool) Remove(tx *types.Transaction) {
 	// fetch the associated account
 	account := p.accounts.get(tx.From)
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1042,8 +1042,8 @@ func TestPop(t *testing.T) {
 
 	// pop the tx
 	pool.Prepare()
-	tx := pool.Peek()
-	pool.Pop(tx)
+	tx := pool.Pop()
+	pool.Remove(tx)
 
 	assert.Equal(t, uint64(0), pool.gauge.read())
 	assert.Equal(t, uint64(0), pool.accounts.get(addr1).promoted.length())
@@ -1068,7 +1068,7 @@ func TestDrop(t *testing.T) {
 
 	// pop the tx
 	pool.Prepare()
-	tx := pool.Peek()
+	tx := pool.Pop()
 	pool.Drop(tx)
 
 	assert.Equal(t, uint64(0), pool.gauge.read())
@@ -1129,7 +1129,7 @@ func TestDrop_RecoverRightNonce(t *testing.T) {
 
 	// pop the tx
 	pool.Prepare()
-	tx := pool.Peek()
+	tx := pool.Pop()
 	pool.Drop(tx)
 
 	assert.Equal(t, uint64(0), pool.gauge.read())
@@ -1162,7 +1162,7 @@ func TestDemote(t *testing.T) {
 
 		//	call demote
 		pool.Prepare()
-		tx := pool.Peek()
+		tx := pool.Pop()
 		pool.Demote(tx)
 
 		assert.Equal(t, uint64(1), pool.gauge.read())
@@ -1198,7 +1198,7 @@ func TestDemote(t *testing.T) {
 
 		//	call demote
 		pool.Prepare()
-		tx := pool.Peek()
+		tx := pool.Pop()
 		pool.Demote(tx)
 
 		//	account was dropped
@@ -1834,12 +1834,12 @@ func TestExecutablesOrder(t *testing.T) {
 
 			var successful []*types.Transaction
 			for {
-				tx := pool.Peek()
+				tx := pool.Pop()
 				if tx == nil {
 					break
 				}
 
-				pool.Pop(tx)
+				pool.Remove(tx)
 				successful = append(successful, tx)
 			}
 
@@ -2027,7 +2027,7 @@ func TestRecovery(t *testing.T) {
 			func() {
 				pool.Prepare()
 				for {
-					tx := pool.Peek()
+					tx := pool.Pop()
 					if tx == nil {
 						break
 					}
@@ -2038,7 +2038,7 @@ func TestRecovery(t *testing.T) {
 					case unrecoverable:
 						pool.Drop(tx)
 					case ok:
-						pool.Pop(tx)
+						pool.Remove(tx)
 					}
 				}
 			}()


### PR DESCRIPTION
# Description

The block would not pack more transactions, when there is a large gas limit transaction who consumes all the remaining gas in the block, Then the whole network `TPS` went down to unbearable level.

This PR simply skips the transaction and go on using the greedy strategy. That makes sense. We should not punish others due to one player make fault.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
