### PR TITLE
replace time.After to time.NewTimer

### DIFF
--- a/blockchain/subscription_test.go
+++ b/blockchain/subscription_test.go
@@ -34,13 +34,15 @@ func TestSubscriptionLinear(t *testing.T) {
 		evnt.AddNewHeader(&types.Header{Number: uint64(i)})
 		e.push(evnt)
 
+		timeoutDelay := time.NewTimer(1 * time.Second)
+
 		// it should fire updateCh
 		select {
 		case evnt := <-eventCh:
 			if evnt.NewChain[0].Number != uint64(i) {
 				t.Fatal("bad")
 			}
-		case <-time.After(1 * time.Second):
+		case <-timeoutDelay.C:
 			t.Fatal("timeout")
 		}
 	}

--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -68,10 +68,12 @@ func HandleSignals(
 		close(gracefulCh)
 	}()
 
+	timeoutDelay := time.NewTimer(5 * time.Second)
+
 	select {
 	case <-signalCh:
 		return errors.New("shutdown by signal channel")
-	case <-time.After(5 * time.Second):
+	case <-timeoutDelay.C:
 		return errors.New("shutdown by timeout")
 	case <-gracefulCh:
 		return nil

--- a/consensus/dev/dev.go
+++ b/consensus/dev/dev.go
@@ -74,8 +74,10 @@ func (d *Dev) nextNotify() chan struct{} {
 		d.interval = 1
 	}
 
+	delay := time.NewTimer(time.Duration(d.interval) * time.Second)
+
 	go func() {
-		<-time.After(time.Duration(d.interval) * time.Second)
+		<-delay.C
 		d.notifyCh <- struct{}{}
 	}()
 

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -825,8 +825,10 @@ func (i *Ibft) runAcceptState() { // start new round
 			// calculate how much time do we have to wait to mine the block
 			delay := time.Until(time.Unix(int64(i.state.block.Header.Timestamp), 0))
 
+			delayTimer := time.NewTimer(delay)
+
 			select {
-			case <-time.After(delay):
+			case <-delayTimer.C:
 			case <-i.closeCh:
 				return
 			}
@@ -1435,7 +1437,7 @@ func (i *Ibft) Close() error {
 
 // getNextMessage reads a new message from the message queue
 func (i *Ibft) getNextMessage(timeout time.Duration) (*proto.MessageReq, bool) {
-	timeoutCh := time.After(timeout)
+	timeoutCh := time.NewTimer(timeout)
 
 	for {
 		msg := i.msgQueue.readMessage(i.getState(), i.state.view)
@@ -1452,7 +1454,7 @@ func (i *Ibft) getNextMessage(timeout time.Duration) (*proto.MessageReq, bool) {
 		// wait until there is a new message or
 		// someone closes the stopCh (i.e. timeout for round change)
 		select {
-		case <-timeoutCh:
+		case <-timeoutCh.C:
 			i.logger.Info("unable to read new message from the message queue", "timeout expired", timeout)
 
 			return nil, true

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -873,10 +873,10 @@ func TestRunSyncState_NewHeadReceivedFromPeer_CallsTxPoolResetWithHeaders(t *tes
 	m.txpool = mockTxPool
 
 	// we need to change state from Sync in order to break from the loop inside runSyncState
-	stateChangeDelay := time.After(100 * time.Millisecond)
+	stateChangeDelay := time.NewTimer(100 * time.Millisecond)
 
 	go func() {
-		<-stateChangeDelay
+		<-stateChangeDelay.C
 		m.setState(AcceptState)
 	}()
 
@@ -904,10 +904,10 @@ func TestRunSyncState_BulkSyncWithPeer_CallsTxPoolResetWithHeaders(t *testing.T)
 	m.txpool = mockTxPool
 
 	// we need to change state from Sync in order to break from the loop inside runSyncState
-	stateChangeDelay := time.After(100 * time.Millisecond)
+	stateChangeDelay := time.NewTimer(100 * time.Millisecond)
 
 	go func() {
-		<-stateChangeDelay
+		<-stateChangeDelay.C
 		m.setState(AcceptState)
 	}()
 
@@ -949,10 +949,10 @@ func TestRunSyncState_Unlock_After_Sync(t *testing.T) {
 	m.txpool = &mockTxPool{}
 
 	// we need to change state from Sync in order to break from the loop inside runSyncState
-	stateChangeDelay := time.After(100 * time.Millisecond)
+	stateChangeDelay := time.NewTimer(100 * time.Millisecond)
 
 	go func() {
-		<-stateChangeDelay
+		<-stateChangeDelay.C
 		m.setState(AcceptState)
 	}()
 

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -82,9 +82,11 @@ func TestDispatcher_HandleWebsocketConnection_EthSubscribe(t *testing.T) {
 			},
 		})
 
+		delayTimer := time.NewTimer(2 * time.Second)
+
 		select {
 		case <-mockConnection.msgCh:
-		case <-time.After(2 * time.Second):
+		case <-delayTimer.C:
 			t.Fatal("\"newHeads\" event not received in 2 seconds")
 		}
 	})

--- a/network/dial/dial_queue_test.go
+++ b/network/dial/dial_queue_test.go
@@ -36,19 +36,26 @@ func TestDialQueue(t *testing.T) {
 		done <- struct{}{}
 	}()
 
-	// we should not get any peer now
-	select {
-	case <-done:
-		t.Fatal("not expected")
-	case <-time.After(1 * time.Second):
+	{
+		delay := time.NewTimer(1 * time.Second)
+		// we should not get any peer now
+		select {
+		case <-done:
+			t.Fatal("not expected")
+		case <-delay.C:
+		}
 	}
 
 	q.AddTask(info0, 1)
 
-	select {
-	case <-done:
-	case <-time.After(1 * time.Second):
-		t.Fatal("timeout")
+	{
+		delay := time.NewTimer(1 * time.Second)
+
+		select {
+		case <-done:
+		case <-delay.C:
+			t.Fatal("timeout")
+		}
 	}
 }
 

--- a/network/gossip_test.go
+++ b/network/gossip_test.go
@@ -19,10 +19,13 @@ func WaitForSubscribers(ctx context.Context, srv *Server, topic string, expected
 		if n := NumSubscribers(srv, topic); n >= expectedNumPeers {
 			return nil
 		}
+
+		delay := time.NewTimer(100 * time.Millisecond)
+
 		select {
 		case <-ctx.Done():
 			return errors.New("canceled")
-		case <-time.After(100 * time.Millisecond):
+		case <-delay.C:
 			continue
 		}
 	}
@@ -93,8 +96,10 @@ func TestSimpleGossip(t *testing.T) {
 	messagesGossiped := 0
 
 	for {
+		delay := time.NewTimer(15 * time.Second)
+
 		select {
-		case <-time.After(time.Second * 15):
+		case <-delay.C:
 			t.Fatalf("Gossip messages not received before timeout")
 		case message := <-messageCh:
 			if message.Message == sentMessage {

--- a/network/server.go
+++ b/network/server.go
@@ -323,8 +323,10 @@ func (s *Server) setupBootnodes() error {
 
 // checkPeerCount will attempt to make new connections if the active peer count is lesser than the specified limit.
 func (s *Server) checkPeerConnections() {
+	delay := time.NewTimer(10 * time.Second)
+
 	for {
-		delay := time.NewTimer(10 * time.Second)
+		delay.Reset(10 * time.Second)
 
 		select {
 		case <-delay.C:

--- a/network/server.go
+++ b/network/server.go
@@ -324,8 +324,10 @@ func (s *Server) setupBootnodes() error {
 // checkPeerCount will attempt to make new connections if the active peer count is lesser than the specified limit.
 func (s *Server) checkPeerConnections() {
 	for {
+		delay := time.NewTimer(10 * time.Second)
+
 		select {
-		case <-time.After(10 * time.Second):
+		case <-delay.C:
 		case <-s.closeCh:
 			return
 		}

--- a/protocol/sync_peer.go
+++ b/protocol/sync_peer.go
@@ -117,7 +117,7 @@ func (s *SyncPeer) purgeBlocks(lastSeen types.Hash) uint64 {
 
 // popBlock pops a block from the block queue [BLOCKING]
 func (s *SyncPeer) popBlock(timeout time.Duration) (b *types.Block, err error) {
-	timeoutCh := time.After(timeout)
+	timeoutCh := time.NewTimer(timeout)
 
 	for {
 		if !s.IsClosed() {
@@ -132,7 +132,7 @@ func (s *SyncPeer) popBlock(timeout time.Duration) (b *types.Block, err error) {
 			s.enqueueLock.Unlock()
 			select {
 			case <-s.enqueueCh:
-			case <-timeoutCh:
+			case <-timeoutCh.C:
 				return nil, ErrPopTimeout
 			}
 		} else {

--- a/protocol/testing.go
+++ b/protocol/testing.go
@@ -205,10 +205,12 @@ func TryPopBlock(t *testing.T, syncer *Syncer, peerID peer.ID, timeout time.Dura
 		}
 	}()
 
+	delay := time.NewTimer(timeout)
+
 	select {
 	case block := <-blockCh:
 		return block, true
-	case <-time.After(timeout):
+	case <-delay.C:
 		return nil, false
 	}
 }

--- a/txpool/event_manager_test.go
+++ b/txpool/event_manager_test.go
@@ -112,6 +112,8 @@ func TestEventManager_SignalEvent(t *testing.T) {
 
 	completed := false
 	for !completed {
+		delay := time.NewTimer(5 * time.Second)
+
 		select {
 		case event := <-subscription.subscriptionChannel:
 			eventsProcessed++
@@ -124,7 +126,7 @@ func TestEventManager_SignalEvent(t *testing.T) {
 				supportedEventsProcessed == validEvents {
 				completed = true
 			}
-		case <-time.After(time.Second * 5):
+		case <-delay.C:
 			completed = true
 		}
 	}
@@ -157,6 +159,8 @@ func TestEventManager_SignalEventOrder(t *testing.T) {
 
 	wg.Add(totalEvents)
 
+	timeoutDelay := time.NewTimer(5 * time.Second)
+
 	go func() {
 		for {
 			select {
@@ -168,7 +172,7 @@ func TestEventManager_SignalEventOrder(t *testing.T) {
 
 					wg.Done()
 				}
-			case <-time.After(time.Second * 5):
+			case <-timeoutDelay.C:
 				for i := 0; i < totalEvents-eventsProcessed; i++ {
 					wg.Done()
 				}

--- a/txpool/event_manager_test.go
+++ b/txpool/event_manager_test.go
@@ -111,8 +111,10 @@ func TestEventManager_SignalEvent(t *testing.T) {
 	supportedEventsProcessed := 0
 
 	completed := false
+	delay := time.NewTimer(5 * time.Second)
+
 	for !completed {
-		delay := time.NewTimer(5 * time.Second)
+		delay.Reset(5 * time.Second)
 
 		select {
 		case event := <-subscription.subscriptionChannel:


### PR DESCRIPTION
# Description

`time.After` exist memory leak

![photo_2022-09-21_11-20-14](https://user-images.githubusercontent.com/111933059/191407033-43181488-3603-464f-a8e2-38e3be07a893.jpg)


# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

create pprof file 

```shell
$ go test -coverprofile coverage.out -timeout 28m -memprofile mem.pprof ./txpool
```
analysis pprof file 

```shell
$ go tool pprof -http 0.0.0.0:8080 -no_browser mem.pprof
```

browser open  http://0.0.0.0:8080


