### PR TITLE
Feature: NAT use different port

### DIFF
--- a/command/server/init.go
+++ b/command/server/init.go
@@ -266,11 +266,9 @@ func (p *serverParams) initNATAddress() error {
 	}
 
 	var parseErr error
+	p.natAddress, parseErr = net.ResolveTCPAddr("tcp", p.rawConfig.Network.NatAddr)
 
-	if p.natAddress, parseErr = net.ResolveTCPAddr("tcp",
-		p.rawConfig.Network.NatAddr,
-	); parseErr != nil {
-
+	if parseErr != nil {
 		//compatible with no port setups
 		fmt.Printf("%s, use libp2p port\n", parseErr)
 

--- a/command/server/init.go
+++ b/command/server/init.go
@@ -210,6 +210,7 @@ func (p *serverParams) initAddresses() error {
 		return err
 	}
 
+	// need libp2p address to be set before initializing nat address
 	if err := p.initNATAddress(); err != nil {
 		return err
 	}
@@ -264,9 +265,25 @@ func (p *serverParams) initNATAddress() error {
 		return nil
 	}
 
-	if p.natAddress = net.ParseIP(
+	var parseErr error
+
+	if p.natAddress, parseErr = net.ResolveTCPAddr("tcp",
 		p.rawConfig.Network.NatAddr,
-	); p.natAddress == nil {
+	); parseErr != nil {
+
+		//compatible with no port setups
+		fmt.Printf("%s, use libp2p port\n", parseErr)
+
+		oldNatAddrCfg := net.ParseIP(p.rawConfig.Network.NatAddr)
+		if oldNatAddrCfg != nil {
+			p.natAddress, parseErr = net.ResolveTCPAddr("tcp",
+				fmt.Sprintf("%s:%d", oldNatAddrCfg.String(), p.libp2pAddress.Port),
+			)
+			if parseErr == nil {
+				return nil
+			}
+		}
+
 		return errInvalidNATAddress
 	}
 

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -67,7 +67,7 @@ var (
 
 var (
 	errInvalidPeerParams = errors.New("both max-peers and max-inbound/outbound flags are set")
-	errInvalidNATAddress = errors.New("could not parse NAT IP address")
+	errInvalidNATAddress = errors.New("could not parse NAT address (ip:port)")
 )
 
 type serverParams struct {
@@ -83,7 +83,7 @@ type serverParams struct {
 
 	libp2pAddress     *net.TCPAddr
 	prometheusAddress *net.TCPAddr
-	natAddress        net.IP
+	natAddress        *net.TCPAddr
 	dnsAddress        multiaddr.Multiaddr
 	grpcAddress       *net.TCPAddr
 	jsonRPCAddress    *net.TCPAddr

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -132,7 +132,7 @@ func setFlags(cmd *cobra.Command) {
 		&params.rawConfig.Network.NatAddr,
 		natFlag,
 		"",
-		"the external IP address without port, as can be seen by peers",
+		"the external address (address:port), as can be seen by peers",
 	)
 
 	cmd.Flags().StringVar(

--- a/network/config.go
+++ b/network/config.go
@@ -12,7 +12,7 @@ import (
 type Config struct {
 	NoDiscover       bool                   // flag indicating if the discovery mechanism should be turned on
 	Addr             *net.TCPAddr           // the base address
-	NatAddr          net.IP                 // the NAT address
+	NatAddr          *net.TCPAddr           // the NAT address
 	DNS              multiaddr.Multiaddr    // the DNS address
 	DataDir          string                 // the base data directory for the client
 	MaxPeers         int64                  // the maximum number of peer connections

--- a/network/server.go
+++ b/network/server.go
@@ -108,8 +108,10 @@ func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 			addr, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", config.NatAddr.IP.String(), config.NatAddr.Port))
 			if err != nil {
 				logger.Error("failed to create NAT address", "error", err)
+
 				return addrs
 			}
+
 			addrs = []multiaddr.Multiaddr{addr}
 		} else if config.DNS != nil {
 			addrs = []multiaddr.Multiaddr{config.DNS}

--- a/network/server.go
+++ b/network/server.go
@@ -105,11 +105,12 @@ func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 
 	addrsFactory := func(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
 		if config.NatAddr != nil {
-			addr, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", config.NatAddr.String(), config.Addr.Port))
-
-			if addr != nil {
-				addrs = []multiaddr.Multiaddr{addr}
+			addr, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", config.NatAddr.IP.String(), config.NatAddr.Port))
+			if err != nil {
+				logger.Error("failed to create NAT address", "error", err)
+				return addrs
 			}
+			addrs = []multiaddr.Multiaddr{addr}
 		} else if config.DNS != nil {
 			addrs = []multiaddr.Multiaddr{config.DNS}
 		}

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -327,7 +327,11 @@ func TestNat(t *testing.T) {
 	testMultiAddrString := fmt.Sprintf("/ip4/%s/tcp/%d", testIP, testPort)
 
 	server, createErr := CreateServer(&CreateServerParams{ConfigCallback: func(c *Config) {
-		c.NatAddr = net.ParseIP(testIP)
+		var err error
+		c.NatAddr, err = net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", testIP, testPort))
+
+		assert.NoError(t, err)
+
 		c.Addr.Port = testPort
 	}})
 	if createErr != nil {
@@ -505,7 +509,7 @@ func TestReconnectionWithNewIP(t *testing.T) {
 					defaultConfig(c)
 					c.DataDir = dir1
 					// same ID to but different IP from servers[1]
-					c.NatAddr = net.ParseIP(natIP)
+					c.NatAddr, _ = net.ResolveTCPAddr("tcp", natIP)
 				},
 			},
 		},


### PR DESCRIPTION
# Description

Add port configuration for NAT, can be configured HAProxy(sidecar) on a single machine without port conflicts

nat flag change:

```
server --nat X.X.X.X  // default port
```

```
server --nat X.X.X.X:1479  // custom port
```



# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

```
root@644365c223d2:/work# make build && mv main dogechain
go build -ldflags="-X 'github.com/dogechain-lab/dogechain/versioning.Version=v1.1.1+a8ae32e8+2022-09-06_07:35:30'" main.go
root@644365c223d2:/work# go test -coverprofile coverage.out -timeout 28m ./...
?   	github.com/dogechain-lab/dogechain	[no test files]
ok  	github.com/dogechain-lab/dogechain/archive	0.039s	coverage: 62.6% of statements
ok  	github.com/dogechain-lab/dogechain/blockchain	0.018s	coverage: 59.8% of statements
?   	github.com/dogechain-lab/dogechain/blockchain/storage	[no test files]
ok  	github.com/dogechain-lab/dogechain/blockchain/storage/leveldb	4.865s	coverage: 27.0% of statements
ok  	github.com/dogechain-lab/dogechain/blockchain/storage/memory	0.002s	coverage: 77.8% of statements
ok  	github.com/dogechain-lab/dogechain/chain	0.066s	coverage: 38.5% of statements
?   	github.com/dogechain-lab/dogechain/command	[no test files]
?   	github.com/dogechain-lab/dogechain/command/backup	[no test files]
?   	github.com/dogechain-lab/dogechain/command/genesis	[no test files]
?   	github.com/dogechain-lab/dogechain/command/helper	[no test files]
?   	github.com/dogechain-lab/dogechain/command/ibft	[no test files]
?   	github.com/dogechain-lab/dogechain/command/ibft/candidates	[no test files]
?   	github.com/dogechain-lab/dogechain/command/ibft/helper	[no test files]
?   	github.com/dogechain-lab/dogechain/command/ibft/propose	[no test files]
?   	github.com/dogechain-lab/dogechain/command/ibft/snapshot	[no test files]
?   	github.com/dogechain-lab/dogechain/command/ibft/status	[no test files]
?   	github.com/dogechain-lab/dogechain/command/ibft/switch	[no test files]
?   	github.com/dogechain-lab/dogechain/command/license	[no test files]
?   	github.com/dogechain-lab/dogechain/command/loadbot	[no test files]
?   	github.com/dogechain-lab/dogechain/command/loadbot/generator	[no test files]
?   	github.com/dogechain-lab/dogechain/command/monitor	[no test files]
?   	github.com/dogechain-lab/dogechain/command/peers	[no test files]
?   	github.com/dogechain-lab/dogechain/command/peers/add	[no test files]
?   	github.com/dogechain-lab/dogechain/command/peers/list	[no test files]
?   	github.com/dogechain-lab/dogechain/command/peers/status	[no test files]
?   	github.com/dogechain-lab/dogechain/command/root	[no test files]
?   	github.com/dogechain-lab/dogechain/command/secrets	[no test files]
?   	github.com/dogechain-lab/dogechain/command/secrets/generate	[no test files]
?   	github.com/dogechain-lab/dogechain/command/secrets/init	[no test files]
?   	github.com/dogechain-lab/dogechain/command/server	[no test files]
?   	github.com/dogechain-lab/dogechain/command/status	[no test files]
?   	github.com/dogechain-lab/dogechain/command/txpool	[no test files]
?   	github.com/dogechain-lab/dogechain/command/txpool/status	[no test files]
?   	github.com/dogechain-lab/dogechain/command/txpool/subscribe	[no test files]
?   	github.com/dogechain-lab/dogechain/command/version	[no test files]
?   	github.com/dogechain-lab/dogechain/consensus	[no test files]
?   	github.com/dogechain-lab/dogechain/consensus/dev	[no test files]
?   	github.com/dogechain-lab/dogechain/consensus/dummy	[no test files]
ok  	github.com/dogechain-lab/dogechain/consensus/ibft	0.343s	coverage: 59.3% of statements
?   	github.com/dogechain-lab/dogechain/consensus/ibft/proto	[no test files]
?   	github.com/dogechain-lab/dogechain/contracts/abis	[no test files]
?   	github.com/dogechain-lab/dogechain/contracts/bridge	[no test files]
?   	github.com/dogechain-lab/dogechain/contracts/systemcontracts	[no test files]
ok  	github.com/dogechain-lab/dogechain/contracts/validatorset	0.003s	coverage: 82.6% of statements
ok  	github.com/dogechain-lab/dogechain/crypto	0.023s	coverage: 75.1% of statements
ok  	github.com/dogechain-lab/dogechain/e2e	457.102s	coverage: [no statements]
?   	github.com/dogechain-lab/dogechain/e2e/framework	[no test files]
?   	github.com/dogechain-lab/dogechain/graphql	[no test files]
ok  	github.com/dogechain-lab/dogechain/graphql/argtype	0.015s	coverage: 42.0% of statements
?   	github.com/dogechain-lab/dogechain/helper/bridge	[no test files]
?   	github.com/dogechain-lab/dogechain/helper/common	[no test files]
?   	github.com/dogechain-lab/dogechain/helper/daemon	[no test files]
ok  	github.com/dogechain-lab/dogechain/helper/enode	0.014s	coverage: 56.2% of statements
?   	github.com/dogechain-lab/dogechain/helper/hex	[no test files]
?   	github.com/dogechain-lab/dogechain/helper/ipc	[no test files]
ok  	github.com/dogechain-lab/dogechain/helper/keccak	0.001s	coverage: 0.0% of statements [no tests to run]
?   	github.com/dogechain-lab/dogechain/helper/keystore	[no test files]
?   	github.com/dogechain-lab/dogechain/helper/progress	[no test files]
?   	github.com/dogechain-lab/dogechain/helper/tests	[no test files]
?   	github.com/dogechain-lab/dogechain/helper/validatorset	[no test files]
?   	github.com/dogechain-lab/dogechain/helper/vault	[no test files]
ok  	github.com/dogechain-lab/dogechain/jsonrpc	3.025s	coverage: 72.4% of statements
?   	github.com/dogechain-lab/dogechain/licenses	[no test files]
ok  	github.com/dogechain-lab/dogechain/network	89.720s	coverage: 80.1% of statements
?   	github.com/dogechain-lab/dogechain/network/common	[no test files]
ok  	github.com/dogechain-lab/dogechain/network/dial	1.002s	coverage: 91.5% of statements
ok  	github.com/dogechain-lab/dogechain/network/discovery	0.031s	coverage: 41.8% of statements
?   	github.com/dogechain-lab/dogechain/network/event	[no test files]
?   	github.com/dogechain-lab/dogechain/network/grpc	[no test files]
ok  	github.com/dogechain-lab/dogechain/network/identity	0.003s	coverage: 22.7% of statements
?   	github.com/dogechain-lab/dogechain/network/proto	[no test files]
?   	github.com/dogechain-lab/dogechain/network/testing	[no test files]
ok  	github.com/dogechain-lab/dogechain/protocol	26.448s	coverage: 76.5% of statements
?   	github.com/dogechain-lab/dogechain/protocol/proto	[no test files]
ok  	github.com/dogechain-lab/dogechain/secrets	0.002s	coverage: 9.1% of statements
?   	github.com/dogechain-lab/dogechain/secrets/awsssm	[no test files]
?   	github.com/dogechain-lab/dogechain/secrets/hashicorpvault	[no test files]
?   	github.com/dogechain-lab/dogechain/secrets/helper	[no test files]
ok  	github.com/dogechain-lab/dogechain/secrets/local	0.015s	coverage: 84.3% of statements
?   	github.com/dogechain-lab/dogechain/server	[no test files]
?   	github.com/dogechain-lab/dogechain/server/proto	[no test files]
ok  	github.com/dogechain-lab/dogechain/state	0.016s	coverage: 14.2% of statements
ok  	github.com/dogechain-lab/dogechain/state/immutable-trie	0.016s	coverage: 58.2% of statements
?   	github.com/dogechain-lab/dogechain/state/runtime	[no test files]
ok  	github.com/dogechain-lab/dogechain/state/runtime/evm	0.018s	coverage: 34.9% of statements
ok  	github.com/dogechain-lab/dogechain/state/runtime/precompiled	0.173s	coverage: 68.4% of statements
ok  	github.com/dogechain-lab/dogechain/tests	260.916s	coverage: 81.6% of statements
ok  	github.com/dogechain-lab/dogechain/txpool	55.065s	coverage: 78.3% of statements
?   	github.com/dogechain-lab/dogechain/txpool/proto	[no test files]
ok  	github.com/dogechain-lab/dogechain/types	0.002s	coverage: 34.9% of statements
ok  	github.com/dogechain-lab/dogechain/types/buildroot	0.231s	coverage: 67.4% of statements
?   	github.com/dogechain-lab/dogechain/versioning	[no test files]
root@644365c223d2:/work#
```
