### PR TITLE
Set gas price to 50GWei for the mainnet never goes back to normal

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -433,18 +433,20 @@ func (e *Eth) GetStorageAt(
 
 // GasPrice returns the average gas price based on the last x blocks
 func (e *Eth) GasPrice() (interface{}, error) {
-	var avgGasPrice string
+	// var avgGasPrice string
 
 	// Grab the average gas price and convert it to a hex value
 	minGasPrice, _ := new(big.Int).SetString(defaultMinGasPrice, 0)
 
-	if e.store.GetAvgGasPrice().Cmp(minGasPrice) == -1 {
-		avgGasPrice = hex.EncodeBig(minGasPrice)
-	} else {
-		avgGasPrice = hex.EncodeBig(e.store.GetAvgGasPrice())
-	}
+	// if e.store.GetAvgGasPrice().Cmp(minGasPrice) == -1 {
+	// 	avgGasPrice = hex.EncodeBig(minGasPrice)
+	// } else {
+	// 	avgGasPrice = hex.EncodeBig(e.store.GetAvgGasPrice())
+	// }
 
-	return avgGasPrice, nil
+	// return avgGasPrice, nil
+
+	return hex.EncodeBig(minGasPrice), nil
 }
 
 // Call executes a smart contract call using the transaction object data


### PR DESCRIPTION
# Description

This PR uses the constant gas price to pull down mainnet gas price right now.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

Please post additional comments in this section if you have them, otherwise delete it
