### PR TITLE
fix lint error in simple shuffle test

### DIFF
--- a/txpool/event_subscription_test.go
+++ b/txpool/event_subscription_test.go
@@ -42,6 +42,7 @@ func shuffleTxPoolEvents(
 
 	randomEventType := func(supported bool) proto.EventType {
 		for {
+			//nolint:gosec
 			randNum, _ := rand.Int(rand.Reader, big.NewInt(int64(len(supportedTypes))))
 
 			randType := allEvents[randNum.Int64()]


### PR DESCRIPTION
# Description

The PR fixes the lint error, which is no need to check shuffle random function security in tests.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually