### PR TITLE
Resolve memory creep when copy header

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,29 +24,7 @@ jobs:
         with:
           version: latest
           args: --timeout=3m
-            -E whitespace
-            -E wsl
-            -E wastedassign
-            -E unconvert
-            -E tparallel
-            -E thelper
-            -E stylecheck
-            -E prealloc
-            -E predeclared
-            -E nolintlint
-            -E nlreturn
-            -E misspell
-            -E makezero
-            -E lll
-            -E importas
-            -E gosec
-            -E gofmt
-            -E goconst
-            -E forcetypeassert
-            -E dogsled
-            -E dupl
-            -E errname
-            -E errorlint
+            -c lint-rule.yaml
           skip-go-installation: true
   test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,7 @@ build:
 
 .PHONY: lint
 lint:
-	golangci-lint run -E whitespace -E wsl -E wastedassign -E unconvert -E tparallel -E thelper -E stylecheck -E prealloc \
-	-E predeclared -E nlreturn -E misspell -E makezero -E lll -E importas -E gosec -E  gofmt -E goconst \
-	-E forcetypeassert -E dogsled -E dupl -E errname -E errorlint -E nolintlint --timeout 2m
+	golangci-lint run -c lint-rule.yaml --timeout=2m
 
 .PHONY: generate-bsd-licenses
 generate-bsd-licenses:

--- a/lint-rule.yaml
+++ b/lint-rule.yaml
@@ -1,0 +1,34 @@
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default-linters
+  enable:
+    - dogsled
+    - dupl
+    - errname
+    - errorlint
+    - forcetypeassert
+    - goconst
+    - gofmt
+    - gosec
+    - importas
+    - lll
+    - makezero
+    - misspell
+    - nlreturn
+    - nolintlint
+    - prealloc
+    - predeclared
+    - stylecheck
+    - thelper
+    - tparallel
+    - unconvert
+    - wastedassign
+    - whitespace
+    - wsl
+
+issues:
+  exclude-rules:
+    - linters:
+        - staticcheck
+      path: "state/runtime/precompiled/base.go"
+      text: "SA1019:"

--- a/state/runtime/precompiled/base.go
+++ b/state/runtime/precompiled/base.go
@@ -7,8 +7,6 @@ import (
 	"github.com/dogechain-lab/dogechain/chain"
 	"github.com/dogechain-lab/dogechain/crypto"
 	"github.com/dogechain-lab/dogechain/helper/keccak"
-
-	//nolint:staticcheck
 	"golang.org/x/crypto/ripemd160"
 )
 

--- a/state/runtime/precompiled/base.go
+++ b/state/runtime/precompiled/base.go
@@ -4,11 +4,12 @@ import (
 	"crypto/sha256"
 	"math/big"
 
-	"golang.org/x/crypto/ripemd160" //nolint:staticcheck
-
 	"github.com/dogechain-lab/dogechain/chain"
 	"github.com/dogechain-lab/dogechain/crypto"
 	"github.com/dogechain-lab/dogechain/helper/keccak"
+
+	//nolint:staticcheck
+	"golang.org/x/crypto/ripemd160"
 )
 
 type ecrecover struct {

--- a/types/header.go
+++ b/types/header.go
@@ -78,13 +78,28 @@ func (n Nonce) MarshalText() ([]byte, error) {
 }
 
 func (h *Header) Copy() *Header {
-	hh := new(Header)
-	*hh = *h
+	newHeader := &Header{
+		ParentHash:   h.ParentHash,
+		Sha3Uncles:   h.Sha3Uncles,
+		Miner:        h.Miner,
+		StateRoot:    h.StateRoot,
+		TxRoot:       h.TxRoot,
+		ReceiptsRoot: h.ReceiptsRoot,
+		LogsBloom:    h.LogsBloom,
+		Difficulty:   h.Difficulty,
+		Number:       h.Number,
+		GasLimit:     h.GasLimit,
+		GasUsed:      h.GasUsed,
+		Timestamp:    h.Timestamp,
+		MixHash:      h.MixHash,
+		Nonce:        h.Nonce,
+		Hash:         h.Hash,
+	}
 
-	hh.ExtraData = make([]byte, len(h.ExtraData))
-	copy(hh.ExtraData[:], h.ExtraData[:])
+	newHeader.ExtraData = make([]byte, len(h.ExtraData))
+	copy(newHeader.ExtraData[:], h.ExtraData[:])
 
-	return hh
+	return newHeader
 }
 
 type Body struct {


### PR DESCRIPTION
# Description

This PR resolves a steady memory creep that has been noted in the Header.Copy() method.

It's merging from 0xPolygon Edge project, the PR reference: [668](https://github.com/0xPolygon/polygon-edge/pull/668)

[zivkovicmilos](https://github.com/zivkovicmilos) had tested in `pprof`.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually