### PR TITLE
[ibft] Get txpool transactions all at once when building block

### DIFF
--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -108,12 +108,15 @@ type transitionInterface interface {
 }
 
 func (d *Dev) writeTransactions(gasLimit uint64, transition transitionInterface) []*types.Transaction {
-	var successful []*types.Transaction
+	var includedTxs []*types.Transaction
 
-	d.txpool.Prepare()
+	// get all pending transactions once and for all
+	pendingTxs := d.txpool.Pending()
+	// get highest price transaction queue
+	priceTxs := types.NewTransactionsByPriceAndNonce(pendingTxs)
 
 	for {
-		tx := d.txpool.Pop()
+		tx := priceTxs.Peek()
 		if tx == nil {
 			d.logger.Debug("no more transactions")
 
@@ -121,48 +124,58 @@ func (d *Dev) writeTransactions(gasLimit uint64, transition transitionInterface)
 		}
 
 		if tx.ExceedsBlockGasLimit(gasLimit) {
+			// The address is punished. For current loop, it would not include its transactions any more.
 			d.txpool.Drop(tx)
+			priceTxs.Pop()
 
 			continue
 		}
 
 		if err := transition.Write(tx); err != nil {
-			d.logger.Debug("write transaction failed", "hash", tx.Hash, "from", tx.From,
-				"nonce", tx.Nonce, "err", err)
-
 			//nolint:errorlint
-			if _, ok := err.(*state.GasLimitReachedTransitionApplicationError); ok {
-				// Ignore those out-of-gas transaction whose gas limit too large
-			} else if _, ok := err.(*state.AllGasUsedError); ok {
+			if _, ok := err.(*state.AllGasUsedError); ok {
 				// no more transaction could be packed
+				d.logger.Debug("Not enough gas for further transactions")
+
 				break
+			} else if _, ok := err.(*state.GasLimitReachedTransitionApplicationError); ok {
+				// Ignore transaction when the free gas not enough
+				d.logger.Debug("Gas limit exceeded for current block", "from", tx.From)
+				priceTxs.Pop()
 			} else if nonceErr, ok := err.(*state.NonceTooLowError); ok {
-				// lower nonce tx, demote all promotable transactions
+				// low nonce tx, should reset accounts once done
+				d.logger.Warn("write transaction nonce too low",
+					"hash", tx.Hash, "from", tx.From, "nonce", tx.Nonce)
+				// skip the address, whose txs should be reset first.
 				d.txpool.DemoteAllPromoted(tx, nonceErr.CorrectNonce)
-				d.logger.Error("write transaction nonce too low", "hash", tx.Hash, "from", tx.From,
-					"nonce", tx.Nonce, "err", err)
+				priceTxs.Pop()
 			} else if nonceErr, ok := err.(*state.NonceTooHighError); ok {
-				// higher nonce tx, demote all promotable transactions
+				// high nonce tx, should reset accounts once done
+				d.logger.Error("write miss some transactions with higher nonce",
+					tx.Hash, "from", tx.From, "nonce", tx.Nonce)
 				d.txpool.DemoteAllPromoted(tx, nonceErr.CorrectNonce)
-				d.logger.Error("write miss some transactions with higher nonce", tx.Hash, "from", tx.From,
-					"nonce", tx.Nonce, "err", err)
+				priceTxs.Pop()
 			} else {
 				// no matter what kind of failure, drop is reasonable for not executed it yet
+				d.logger.Debug("write not executed transaction failed",
+					"hash", tx.Hash, "from", tx.From,
+					"nonce", tx.Nonce, "err", err)
 				d.txpool.Drop(tx)
+				priceTxs.Pop()
 			}
 
 			continue
 		}
 
-		// no errors, pop the tx from the pool
-		d.txpool.RemoveExecuted(tx)
+		// no errors, go on
+		priceTxs.Shift()
 
-		successful = append(successful, tx)
+		includedTxs = append(includedTxs, tx)
 	}
 
-	d.logger.Info("picked out txns from pool", "num", len(successful), "remaining", d.txpool.Length())
+	d.logger.Info("picked out txns from pool", "num", len(includedTxs))
 
-	return successful
+	return includedTxs
 }
 
 // writeNewBLock generates a new block based on transactions from the pool,

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -1,6 +1,7 @@
 package txpool
 
 import (
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -199,6 +200,29 @@ func (m *accountsMap) pruneStaleEnqueuedTxs(outdateDuration time.Duration) []*ty
 	})
 
 	return pruned
+}
+
+// poolPendings returns all promoted nonce ascending transactions.
+func (m *accountsMap) poolPendings() map[types.Address][]*types.Transaction {
+	allPromoted := make(map[types.Address][]*types.Transaction)
+
+	m.Range(func(key, value interface{}) bool {
+		addr, _ := key.(types.Address)
+		account := m.get(addr)
+
+		account.promoted.lock(false)
+		defer account.promoted.unlock()
+
+		if account.promoted.length() != 0 {
+			allPromoted[addr] = account.promoted.Transactions()
+		}
+
+		sort.Stable(types.PoolTxByNonce(allPromoted[addr]))
+
+		return true
+	})
+
+	return allPromoted
 }
 
 // An account is the core structure for processing

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -206,7 +206,7 @@ func (m *accountsMap) pruneStaleEnqueuedTxs(outdateDuration time.Duration) []*ty
 func (m *accountsMap) poolPendings() map[types.Address][]*types.Transaction {
 	allPromoted := make(map[types.Address][]*types.Transaction)
 
-	m.Range(func(key, value interface{}) bool {
+	m.cmap.Range(func(key, value interface{}) bool {
 		addr, _ := key.(types.Address)
 		account := m.get(addr)
 

--- a/txpool/query.go
+++ b/txpool/query.go
@@ -1,6 +1,8 @@
 package txpool
 
-import "github.com/dogechain-lab/dogechain/types"
+import (
+	"github.com/dogechain-lab/dogechain/types"
+)
 
 /* QUERY methods */
 // Used to query the pool for specific state info.
@@ -45,4 +47,8 @@ func (p *TxPool) GetTxs(inclQueued bool) (
 	allPromoted, allEnqueued = p.accounts.allTxs(inclQueued)
 
 	return
+}
+
+func (p *TxPool) Pending() map[types.Address][]*types.Transaction {
+	return p.accounts.poolPendings()
 }

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -693,6 +693,10 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 		return ErrAlreadyKnown
 	}
 
+	if tx.ReceivedTime.IsZero() {
+		tx.ReceivedTime = time.Now() // mark the tx received time
+	}
+
 	// initialize account for this address once
 	if !p.accounts.exists(tx.From) {
 		p.createAccountOnce(tx.From)

--- a/types/rlp_unmarshal_storage.go
+++ b/types/rlp_unmarshal_storage.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/dogechain-lab/fastrlp"
 )
@@ -81,6 +82,9 @@ func (t *Transaction) UnmarshalStoreRLPFrom(p *fastrlp.Parser, v *fastrlp.Value)
 	if err = elems[1].GetAddr(t.From[:]); err != nil {
 		return err
 	}
+
+	// resolve its receive time
+	t.ReceivedTime = time.Now()
 
 	return nil
 }

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -3,6 +3,7 @@ package types
 import (
 	"math/big"
 	"sync/atomic"
+	"time"
 
 	"github.com/dogechain-lab/dogechain/helper/keccak"
 )
@@ -22,6 +23,9 @@ type Transaction struct {
 
 	// Cache
 	size atomic.Value
+
+	// time at which the node received the tx
+	ReceivedTime time.Time
 }
 
 func (t *Transaction) IsContractCreation() bool {
@@ -82,6 +86,8 @@ func (t *Transaction) Copy() *Transaction {
 	if t.S != nil {
 		tt.S = new(big.Int).SetBits(t.S.Bits())
 	}
+
+	tt.ReceivedTime = t.ReceivedTime
 
 	return tt
 }

--- a/types/transaction_test.go
+++ b/types/transaction_test.go
@@ -40,6 +40,7 @@ func TestTransactionTimeSort(t *testing.T) {
 
 	// Generate a batch of transactions with overlapping prices, but different creation times
 	groups := map[Address][]*Transaction{}
+
 	for start, addr := range addrs {
 		// no sign, not matter in test
 		tx := &Transaction{
@@ -61,6 +62,7 @@ func TestTransactionTimeSort(t *testing.T) {
 
 	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {
 		txs = append(txs, tx)
+
 		txset.Shift()
 	}
 
@@ -70,6 +72,7 @@ func TestTransactionTimeSort(t *testing.T) {
 
 	for i, txi := range txs {
 		fromi := txi.From
+
 		if i+1 < len(txs) {
 			next := txs[i+1]
 			fromNext := next.From

--- a/types/transaction_test.go
+++ b/types/transaction_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestTransactionCopy(t *testing.T) {
@@ -23,5 +24,65 @@ func TestTransactionCopy(t *testing.T) {
 
 	if !reflect.DeepEqual(txn, newTxn) {
 		t.Fatal("[ERROR] Copied transaction not equal base transaction")
+	}
+}
+
+// Tests that if multiple transactions have the same price, the ones seen earlier
+// are prioritized to avoid network spam attacks aiming for a specific ordering.
+func TestTransactionTimeSort(t *testing.T) {
+	addrs := []Address{
+		StringToAddress("0x1"),
+		StringToAddress("0x2"),
+		StringToAddress("0x3"),
+		StringToAddress("0x4"),
+		StringToAddress("0x5"),
+	}
+
+	// Generate a batch of transactions with overlapping prices, but different creation times
+	groups := map[Address][]*Transaction{}
+	for start, addr := range addrs {
+		// no sign, not matter in test
+		tx := &Transaction{
+			Nonce:        0,
+			To:           &ZeroAddress,
+			Value:        big.NewInt(100),
+			Gas:          100,
+			GasPrice:     big.NewInt(1),
+			From:         addr,
+			ReceivedTime: time.Unix(0, int64(len(addrs)-start)),
+		}
+
+		groups[addr] = append(groups[addr], tx)
+	}
+	// Sort the transactions and cross check the nonce ordering
+	txset := NewTransactionsByPriceAndNonce(groups)
+
+	txs := []*Transaction{}
+
+	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {
+		txs = append(txs, tx)
+		txset.Shift()
+	}
+
+	if len(txs) != len(addrs) {
+		t.Errorf("expected %d transactions, found %d", len(addrs), len(txs))
+	}
+
+	for i, txi := range txs {
+		fromi := txi.From
+		if i+1 < len(txs) {
+			next := txs[i+1]
+			fromNext := next.From
+
+			if txi.GasPrice.Cmp(next.GasPrice) < 0 {
+				t.Errorf("invalid gasprice ordering: tx #%d (A=%x P=%v) < tx #%d (A=%x P=%v)",
+					i, fromi[:4], txi.GasPrice, i+1, fromNext[:4], next.GasPrice)
+			}
+			// Make sure time order is ascending if the txs have the same gas price
+			if txi.GasPrice.Cmp(next.GasPrice) == 0 && txi.ReceivedTime.After(next.ReceivedTime) {
+				t.Errorf("invalid received time ordering: tx #%d (A=%x T=%v) > tx #%d (A=%x T=%v)",
+					i, fromi[:4], txi.ReceivedTime, i+1, fromNext[:4], next.ReceivedTime)
+			}
+		}
 	}
 }


### PR DESCRIPTION
# Description

The `txpool` prepare, push and pop transactions to hundreds of thousands heaps, it would be bad performance when the active accounts are huge amount (e.g. 100 kilo).

Besides, it is a bad pattern that the `ibft` module knew too much details of the `txpool`.

The idea was heavily inspired by the [go-ethereum](https://github.com/ethereum/go-ethereum) and [harmony](https://github.com/harmony-one/harmony).

The PR :
* Removes the 'demote' flags of the `server` command.
  * Whose function causes transactions to be discarded irreversibly.
* Reduces the interface exposure of `txpool`.
  * Supply more capsuled interface.
* Get transactions only once when building block in `ibft` module.
    * Use only one heap, maximum its performance.
    * The heap is sorted in price, and received time.
    * The transaction queues are nonce sorted in slice.
    * Would not insert new transactions, which is unnecessary when the block generation time is very short.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

#### 1 node pprof test

* Set up a pos mode server with `pprof` flag set.
* Send huge amount transactions of different accounts using some tool.
* Check cpu usage and heatmap.

The node should perform OK in this branch, and yields bad performance in the target branch.

#### 4 nodes network test

Not done yet.

# Documentation update

Will update documentation once it merged.
