### PR TITLE
[Txpool] Prune inactive account enqueued transactions when promotion outdated

### DIFF
--- a/command/default.go
+++ b/command/default.go
@@ -3,16 +3,13 @@ package command
 import "github.com/dogechain-lab/dogechain/server"
 
 const (
-	DefaultGenesisFileName     = "genesis.json"
-	DefaultChainName           = "dogechain"
-	DefaultChainID             = 100
-	DefaultPremineBalance      = "0x3635C9ADC5DEA00000" // 1000 ETH
-	DefaultConsensus           = server.IBFTConsensus
-	DefaultPriceLimit          = 0
-	DefaultMaxSlots            = 4096
-	DefaultMaxAccountDemotions = 10      // account demotion counter limit
-	DefaultGenesisGasUsed      = 458752  // 0x70000
-	DefaultGenesisGasLimit     = 5242880 // 0x500000
+	DefaultGenesisFileName = "genesis.json"
+	DefaultChainName       = "dogechain"
+	DefaultChainID         = 100
+	DefaultPremineBalance  = "0x3635C9ADC5DEA00000" // 1000 ETH
+	DefaultConsensus       = server.IBFTConsensus
+	DefaultGenesisGasUsed  = 458752  // 0x70000
+	DefaultGenesisGasLimit = 5242880 // 0x500000
 )
 
 const (

--- a/command/default.go
+++ b/command/default.go
@@ -3,18 +3,16 @@ package command
 import "github.com/dogechain-lab/dogechain/server"
 
 const (
-	DefaultGenesisFileName       = "genesis.json"
-	DefaultChainName             = "dogechain"
-	DefaultChainID               = 100
-	DefaultPremineBalance        = "0x3635C9ADC5DEA00000" // 1000 ETH
-	DefaultConsensus             = server.IBFTConsensus
-	DefaultPriceLimit            = 0
-	DefaultMaxSlots              = 4096
-	DefaultMaxAccountDemotions   = 10      // account demotion counter limit
-	DefaultPruneTickSeconds      = 300     // ticker duration for pruning account future transactions
-	DefaultPromoteOutdateSeconds = 1800    // not promoted account for a long time would be pruned
-	DefaultGenesisGasUsed        = 458752  // 0x70000
-	DefaultGenesisGasLimit       = 5242880 // 0x500000
+	DefaultGenesisFileName     = "genesis.json"
+	DefaultChainName           = "dogechain"
+	DefaultChainID             = 100
+	DefaultPremineBalance      = "0x3635C9ADC5DEA00000" // 1000 ETH
+	DefaultConsensus           = server.IBFTConsensus
+	DefaultPriceLimit          = 0
+	DefaultMaxSlots            = 4096
+	DefaultMaxAccountDemotions = 10      // account demotion counter limit
+	DefaultGenesisGasUsed      = 458752  // 0x70000
+	DefaultGenesisGasLimit     = 5242880 // 0x500000
 )
 
 const (

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -6,11 +6,9 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/dogechain-lab/dogechain/command"
 	"github.com/dogechain-lab/dogechain/jsonrpc"
 	"github.com/dogechain-lab/dogechain/network"
 	"github.com/dogechain-lab/dogechain/txpool"
-
 	"github.com/hashicorp/hcl"
 )
 
@@ -87,9 +85,9 @@ func DefaultConfig() *Config {
 		Telemetry:  &Telemetry{},
 		ShouldSeal: false,
 		TxPool: &TxPool{
-			PriceLimit:            command.DefaultPriceLimit,
-			MaxSlots:              command.DefaultMaxSlots,
-			MaxAccountDemotions:   command.DefaultMaxAccountDemotions,
+			PriceLimit:            0,
+			MaxSlots:              txpool.DefaultMaxSlots,
+			MaxAccountDemotions:   txpool.DefaultMaxAccountDemotions,
 			PruneTickSeconds:      txpool.DefaultPruneTickSeconds,
 			PromoteOutdateSeconds: txpool.DefaultPromoteOutdateSeconds,
 		},

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dogechain-lab/dogechain/command"
 	"github.com/dogechain-lab/dogechain/jsonrpc"
 	"github.com/dogechain-lab/dogechain/network"
+	"github.com/dogechain-lab/dogechain/txpool"
 
 	"github.com/hashicorp/hcl"
 )
@@ -89,8 +90,8 @@ func DefaultConfig() *Config {
 			PriceLimit:            command.DefaultPriceLimit,
 			MaxSlots:              command.DefaultMaxSlots,
 			MaxAccountDemotions:   command.DefaultMaxAccountDemotions,
-			PruneTickSeconds:      command.DefaultPruneTickSeconds,
-			PromoteOutdateSeconds: command.DefaultPromoteOutdateSeconds,
+			PruneTickSeconds:      txpool.DefaultPruneTickSeconds,
+			PromoteOutdateSeconds: txpool.DefaultPromoteOutdateSeconds,
 		},
 		LogLevel:    "INFO",
 		RestoreFile: "",

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -175,14 +175,14 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().Uint64Var(
 		&params.rawConfig.TxPool.MaxSlots,
 		maxSlotsFlag,
-		command.DefaultMaxSlots,
+		txpool.DefaultMaxSlots,
 		"maximum slots in the pool",
 	)
 
 	cmd.Flags().Uint64Var(
 		&params.rawConfig.TxPool.MaxAccountDemotions,
 		maxAccountDemotionsFlag,
-		command.DefaultMaxAccountDemotions,
+		txpool.DefaultMaxAccountDemotions,
 		"maximum account demontion counter limit in the pool",
 	)
 

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dogechain-lab/dogechain/command"
 	"github.com/dogechain-lab/dogechain/crypto"
 	"github.com/dogechain-lab/dogechain/helper/daemon"
+	"github.com/dogechain-lab/dogechain/txpool"
 	"github.com/howeyc/gopass"
 	"github.com/spf13/cobra"
 
@@ -188,14 +189,14 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().Uint64Var(
 		&params.rawConfig.TxPool.PruneTickSeconds,
 		pruneTickSecondsFlag,
-		command.DefaultPruneTickSeconds,
+		txpool.DefaultPruneTickSeconds,
 		"tick seconds for pruning account future transactions in the pool",
 	)
 
 	cmd.Flags().Uint64Var(
 		&params.rawConfig.TxPool.PromoteOutdateSeconds,
 		promoteOutdateSecondsFlag,
-		command.DefaultPromoteOutdateSeconds,
+		txpool.DefaultPromoteOutdateSeconds,
 		"account in the pool not promoted for a long time would be pruned",
 	)
 

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -29,7 +29,7 @@ func (m *accountsMap) initOnce(addr types.Address, nonce uint64) *account {
 		newAccount.setNonce(nonce)
 
 		// set the timestamp for pruning. Reinit account should reset it.
-		newAccount.lastPromoted = time.Now()
+		newAccount.updatePromoted()
 
 		// update global count
 		atomic.AddUint64(&m.count, 1)
@@ -341,9 +341,9 @@ func (a *account) promote() (promoted []*types.Transaction, dropped []*types.Tra
 	// is higher than the one previously stored.
 	if nextNonce > currentNonce {
 		a.setNonce(nextNonce)
+		// only update the promotion timestamp when it is actually promoted.
+		a.updatePromoted()
 	}
-
-	a.updatePromoted()
 
 	return
 }

--- a/txpool/default.go
+++ b/txpool/default.go
@@ -1,0 +1,10 @@
+package txpool
+
+const (
+	DefaultPruneTickSeconds      = 300  // ticker duration for pruning account future transactions
+	DefaultPromoteOutdateSeconds = 3600 // not promoted account for a long time would be pruned
+	// txpool transaction max slots. tx <= 32kB would only take 1 slot. tx > 32kB would take
+	// ceil(tx.size / 32kB) slots.
+	DefaultMaxSlots            = 4096
+	DefaultMaxAccountDemotions = 10 // account demotion counter limit
+)

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -264,9 +264,7 @@ func (p *TxPool) Start() {
 	// set default value of txpool transactions gauge
 	p.metrics.SetDefaultValue(0)
 
-	// p.pruneAccountTicker = time.NewTicker(p.pruneTick)
-	// case <-p.pruneAccountTicker.C:
-	// 	go p.pruneStaleAccounts()
+	p.pruneAccountTicker = time.NewTicker(p.pruneTick)
 
 	go func() {
 		for {
@@ -277,6 +275,8 @@ func (p *TxPool) Start() {
 				go p.handleEnqueueRequest(req)
 			case req := <-p.promoteReqCh:
 				go p.handlePromoteRequest(req)
+			case <-p.pruneAccountTicker.C:
+				go p.pruneStaleAccounts()
 			}
 		}
 	}()

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -20,11 +20,14 @@ import (
 )
 
 const (
-	txSlotSize                   = 32 * 1024  // 32kB
-	txMaxSize                    = 128 * 1024 //128Kb
-	topicNameV1                  = "txpool/0.1"
-	defaultPruneTickSeconds      = 300
-	defaultPromoteOutdateSeconds = 3600
+	DefaultPruneTickSeconds      = 300  // ticker duration for pruning account future transactions
+	DefaultPromoteOutdateSeconds = 3600 // not promoted account for a long time would be pruned
+)
+
+const (
+	txSlotSize  = 32 * 1024  // 32kB
+	txMaxSize   = 128 * 1024 //128Kb
+	topicNameV1 = "txpool/0.1"
 )
 
 // errors
@@ -197,11 +200,11 @@ func NewTxPool(
 	)
 
 	if pruneTickSeconds == 0 {
-		pruneTickSeconds = defaultPruneTickSeconds
+		pruneTickSeconds = DefaultPruneTickSeconds
 	}
 
 	if promoteOutdateSeconds == 0 {
-		promoteOutdateSeconds = defaultPromoteOutdateSeconds
+		promoteOutdateSeconds = DefaultPromoteOutdateSeconds
 	}
 
 	pool := &TxPool{

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -834,24 +834,12 @@ func (p *TxPool) resetAccounts(stateNonces map[types.Address]uint64) {
 	//	prune pool state
 	if len(allPrunedPromoted) > 0 {
 		cleanup(allPrunedPromoted...)
-		p.eventManager.signalEvent(
-			proto.EventType_PRUNED_PROMOTED,
-			toHash(allPrunedPromoted...)...,
-		)
-
-		// update metrics
-		p.metrics.PendingTxs.Add(float64(-1 * len(allPrunedPromoted)))
+		p.decreaseQueueGauge(allPrunedPromoted, p.metrics.PendingTxs, proto.EventType_PRUNED_PROMOTED)
 	}
 
 	if len(allPrunedEnqueued) > 0 {
 		cleanup(allPrunedEnqueued...)
-		p.eventManager.signalEvent(
-			proto.EventType_PRUNED_ENQUEUED,
-			toHash(allPrunedEnqueued...)...,
-		)
-
-		// update metrics
-		p.metrics.EnqueueTxs.Add(float64(-1 * len(allPrunedEnqueued)))
+		p.decreaseQueueGauge(allPrunedEnqueued, p.metrics.EnqueueTxs, proto.EventType_PRUNED_ENQUEUED)
 	}
 }
 

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -24,7 +24,7 @@ const (
 	txMaxSize                    = 128 * 1024 //128Kb
 	topicNameV1                  = "txpool/0.1"
 	defaultPruneTickSeconds      = 300
-	defaultPromoteOutdateSeconds = 1800
+	defaultPromoteOutdateSeconds = 3600
 )
 
 // errors

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -20,11 +20,6 @@ import (
 )
 
 const (
-	DefaultPruneTickSeconds      = 300  // ticker duration for pruning account future transactions
-	DefaultPromoteOutdateSeconds = 3600 // not promoted account for a long time would be pruned
-)
-
-const (
 	txSlotSize  = 32 * 1024  // 32kB
 	txMaxSize   = 128 * 1024 //128Kb
 	topicNameV1 = "txpool/0.1"
@@ -197,6 +192,8 @@ func NewTxPool(
 	var (
 		pruneTickSeconds      = config.PruneTickSeconds
 		promoteOutdateSeconds = config.PromoteOutdateSeconds
+		maxSlot               = config.MaxSlots
+		maxAccountDemotions   = config.MaxAccountDemotions
 	)
 
 	if pruneTickSeconds == 0 {
@@ -207,6 +204,14 @@ func NewTxPool(
 		promoteOutdateSeconds = DefaultPromoteOutdateSeconds
 	}
 
+	if maxSlot == 0 {
+		maxSlot = DefaultMaxSlots
+	}
+
+	if maxAccountDemotions == 0 {
+		maxAccountDemotions = DefaultMaxAccountDemotions
+	}
+
 	pool := &TxPool{
 		logger:                 logger.Named("txpool"),
 		forks:                  forks,
@@ -215,10 +220,10 @@ func NewTxPool(
 		accounts:               accountsMap{},
 		executables:            newPricedQueue(),
 		index:                  lookupMap{all: make(map[types.Hash]*types.Transaction)},
-		gauge:                  slotGauge{height: 0, max: config.MaxSlots},
+		gauge:                  slotGauge{height: 0, max: maxSlot},
 		priceLimit:             config.PriceLimit,
 		sealing:                config.Sealing,
-		maxAccountDemotions:    config.MaxAccountDemotions,
+		maxAccountDemotions:    maxAccountDemotions,
 		pruneTick:              time.Second * time.Duration(pruneTickSeconds),
 		promoteOutdateDuration: time.Second * time.Duration(promoteOutdateSeconds),
 	}

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1341,6 +1341,8 @@ func BenchmarkPruneStaleAccounts10KAccounts(b *testing.B)  { benchmarkPruneStale
 func BenchmarkPruneStaleAccounts100KAccounts(b *testing.B) { benchmarkPruneStaleAccounts(b, 100000) }
 
 func benchmarkPruneStaleAccounts(b *testing.B, accountSize int) {
+	b.Helper()
+
 	pool, err := newTestPoolWithSlots(uint64(accountSize + 1))
 	assert.NoError(b, err)
 
@@ -1367,6 +1369,7 @@ func benchmarkPruneStaleAccounts(b *testing.B, accountSize int) {
 		if !pool.accounts.exists(addr) {
 			pool.createAccountOnce(addr)
 		}
+
 		pool.accounts.get(addr).lastPromoted = lastPromotedTime
 	}
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -1281,18 +1281,21 @@ func TestEnqueuedPruning(t *testing.T) {
 
 	testTable := []struct {
 		name            string
+		futureTx        *types.Transaction
 		lastPromoted    time.Time
 		expectedTxCount uint64
 		expectedGauge   uint64
 	}{
 		{
 			"prune stale tx",
+			newTx(addr1, 3, 1),
 			time.Now().Add(-time.Second * DefaultPromoteOutdateSeconds),
 			0,
 			0,
 		},
 		{
 			"no stale tx to prune",
+			newTx(addr1, 5, 1),
 			time.Now().Add(-5 * time.Second),
 			1,
 			1,
@@ -1310,7 +1313,8 @@ func TestEnqueuedPruning(t *testing.T) {
 			pool.SetSigner(&mockSigner{})
 
 			go func() {
-				err := pool.addTx(local, newTx(addr1, 5, 1))
+				// add a future nonce tx
+				err := pool.addTx(local, test.futureTx)
 				assert.NoError(t, err)
 			}()
 			pool.handleEnqueueRequest(<-pool.enqueueReqCh)

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -94,8 +94,8 @@ func newTestPoolWithSlots(maxSlots uint64, mockStore ...store) (*TxPool, error) 
 			MaxSlots:              maxSlots,
 			Sealing:               false,
 			MaxAccountDemotions:   defaultMaxAccountDemotions,
-			PruneTickSeconds:      defaultPruneTickSeconds,
-			PromoteOutdateSeconds: defaultPromoteOutdateSeconds,
+			PruneTickSeconds:      DefaultPruneTickSeconds,
+			PromoteOutdateSeconds: DefaultPromoteOutdateSeconds,
 		},
 	)
 }
@@ -1287,7 +1287,7 @@ func TestEnqueuedPruning(t *testing.T) {
 	}{
 		{
 			"prune stale tx",
-			time.Now().Add(-time.Second * defaultPromoteOutdateSeconds),
+			time.Now().Add(-time.Second * DefaultPromoteOutdateSeconds),
 			0,
 			0,
 		},


### PR DESCRIPTION
# Description

This PR re-enables the feature, prune inactive account enqueued transactions, evaluate the outdate time based on its last promotion time.

The `txpool` without any prune policy would finally be filled with high nonce transactions, especially attacked by `DOS`.

So more limitation and prune policy should be imported. And the PR is the first one.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

* Set up a dev node, using flags `--promote-outdate-seconds 180 --prune-tick-seconds 10`. 
* Send some future transactions to it using `MetaMask`.
* Wait 3 minutes or so.
* Query `txpool` status every 10 seconds.

* In `dev` branch, `txpool` status should remain the same.
* In the PR branch, `txpool` should have zero enqueued transactions or `n` transactions.
    * Because `Metamask` would keep re-sending transactions not promoted over and over again.
    * It should be the right symptom.

```bash
[TXPOOL STATUS]
Pending transactions  = 0
Enqueued transactions = 0
Max slots             = 4096

[TXPOOL STATUS]
Pending transactions  = 0
Enqueued transactions = 8
Max slots             = 4096

[TXPOOL STATUS]
Pending transactions  = 0
Enqueued transactions = 0
Max slots             = 4096

...
```

# Documentation update

* Will update documentation once `1.2.0` released.