### PR TITLE
Respect gas limit config in eth_gasPrice endpoint

### DIFF
--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -45,6 +45,7 @@ type Dispatcher struct {
 	endpoints               endpoints
 	chainID                 uint64
 	jsonRPCBatchLengthLimit uint64
+	priceLimit              uint64
 }
 
 func newDispatcher(
@@ -53,11 +54,13 @@ func newDispatcher(
 	chainID uint64,
 	jsonRPCBatchLengthLimit uint64,
 	blockRangeLimit uint64,
+	priceLimit uint64,
 ) *Dispatcher {
 	d := &Dispatcher{
 		logger:                  logger.Named("dispatcher"),
 		chainID:                 chainID,
 		jsonRPCBatchLengthLimit: jsonRPCBatchLengthLimit,
+		priceLimit:              priceLimit,
 	}
 
 	if store != nil {
@@ -71,7 +74,13 @@ func newDispatcher(
 }
 
 func (d *Dispatcher) registerEndpoints(store JSONRPCStore) {
-	d.endpoints.Eth = &Eth{d.logger, store, d.chainID, d.filterManager}
+	d.endpoints.Eth = &Eth{
+		logger:        d.logger,
+		store:         store,
+		chainID:       d.chainID,
+		filterManager: d.filterManager,
+		priceLimit:    d.priceLimit,
+	}
 	d.endpoints.Net = &Net{store, d.chainID}
 	d.endpoints.Web3 = &Web3{}
 	d.endpoints.TxPool = &TxPool{store}

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -58,7 +58,7 @@ func expectBatchJSONResult(data []byte, v interface{}) error {
 func TestDispatcher_HandleWebsocketConnection_EthSubscribe(t *testing.T) {
 	t.Run("clients should be able to receive \"newHeads\" event thru eth_subscribe", func(t *testing.T) {
 		store := newMockStore()
-		dispatcher := newDispatcher(hclog.NewNullLogger(), store, 0, 0, 0)
+		dispatcher := newDispatcher(hclog.NewNullLogger(), store, 0, 0, 0, 0)
 
 		mockConnection := &mockWsConn{
 			msgCh: make(chan []byte, 1),
@@ -92,7 +92,7 @@ func TestDispatcher_HandleWebsocketConnection_EthSubscribe(t *testing.T) {
 
 func TestDispatcher_WebsocketConnection_RequestFormats(t *testing.T) {
 	store := newMockStore()
-	dispatcher := newDispatcher(hclog.NewNullLogger(), store, 0, 0, 0)
+	dispatcher := newDispatcher(hclog.NewNullLogger(), store, 0, 0, 0, 0)
 
 	mockConnection := &mockWsConn{
 		msgCh: make(chan []byte, 1),
@@ -196,7 +196,7 @@ func (m *mockService) Filter(f LogQuery) (interface{}, error) {
 func TestDispatcherFuncDecode(t *testing.T) {
 	srv := &mockService{msgCh: make(chan interface{}, 10)}
 
-	dispatcher := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0)
+	dispatcher := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0, 0)
 	dispatcher.registerService("mock", srv)
 
 	handleReq := func(typ string, msg string) interface{} {
@@ -278,7 +278,7 @@ func TestDispatcherBatchRequest(t *testing.T) {
 		{
 			"leading-whitespace",
 			"test with leading whitespace (\"  \\t\\n\\n\\r\\)",
-			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0),
+			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0, 0),
 			append([]byte{0x20, 0x20, 0x09, 0x0A, 0x0A, 0x0D}, []byte(`[
 				{"id":1,"jsonrpc":"2.0","method":"eth_getBalance","params":["0x1", true]},
                 {"id":2,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x2", true]},
@@ -294,7 +294,7 @@ func TestDispatcherBatchRequest(t *testing.T) {
 		{
 			"valid-batch-req",
 			"test with batch req length within batchRequestLengthLimit",
-			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0),
+			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0, 0),
 			[]byte(`[
 				{"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
                 {"id":2,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
@@ -314,7 +314,7 @@ func TestDispatcherBatchRequest(t *testing.T) {
 		{
 			"invalid-batch-req",
 			"test with batch req length exceeding batchRequestLengthLimit",
-			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 3, 1000),
+			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 3, 1000, 0),
 			[]byte(`[
                 {"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
                 {"id":2,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
@@ -328,7 +328,7 @@ func TestDispatcherBatchRequest(t *testing.T) {
 		{
 			"no-limits",
 			"test when limits are not set",
-			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0),
+			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0, 0),
 			[]byte(`[
                 {"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
                 {"id":2,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -79,6 +79,7 @@ type Eth struct {
 	store         ethStore
 	chainID       uint64
 	filterManager *FilterManager
+	priceLimit    uint64
 }
 
 var (
@@ -435,7 +436,12 @@ func (e *Eth) GetStorageAt(
 func (e *Eth) GasPrice() (interface{}, error) {
 	// var avgGasPrice string
 	// Grab the average gas price and convert it to a hex value
+	priceLimit := new(big.Int).SetUint64(e.priceLimit)
 	minGasPrice, _ := new(big.Int).SetString(defaultMinGasPrice, 0)
+
+	if priceLimit.Cmp(minGasPrice) == -1 {
+		priceLimit = minGasPrice
+	}
 
 	// if e.store.GetAvgGasPrice().Cmp(minGasPrice) == -1 {
 	// 	avgGasPrice = hex.EncodeBig(minGasPrice)
@@ -445,7 +451,7 @@ func (e *Eth) GasPrice() (interface{}, error) {
 
 	// return avgGasPrice, nil
 
-	return hex.EncodeBig(minGasPrice), nil
+	return hex.EncodeBig(priceLimit), nil
 }
 
 // Call executes a smart contract call using the transaction object data

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -223,5 +223,5 @@ func TestEth_GetNextNonce(t *testing.T) {
 }
 
 func newTestEthEndpoint(store ethStore) *Eth {
-	return &Eth{hclog.NewNullLogger(), store, 100, nil}
+	return &Eth{hclog.NewNullLogger(), store, 100, nil, 0}
 }

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -63,6 +63,7 @@ type Config struct {
 	BatchLengthLimit         uint64
 	BlockRangeLimit          uint64
 	EnableWS                 bool
+	PriceLimit               uint64
 }
 
 // NewJSONRPC returns the JSONRPC http server
@@ -70,8 +71,14 @@ func NewJSONRPC(logger hclog.Logger, config *Config) (*JSONRPC, error) {
 	srv := &JSONRPC{
 		logger: logger.Named("jsonrpc"),
 		config: config,
-		dispatcher: newDispatcher(logger, config.Store, config.ChainID,
-			config.BatchLengthLimit, config.BlockRangeLimit),
+		dispatcher: newDispatcher(
+			logger,
+			config.Store,
+			config.ChainID,
+			config.BatchLengthLimit,
+			config.BlockRangeLimit,
+			config.PriceLimit,
+		),
 	}
 
 	// start http server

--- a/jsonrpc/web3_endpoint_test.go
+++ b/jsonrpc/web3_endpoint_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestWeb3EndpointSha3(t *testing.T) {
-	dispatcher := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 20, 1000)
+	dispatcher := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 20, 1000, 0)
 
 	resp, err := dispatcher.Handle([]byte(`{
 		"method": "web3_sha3",
@@ -25,7 +25,7 @@ func TestWeb3EndpointSha3(t *testing.T) {
 }
 
 func TestWeb3EndpointClientVersion(t *testing.T) {
-	dispatcher := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 20, 1000)
+	dispatcher := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 20, 1000, 0)
 
 	resp, err := dispatcher.Handle([]byte(`{
 		"method": "web3_clientVersion",

--- a/server/server.go
+++ b/server/server.go
@@ -604,6 +604,7 @@ func (s *Server) setupJSONRPC() error {
 		BatchLengthLimit:         s.config.JSONRPC.BatchLengthLimit,
 		BlockRangeLimit:          s.config.JSONRPC.BlockRangeLimit,
 		EnableWS:                 s.config.JSONRPC.EnableWS,
+		PriceLimit:               s.config.PriceLimit,
 	}
 
 	srv, err := jsonrpc.NewJSONRPC(s.logger, conf)


### PR DESCRIPTION
# Description

The PR uses gas limit as the basic gas price in the `eth_gasPrice` endpoint.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually