### PR TITLE
[txpool] Fix lower nonce transactions not dropped when promoting

### DIFF
--- a/txpool/account.go
+++ b/txpool/account.go
@@ -302,7 +302,8 @@ func (a *account) promote() (promoted []*types.Transaction, dropped []*types.Tra
 		return
 	}
 
-	nextNonce := a.enqueued.peek().Nonce
+	// the first promotable nonce
+	nextNonce := currentNonce
 
 	//	move all promotable txs (enqueued txs that are sequential in nonce)
 	//	to the account's promoted queue
@@ -312,13 +313,13 @@ func (a *account) promote() (promoted []*types.Transaction, dropped []*types.Tra
 			break
 		}
 
-		if tx.Nonce < currentNonce {
+		if tx.Nonce < nextNonce {
 			// pop out too low nonce tx, which should be drop
 			tx = a.enqueued.pop()
 			dropped = append(dropped, tx)
 
 			continue
-		} else if tx.Nonce > currentNonce {
+		} else if tx.Nonce > nextNonce {
 			// nothing to prmote
 			break
 		}

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -312,13 +312,13 @@ func (a *account) promote() (promoted []*types.Transaction, dropped []*types.Tra
 			break
 		}
 
-		if tx.Nonce < nextNonce {
+		if tx.Nonce < currentNonce {
 			// pop out too low nonce tx, which should be drop
 			tx = a.enqueued.pop()
 			dropped = append(dropped, tx)
 
 			continue
-		} else if tx.Nonce > nextNonce {
+		} else if tx.Nonce > currentNonce {
 			// nothing to prmote
 			break
 		}

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -284,8 +284,8 @@ func (a *account) enqueue(tx *types.Transaction) error {
 //
 // Eligible transactions are all sequential in order of nonce
 // and the first one has to have nonce less (or equal) to the account's
-// nextNonce.
-func (a *account) promote() []*types.Transaction {
+// nextNonce. Lower nonce transaction would be dropped when promoting.
+func (a *account) promote() (promoted []*types.Transaction, dropped []*types.Transaction) {
 	a.promoted.lock(true)
 	a.enqueued.lock(true)
 
@@ -299,18 +299,27 @@ func (a *account) promote() []*types.Transaction {
 	if a.enqueued.length() == 0 ||
 		a.enqueued.peek().Nonce > currentNonce {
 		// nothing to promote
-		return nil
+		return
 	}
 
-	promoted := make([]*types.Transaction, 0)
 	nextNonce := a.enqueued.peek().Nonce
 
 	//	move all promotable txs (enqueued txs that are sequential in nonce)
 	//	to the account's promoted queue
 	for {
 		tx := a.enqueued.peek()
-		if tx == nil ||
-			tx.Nonce != nextNonce {
+		if tx == nil {
+			break
+		}
+
+		if tx.Nonce < nextNonce {
+			// pop out too low nonce tx, which should be drop
+			tx = a.enqueued.pop()
+			dropped = append(dropped, tx)
+
+			continue
+		} else if tx.Nonce > nextNonce {
+			// nothing to prmote
 			break
 		}
 
@@ -336,5 +345,5 @@ func (a *account) promote() []*types.Transaction {
 	// update timestamp for pruning
 	a.lastPromoted = time.Now()
 
-	return promoted
+	return
 }

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -651,7 +651,7 @@ func TestPromoteHandler(t *testing.T) {
 		go pool.handlePromoteRequest(<-pool.promoteReqCh)
 
 		// waiting for the promoted event
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 		defer cancel()
 
 		// 1 dropped, 1 promoted.
@@ -673,7 +673,7 @@ func TestPromoteHandler(t *testing.T) {
 		assert.Equal(t, 1, promotedCount)
 
 		assert.Equal(t, uint64(1), pool.gauge.read())
-		assert.Equal(t, promotableNonce, pool.accounts.get(addr1).getNonce())
+		assert.Equal(t, promotableNonce+1, pool.accounts.get(addr1).getNonce())
 
 		assert.Equal(t, uint64(0), pool.accounts.get(addr1).enqueued.length())
 		assert.Equal(t, uint64(1), pool.accounts.get(addr1).promoted.length())

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -613,6 +613,71 @@ func TestPromoteHandler(t *testing.T) {
 		assert.Equal(t, uint64(0), pool.accounts.get(addr1).enqueued.length())
 		assert.Equal(t, uint64(20), pool.accounts.get(addr1).promoted.length())
 	})
+
+	t.Run("Two txs -> one promoted, the lower nonce dropped", func(t *testing.T) {
+		/* This example illustrates the fault tolerance of the promoting handler:
+		The lower nonce transaction should be dropped when it is accidently inserted
+		into the enqueued queue. It should not block any promotable transactions. */
+		pool, err := newTestPool()
+		assert.NoError(t, err)
+		pool.SetSigner(&mockSigner{})
+		const promotableNonce = uint64(5)
+
+		// event sub
+		subscription := pool.eventManager.subscribe([]proto.EventType{
+			proto.EventType_PROMOTED,
+			proto.EventType_PRUNED_ENQUEUED,
+		})
+
+		// Prepare the bug test case. It is a bug, but sometimes it happeds.
+		// set account nonce large to make the first tx lower nonce
+		acc := pool.createAccountOnce(addr1)
+		acc.setNonce(promotableNonce)
+		// lower nonce tx
+		lowerNonceTx := newTx(addr1, 0, 1)
+		// enqueue it by hand
+		acc.enqueued.push(lowerNonceTx)
+		pool.gauge.increase(1)
+		assert.Equal(t, uint64(1), pool.accounts.get(addr1).enqueued.length())
+
+		go func() {
+			// promotable
+			err = pool.addTx(local, newTx(addr1, promotableNonce, 1))
+			assert.NoError(t, err)
+		}()
+		// enqueue
+		go pool.handleEnqueueRequest(<-pool.enqueueReqCh)
+		// promote
+		go pool.handlePromoteRequest(<-pool.promoteReqCh)
+
+		// waiting for the promoted event
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+		defer cancel()
+
+		// 1 dropped, 1 promoted.
+		events := waitForEvents(ctx, subscription, 2)
+
+		var prunedCount, promotedCount int
+		// count events
+		for _, ev := range events {
+			switch ev.Type {
+			case proto.EventType_PROMOTED:
+				promotedCount++
+			case proto.EventType_PRUNED_ENQUEUED:
+				prunedCount++
+			}
+		}
+
+		// assert
+		assert.Equal(t, 1, prunedCount)
+		assert.Equal(t, 1, promotedCount)
+
+		assert.Equal(t, uint64(1), pool.gauge.read())
+		assert.Equal(t, promotableNonce, pool.accounts.get(addr1).getNonce())
+
+		assert.Equal(t, uint64(0), pool.accounts.get(addr1).enqueued.length())
+		assert.Equal(t, uint64(1), pool.accounts.get(addr1).promoted.length())
+	})
 }
 
 func TestResetAccount(t *testing.T) {

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -616,7 +616,7 @@ func TestPromoteHandler(t *testing.T) {
 
 	t.Run("Two txs -> one promoted, the lower nonce dropped", func(t *testing.T) {
 		/* This example illustrates the fault tolerance of the promoting handler:
-		The lower nonce transaction should be dropped when it is accidently inserted
+		The lower nonce transaction should be dropped when it is accidentally inserted
 		into the enqueued queue. It should not block any promotable transactions. */
 		pool, err := newTestPool()
 		assert.NoError(t, err)


### PR DESCRIPTION
# Description

The `txpool` do not drop lower nonce transactions in `enqueued` when promoting, which makes the account could never back to normal again.

This PR fixes the issue.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually