### PR TITLE
Fix/ws timeout filter not removed

### DIFF
--- a/jsonrpc/filter_manager.go
+++ b/jsonrpc/filter_manager.go
@@ -553,12 +553,8 @@ func (f *FilterManager) GetFilterChanges(id string) (string, error) {
 
 // getFilterAndChanges returns the updates of the filter with given ID in string
 func (f *FilterManager) getFilterAndChanges(id string) (filter, string, error) {
-	f.RLock()
-	defer f.RUnlock()
-
-	filter, ok := f.filters[id]
-
-	if !ok {
+	filter := f.getFilterByID(id)
+	if filter == nil {
 		return nil, "", ErrFilterDoesNotExists
 	}
 

--- a/jsonrpc/filter_manager.go
+++ b/jsonrpc/filter_manager.go
@@ -580,6 +580,7 @@ func (f *FilterManager) removeFilterByID(id string) bool {
 	if !ok {
 		// not exits, should not retry
 		f.logger.Debug("filter not in list", "id", id)
+
 		return true
 	}
 

--- a/jsonrpc/filter_manager.go
+++ b/jsonrpc/filter_manager.go
@@ -34,6 +34,8 @@ var defaultTimeout = 1 * time.Minute
 const (
 	// The index in heap which is indicating the element is not in the heap
 	NoIndexInHeap = -1
+	// _checkDuration is for filter timeout check
+	_checkDuration = time.Second
 )
 
 // filter is an interface that BlockFilter and LogFilter implement
@@ -295,47 +297,38 @@ func (f *FilterManager) Run() {
 		}
 	}()
 
-	var timeoutCh <-chan time.Time
+	// Do not use 'for range + create long time after chan' any more,
+	// which would bring out some unpredictable result, especially when
+	// re-assgining the chan, the elder one would not be recycled by
+	// the GC as we expected.
+	// Use 'timer + reset' instead.
+	var checkTimer = time.NewTimer(_checkDuration)
+	defer checkTimer.Stop()
 
-OUT_LOOP:
 	for {
 		// check for the next filter to be removed
 		filterBase := f.nextTimeoutFilter()
+		// remove expired filter first
+		if filterBase != nil && filterBase.expiresAt.Before(time.Now()) {
+			f.logger.Info("filter timeout", "id", filterBase.id, "expiresAt", filterBase.expiresAt)
+			f.Uninstall(filterBase.id)
 
-		// set timer to remove filter
-		if filterBase != nil {
-			// It is awful, which would simple drop the not expired timer to the GC,
-			// which might take several minutes to recycle it.
-			// And even worse, the ws filter don't have an expire timestamp, which
-			// means we might make an imediate fired timer.
-			timeoutCh = time.After(time.Until(filterBase.expiresAt))
+			continue
 		}
 
+		// reset timer for next check
+		checkTimer.Reset(_checkDuration)
+
 		select {
-		case evnt := <-watchCh:
+		case ev := <-watchCh:
 			// new blockchain event
-			if err := f.dispatchEvent(evnt); err != nil {
+			if err := f.dispatchEvent(ev); err != nil {
 				f.logger.Error("failed to dispatch event", "err", err)
 			}
-
-		case <-timeoutCh:
-			// timeout for filter
-			// might be nil
-			if filterBase == nil {
-				f.logger.Warn("timeout filterBase is nil")
-
-				continue OUT_LOOP
-			}
-
-			f.logger.Info("filterBase timeout", "id", filterBase.id, "expiresAt", filterBase.expiresAt)
-
-			if !f.Uninstall(filterBase.id) {
-				f.logger.Error("failed to uninstall filter", "id", filterBase.id)
-			}
-
+		case <-checkTimer.C:
+			// no need to do anything, checkout the timeout filter in the next loop
 		case <-f.updateCh:
 			// filters change, reset the loop to start the timeout timer
-
 		case <-f.closeCh:
 			// stop the filter manager
 			return
@@ -585,13 +578,18 @@ func (f *FilterManager) Uninstall(id string) bool {
 func (f *FilterManager) removeFilterByID(id string) bool {
 	filter, ok := f.filters[id]
 	if !ok {
-		return false
+		// not exits, should not retry
+		f.logger.Debug("filter not in list", "id", id)
+		return true
 	}
 
 	delete(f.filters, id)
 
 	if removed := f.timeouts.removeFilter(filter.getFilterBase()); removed {
+		f.logger.Debug("filter found in timeout heap", "id", id)
 		f.emitSignalToUpdateCh()
+	} else {
+		f.logger.Debug("filter already removed from timeout heap", "id", id)
 	}
 
 	return true
@@ -827,7 +825,7 @@ func (t *timeHeapImpl) Pop() interface{} {
 	n := len(old)
 	item := old[n-1]
 	old[n-1] = nil
-	item.heapIndex = -1
+	item.heapIndex = NoIndexInHeap // pop out and set it to not in heap
 	*t = old[0 : n-1]
 
 	return item

--- a/txpool/event_subscription_test.go
+++ b/txpool/event_subscription_test.go
@@ -42,6 +42,7 @@ func shuffleTxPoolEvents(
 
 	randomEventType := func(supported bool) proto.EventType {
 		for {
+			//nolint:gosec
 			randNum, _ := rand.Int(rand.Reader, big.NewInt(int64(len(supportedTypes))))
 
 			randType := allEvents[randNum.Int64()]


### PR DESCRIPTION
# Description

The `jsonrpc` filter was not removed elegantly when timeout, and might block querying even the whole program in some extreme cases.

When triggered, it kept printing log like that:

```
dogechain.filter: filterBase timeout: id=46eeaded-d726-4202-b4d1-f338ab1427a8 expiresAt="2022-08-25 17:56:25"
dogechain.filter: failed to uninstall filter: id=46eeaded-d726-4202-b4d1-f338ab1427a8
dogechain.filter: filterBase timeout: id=46eeaded-d726-4202-b4d1-f338ab1427a8 expiresAt="2022-08-25 17:56:25"
dogechain.filter: failed to uninstall filter: id=46eeaded-d726-4202-b4d1-f338ab1427a8
// repeated on and on...
```

The PR fixes this issue. Here is the solution.

We use only one timer and reset it for the `timeout` checking, and do nothing when the timer fired. 
The timer puts down the responsibility of handling the business, its only purpose is to make the loop go round. 

That makes sense.
If the node is idle, it should not wait too long for the hurry serving. 
If the node is busy, it should focus on the current job instead of distracted from dealing with clutter.
And finally, It shouldn't bordered by the timeout filters, so we remove all those outdated filters once and for all.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

1. Set up a dev mode node.
2. Send several `eth_newBlockFilter`, `eth_newLogFilter`, `eth_getFilterChanges` requests using `curl` or WebSocket client, in order to trigger with different timeout timestamps.
3. Watch the logs.

We should find only one 'adding', 'deletion' for each filter, and never get any repeated timeout logs no matter how many times we test.