### PR TITLE
[ibft] Stop reset current nonce when executable transaction nonce not right

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -434,7 +434,6 @@ func (e *Eth) GetStorageAt(
 // GasPrice returns the average gas price based on the last x blocks
 func (e *Eth) GasPrice() (interface{}, error) {
 	// var avgGasPrice string
-
 	// Grab the average gas price and convert it to a hex value
 	minGasPrice, _ := new(big.Int).SetString(defaultMinGasPrice, 0)
 


### PR DESCRIPTION
# Description

The ibft validator would reset the nonce to some invalid transaction, which is awful when the nonce not right.

This PR fixes the bug.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually