### PR TITLE
Backup support zstd

### DIFF
--- a/archive/backup.go
+++ b/archive/backup.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -148,7 +149,8 @@ func writeMetadata(writer io.Writer, logger hclog.Logger, to uint64, toHash type
 		LatestHash: toHash,
 	}
 
-	_, err := writer.Write(metadata.MarshalRLP())
+	// tips: writer.Write() not necessarily write all data, use io.Copy() instead
+	_, err := io.Copy(writer, bytes.NewBuffer(metadata.MarshalRLP()))
 	if err != nil {
 		return err
 	}
@@ -199,7 +201,8 @@ func processExportStream(
 			return from, to, err
 		}
 
-		if _, err := writer.Write(event.Data); err != nil {
+		// tips: writer.Write() not necessarily write all data, use io.Copy() instead
+		if _, err := io.Copy(writer, bytes.NewBuffer(event.Data)); err != nil {
 			return from, to, err
 		}
 

--- a/archive/backup_test.go
+++ b/archive/backup_test.go
@@ -254,8 +254,8 @@ func Test_processExportStream(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, tt.from, *from)
-			assert.Equal(t, tt.to, *to)
+			assert.Equal(t, tt.from, from)
+			assert.Equal(t, tt.to, to)
 
 			// create expected data
 			expectedData := make([]byte, 0)

--- a/archive/restore.go
+++ b/archive/restore.go
@@ -1,6 +1,8 @@
 package archive
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -11,7 +13,10 @@ import (
 	"github.com/dogechain-lab/dogechain/helper/common"
 	"github.com/dogechain-lab/dogechain/helper/progress"
 	"github.com/dogechain-lab/dogechain/types"
+	"github.com/klauspost/compress/zstd"
 )
+
+var zstdMagic = []byte{0x28, 0xb5, 0x2f, 0xfd} // zstd Magic number
 
 type blockchainInterface interface {
 	SubscribeEvents() blockchain.Subscription
@@ -24,12 +29,32 @@ type blockchainInterface interface {
 
 // RestoreChain reads blocks from the archive and write to the chain
 func RestoreChain(chain blockchainInterface, filePath string, progression *progress.ProgressionWrapper) error {
-	fp, err := os.Open(filePath)
+	fp, err := os.OpenFile(filePath, os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	fbuf := bufio.NewReaderSize(fp, 1*1024*1024) // 1MB buffer
+
+	// check whether the file is compressed
+	fileMagic, err := fbuf.Peek(len(zstdMagic))
 	if err != nil {
 		return err
 	}
 
-	blockStream := newBlockStream(fp)
+	if bytes.Equal(fileMagic[:], zstdMagic[:]) {
+		zstdReader, err := zstd.NewReader(fbuf)
+		if err != nil {
+			return err
+		}
+		defer zstdReader.Close()
+
+		// replace the reader with zstd reader
+		fbuf = bufio.NewReader(zstdReader)
+	}
+
+	blockStream := newBlockStream(fbuf)
 
 	return importBlocks(chain, blockStream, progression)
 }

--- a/archive/restore.go
+++ b/archive/restore.go
@@ -43,18 +43,22 @@ func RestoreChain(chain blockchainInterface, filePath string, progression *progr
 		return err
 	}
 
+	var readBuf io.Reader
+
 	if bytes.Equal(fileMagic[:], zstdMagic[:]) {
+
 		zstdReader, err := zstd.NewReader(fbuf)
 		if err != nil {
 			return err
 		}
 		defer zstdReader.Close()
 
-		// replace the reader with zstd reader
-		fbuf = bufio.NewReader(zstdReader)
+		readBuf = zstdReader
+	} else {
+		readBuf = fbuf
 	}
 
-	blockStream := newBlockStream(fbuf)
+	blockStream := newBlockStream(readBuf)
 
 	return importBlocks(chain, blockStream, progression)
 }

--- a/archive/restore.go
+++ b/archive/restore.go
@@ -46,7 +46,6 @@ func RestoreChain(chain blockchainInterface, filePath string, progression *progr
 	var readBuf io.Reader
 
 	if bytes.Equal(fileMagic[:], zstdMagic[:]) {
-
 		zstdReader, err := zstd.NewReader(fbuf)
 		if err != nil {
 			return err

--- a/command/backup/backup.go
+++ b/command/backup/backup.go
@@ -63,7 +63,7 @@ func setFlags(cmd *cobra.Command) {
 		&params.zstdLevel,
 		zstdLevelFlag,
 		3,
-		"zstd compression level",
+		"zstd compression level, range 1-10",
 	)
 }
 

--- a/command/backup/backup.go
+++ b/command/backup/backup.go
@@ -44,6 +44,27 @@ func setFlags(cmd *cobra.Command) {
 		"",
 		"the end height of the chain in backup",
 	)
+
+	cmd.Flags().BoolVar(
+		&params.overwriteFile,
+		overwriteFileFlag,
+		false,
+		"force overwrite the backup file if it already exists",
+	)
+
+	cmd.Flags().BoolVar(
+		&params.enableZstdCompression,
+		zstdFlag,
+		false,
+		"enable zstd compression",
+	)
+
+	cmd.Flags().IntVar(
+		&params.zstdLevel,
+		zstdLevelFlag,
+		3,
+		"zstd compression level",
+	)
 }
 
 func runPreRun(_ *cobra.Command, _ []string) error {

--- a/command/backup/params.go
+++ b/command/backup/params.go
@@ -11,9 +11,12 @@ import (
 )
 
 const (
-	outFlag  = "out"
-	fromFlag = "from"
-	toFlag   = "to"
+	outFlag           = "out"
+	fromFlag          = "from"
+	toFlag            = "to"
+	overwriteFileFlag = "overwrite-file"
+	zstdFlag          = "zstd"
+	zstdLevelFlag     = "zstd-level"
 )
 
 var (
@@ -30,6 +33,11 @@ type backupParams struct {
 
 	fromRaw string
 	toRaw   string
+
+	overwriteFile bool
+
+	enableZstdCompression bool
+	zstdLevel             int
 
 	from uint64
 	to   *uint64
@@ -86,6 +94,9 @@ func (p *backupParams) createBackup(grpcAddress string) error {
 		p.from,
 		p.to,
 		p.out,
+		p.overwriteFile,
+		p.enableZstdCompression,
+		p.zstdLevel,
 	)
 	if err != nil {
 		return err

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -140,7 +140,13 @@ func GetIBFTOperatorClientConnection(address string) (
 
 // GetGRPCConnection returns a grpc client connection
 func GetGRPCConnection(address string) (*grpc.ClientConn, error) {
-	conn, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.Dial(
+		address,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(common.MaxGrpcMsgSize),
+			grpc.MaxCallSendMsgSize(common.MaxGrpcMsgSize)))
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to server: %w", err)
 	}

--- a/command/loadbot/generators.go
+++ b/command/loadbot/generators.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/dogechain-lab/dogechain/crypto"
+	"github.com/dogechain-lab/dogechain/helper/common"
 	txpoolOp "github.com/dogechain-lab/dogechain/txpool/proto"
 	"github.com/dogechain-lab/dogechain/types"
 	"github.com/umbracle/go-web3/jsonrpc"
@@ -25,7 +26,12 @@ func createJSONRPCClient(endpoint string, maxConns int) (*jsonrpc.Client, error)
 }
 
 func createGRPCClient(endpoint string) (txpoolOp.TxnPoolOperatorClient, error) {
-	conn, err := grpc.Dial(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.Dial(
+		endpoint,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(common.MaxGrpcMsgSize),
+			grpc.MaxCallSendMsgSize(common.MaxGrpcMsgSize)))
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/backup_test.go
+++ b/e2e/backup_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestBackup(t *testing.T) {
 	compressionFile := path.Join(os.TempDir(), "e2e_testbackup.bin.zstd")
-	noCompressionFile := path.Join(os.TempDir() + "e2e_testbackup.bin")
+	noCompressionFile := path.Join(os.TempDir(), "e2e_testbackup.bin")
 	backupFiles := []string{noCompressionFile, compressionFile}
 
 	var toBlock uint64 = 10

--- a/e2e/backup_test.go
+++ b/e2e/backup_test.go
@@ -1,0 +1,98 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/dogechain-lab/dogechain/archive"
+	"github.com/dogechain-lab/dogechain/command/helper"
+	"github.com/dogechain-lab/dogechain/e2e/framework"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+	"github.com/umbracle/go-web3"
+)
+
+func TestBackup(t *testing.T) {
+	compressionFile := path.Join(os.TempDir(), "e2e_testbackup.bin.zstd")
+	noCompressionFile := path.Join(os.TempDir() + "e2e_testbackup.bin")
+	backupFiles := []string{noCompressionFile, compressionFile}
+
+	var toBlock uint64 = 10
+
+	svrs := framework.NewTestServers(t, 4, func(config *framework.TestServerConfig) {
+		config.SetConsensus(framework.ConsensusDev)
+		config.SetSeal(true)
+		config.SetDevInterval(1)
+	})
+
+	svr := svrs[0]
+
+	errs := framework.WaitForServersToSeal(svrs, toBlock)
+	for _, err := range errs {
+		assert.NoError(t, err)
+	}
+
+	connection, err := helper.GetGRPCConnection(
+		svr.GrpcAddr(),
+	)
+
+	assert.NoError(t, err)
+
+	for _, backupFile := range backupFiles {
+		resFrom, resTo, err := archive.CreateBackup(
+			connection,
+			hclog.NewNullLogger(),
+			0,
+			&toBlock,
+			backupFile,
+			true,
+			false,
+			3,
+		)
+
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(0), resFrom)
+		assert.Equal(t, uint64(10), resTo)
+
+		t.Cleanup(func() {
+			os.Remove(backupFile)
+		})
+	}
+
+	block, err := svr.JSONRPC().Eth().GetBlockByNumber(web3.BlockNumber(toBlock), false)
+	assert.NoError(t, err)
+
+	blockHash := block.Hash
+
+	for _, svr := range svrs {
+		svr.Stop()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for _, backupFile := range backupFiles {
+		os.RemoveAll(path.Join(svr.Config.RootDir, "blockchain"))
+		os.RemoveAll(path.Join(svr.Config.RootDir, "trie"))
+
+		restoreSvr := framework.NewTestServer(t, svr.Config.RootDir, func(config *framework.TestServerConfig) {
+			*config = *svr.Config
+			config.SetRestoreFile(backupFile)
+		})
+
+		err := restoreSvr.Start(ctx)
+		assert.NoError(t, err)
+
+		block, err := restoreSvr.JSONRPC().Eth().GetBlockByNumber(web3.BlockNumber(toBlock), false)
+		assert.NoError(t, err)
+
+		restoreHash := block.Hash
+
+		assert.Equal(t, blockHash, restoreHash)
+
+		restoreSvr.Stop()
+	}
+}

--- a/e2e/framework/config.go
+++ b/e2e/framework/config.go
@@ -50,6 +50,7 @@ type TestServerConfig struct {
 	BridgeOwner    types.Address        // bridge contract owner
 	BridgeSigners  []types.Address      // bridge contract signers
 	IsWSEnable     bool                 // enable websocket or not
+	RestoreFile    string               // blockchain restore file
 }
 
 // DataDir returns path of data directory server uses
@@ -169,4 +170,8 @@ func (t *TestServerConfig) SetBridgeSigners(signers []types.Address) {
 
 func (t *TestServerConfig) EnableWebSocket() {
 	t.IsWSEnable = true
+}
+
+func (t *TestServerConfig) SetRestoreFile(path string) {
+	t.RestoreFile = path
 }

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -336,6 +336,10 @@ func (t *TestServer) Start(ctx context.Context) error {
 		args = append(args, "--enable-ws")
 	}
 
+	if t.Config.RestoreFile != "" {
+		args = append(args, "--restore", t.Config.RestoreFile)
+	}
+
 	switch t.Config.Consensus {
 	case ConsensusIBFT:
 		args = append(args, "--data-dir", filepath.Join(t.Config.RootDir, t.Config.IBFTDir))

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dogechain-lab/dogechain/consensus/ibft"
 	ibftOp "github.com/dogechain-lab/dogechain/consensus/ibft/proto"
 	"github.com/dogechain-lab/dogechain/crypto"
+	"github.com/dogechain-lab/dogechain/helper/common"
 	"github.com/dogechain-lab/dogechain/helper/tests"
 	"github.com/dogechain-lab/dogechain/network"
 	"github.com/dogechain-lab/dogechain/secrets"
@@ -116,7 +117,10 @@ func (t *TestServer) JSONRPC() *jsonrpc.Client {
 func (t *TestServer) Operator() proto.SystemClient {
 	conn, err := grpc.Dial(
 		t.GrpcAddr(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(common.MaxGrpcMsgSize),
+			grpc.MaxCallSendMsgSize(common.MaxGrpcMsgSize)))
 	if err != nil {
 		t.t.Fatal(err)
 	}
@@ -127,7 +131,10 @@ func (t *TestServer) Operator() proto.SystemClient {
 func (t *TestServer) TxnPoolOperator() txpoolProto.TxnPoolOperatorClient {
 	conn, err := grpc.Dial(
 		t.GrpcAddr(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(common.MaxGrpcMsgSize),
+			grpc.MaxCallSendMsgSize(common.MaxGrpcMsgSize)))
 	if err != nil {
 		t.t.Fatal(err)
 	}
@@ -138,7 +145,10 @@ func (t *TestServer) TxnPoolOperator() txpoolProto.TxnPoolOperatorClient {
 func (t *TestServer) IBFTOperator() ibftOp.IbftOperatorClient {
 	conn, err := grpc.Dial(
 		t.GrpcAddr(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(common.MaxGrpcMsgSize),
+			grpc.MaxCallSendMsgSize(common.MaxGrpcMsgSize)))
 	if err != nil {
 		t.t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/graph-gophers/graphql-go v1.4.0
 	github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef
 	github.com/ipfs/go-cid v0.1.0 // indirect
-	github.com/klauspost/compress v1.14.2 // indirect
+	github.com/klauspost/compress v1.14.2
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/umbracle/fastrlp v0.0.0-20220527094140-59d5dd30e722 // indirect

--- a/go.sum
+++ b/go.sum
@@ -172,7 +172,6 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -1035,8 +1034,6 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
-github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
-github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
 github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -20,6 +20,8 @@ var (
 	// Our staking repo is written in JS, as are many other clients
 	// If we use higher value JS will not be able to parse it
 	MaxSafeJSInt = uint64(math.Pow(2, 53) - 2)
+
+	MaxGrpcMsgSize = 16 * 1024 * 1024 // 16MB
 )
 
 // Min returns the strictly lower number

--- a/server/server.go
+++ b/server/server.go
@@ -138,10 +138,13 @@ func NewServer(config *Config) (*Server, error) {
 	}
 
 	m := &Server{
-		logger:             logger,
-		config:             config,
-		chain:              config.Chain,
-		grpcServer:         grpc.NewServer(),
+		logger: logger,
+		config: config,
+		chain:  config.Chain,
+		grpcServer: grpc.NewServer(
+			grpc.MaxRecvMsgSize(common.MaxGrpcMsgSize),
+			grpc.MaxSendMsgSize(common.MaxGrpcMsgSize),
+		),
 		restoreProgression: progress.NewProgressionWrapper(progress.ChainSyncRestore),
 	}
 


### PR DESCRIPTION
# Description

* Backup support zstd compression
* gRPC message size limit increase to 16MB (fix backup error)
* don't remove backup file on error
* fix dangling pointer

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

require :
  1. zstd tools (ubuntu install `zstd` package)
 
test process:

1. create backup (no compression and zstd compression)

```
$ ./dogechain backup --from 0 --to 99 --overwrite-file --zstd --out backup_blocks.zst
$ ./dogechain backup --from 0 --to 99 --overwrite-file --out backup_blocks_nocompr
```

2. decompression zstd

```
$ zstd -d backup_blocks.zst
```

3. check sha256

```
$ sha256sum backup_blocks 
$ sha256sum backup_blocks_nocompr
```

4. run server (restore) 

```
./dogechain server  --data-dir ./data --chain ./genesis.json  --restore ./backup_blocks.zst
```