### PR TITLE
Add enable-ws flag in server command

### DIFF
--- a/command/server/config.go
+++ b/command/server/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	GraphQLAddr              string     `json:"graphql_addr"`
 	JSONRPCBatchRequestLimit uint64     `json:"json_rpc_batch_request_limit" yaml:"json_rpc_batch_request_limit"`
 	JSONRPCBlockRangeLimit   uint64     `json:"json_rpc_block_range_limit" yaml:"json_rpc_block_range_limit"`
+	EnableWS                 bool       `json:"enable_ws"`
 }
 
 // Telemetry holds the config details for metric services.
@@ -101,6 +102,7 @@ func DefaultConfig() *Config {
 		EnableGraphQL:            false,
 		JSONRPCBatchRequestLimit: jsonrpc.DefaultJSONRPCBatchRequestLimit,
 		JSONRPCBlockRangeLimit:   jsonrpc.DefaultJSONRPCBlockRangeLimit,
+		EnableWS:                 false,
 	}
 }
 

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -48,6 +48,7 @@ const (
 	enableGraphQLFlag            = "enable-graphql"
 	jsonRPCBatchRequestLimitFlag = "json-rpc-batch-request-limit"
 	jsonRPCBlockRangeLimitFlag   = "json-rpc-block-range-limit"
+	enableWSFlag                 = "enable-ws"
 )
 
 const (
@@ -179,6 +180,7 @@ func (p *serverParams) generateConfig() *server.Config {
 			AccessControlAllowOrigin: p.corsAllowedOrigins,
 			BatchLengthLimit:         p.rawConfig.JSONRPCBatchRequestLimit,
 			BlockRangeLimit:          p.rawConfig.JSONRPCBlockRangeLimit,
+			EnableWS:                 p.rawConfig.EnableWS,
 		},
 		EnableGraphQL: p.rawConfig.EnableGraphQL,
 		GraphQL: &server.GraphQL{

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -293,6 +293,13 @@ func setFlags(cmd *cobra.Command) {
 			"that consider fromBlock/toBlock values (e.g. eth_getLogs)",
 	)
 
+	cmd.Flags().BoolVar(
+		&params.rawConfig.EnableWS,
+		enableWSFlag,
+		false,
+		"the flag indicating that node enable websocket service",
+	)
+
 	setDevFlags(cmd)
 }
 

--- a/e2e/framework/config.go
+++ b/e2e/framework/config.go
@@ -49,6 +49,7 @@ type TestServerConfig struct {
 	Signer         *crypto.EIP155Signer // Signer used for transactions
 	BridgeOwner    types.Address        // bridge contract owner
 	BridgeSigners  []types.Address      // bridge contract signers
+	IsWSEnable     bool                 // enable websocket or not
 }
 
 // DataDir returns path of data directory server uses
@@ -164,4 +165,8 @@ func (t *TestServerConfig) SetBridgeOwner(owner types.Address) {
 
 func (t *TestServerConfig) SetBridgeSigners(signers []types.Address) {
 	t.BridgeSigners = signers
+}
+
+func (t *TestServerConfig) EnableWebSocket() {
+	t.IsWSEnable = true
 }

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -322,6 +322,10 @@ func (t *TestServer) Start(ctx context.Context) error {
 		"--jsonrpc", t.JSONRPCAddr(),
 	}
 
+	if t.Config.IsWSEnable {
+		args = append(args, "--enable-ws")
+	}
+
 	switch t.Config.Consensus {
 	case ConsensusIBFT:
 		args = append(args, "--data-dir", filepath.Join(t.Config.RootDir, t.Config.IBFTDir))

--- a/e2e/websocket_test.go
+++ b/e2e/websocket_test.go
@@ -61,6 +61,7 @@ func TestWS_Response(t *testing.T) {
 	srvs := framework.NewTestServers(t, 1, func(config *framework.TestServerConfig) {
 		config.SetConsensus(framework.ConsensusDev)
 		config.SetSeal(true)
+		config.EnableWebSocket()
 
 		for _, account := range preminedAccounts {
 			config.Premine(account.address, account.balance)

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -62,6 +62,7 @@ type Config struct {
 	AccessControlAllowOrigin []string
 	BatchLengthLimit         uint64
 	BlockRangeLimit          uint64
+	EnableWS                 bool
 }
 
 // NewJSONRPC returns the JSONRPC http server
@@ -95,7 +96,10 @@ func (j *JSONRPC) setupHTTP() error {
 	jsonRPCHandler := http.HandlerFunc(j.handle)
 	mux.Handle("/", middlewareFactory(j.config)(jsonRPCHandler))
 
-	mux.HandleFunc("/ws", j.handleWs)
+	// would only enable websocket when set
+	if j.config.EnableWS {
+		mux.HandleFunc("/ws", j.handleWs)
+	}
 
 	srv := http.Server{
 		Handler:           mux,

--- a/server/config.go
+++ b/server/config.go
@@ -71,6 +71,7 @@ type JSONRPC struct {
 	AccessControlAllowOrigin []string
 	BatchLengthLimit         uint64
 	BlockRangeLimit          uint64
+	EnableWS                 bool
 }
 
 type GraphQL struct {

--- a/server/server.go
+++ b/server/server.go
@@ -597,6 +597,7 @@ func (s *Server) setupJSONRPC() error {
 		AccessControlAllowOrigin: s.config.JSONRPC.AccessControlAllowOrigin,
 		BatchLengthLimit:         s.config.JSONRPC.BatchLengthLimit,
 		BlockRangeLimit:          s.config.JSONRPC.BlockRangeLimit,
+		EnableWS:                 s.config.JSONRPC.EnableWS,
 	}
 
 	srv, err := jsonrpc.NewJSONRPC(s.logger, conf)


### PR DESCRIPTION
# Description

The WebSocket enpoint was enabled by default, it would consumes too many connections of the RPC node when exposed in the Internet.

This PR adds the `enable-ws` flag to the server command, and disable the WebSocket endpoint by default.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

* setup a new `dev` mode server, using `enable-ws` flag or without it.
* Use WebSocket client, connect to localhost WebSocket endpoint.

We should not be able to connect to `ws://localhost:8545/ws` endpoint when `enable-ws` flag not set. And vice versa.

# Documentation update

Would update the documentation when new released done.
