### PR TITLE
Stop server elegantly instead of panic when db closed

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -92,6 +92,7 @@ type Verifier interface {
 	PreStateCommit(header *types.Header, txn *state.Transition) error
 }
 
+//nolint:lll
 type Executor interface {
 	ProcessBlock(parentRoot types.Hash, block *types.Block, blockCreator types.Address, stop *bool) (*state.Transition, error)
 }

--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -290,6 +290,7 @@ func (m *mockExecutor) ProcessBlock(
 	parentRoot types.Hash,
 	block *types.Block,
 	blockCreator types.Address,
+	stop *bool,
 ) (*state.Transition, error) {
 	if m.processBlockFn != nil {
 		return m.processBlockFn(parentRoot, block, blockCreator)

--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -290,13 +290,16 @@ func (m *mockExecutor) ProcessBlock(
 	parentRoot types.Hash,
 	block *types.Block,
 	blockCreator types.Address,
-	stop *bool,
 ) (*state.Transition, error) {
 	if m.processBlockFn != nil {
 		return m.processBlockFn(parentRoot, block, blockCreator)
 	}
 
 	return nil, nil
+}
+
+func (m *mockExecutor) Stop() {
+	// do nothing
 }
 
 func (m *mockExecutor) HookProcessBlock(fn processBlockDelegate) {

--- a/e2e/framework/config.go
+++ b/e2e/framework/config.go
@@ -51,6 +51,7 @@ type TestServerConfig struct {
 	BridgeSigners  []types.Address      // bridge contract signers
 	IsWSEnable     bool                 // enable websocket or not
 	RestoreFile    string               // blockchain restore file
+	BlockTime      uint64               // minimum block generation time (in s)
 }
 
 // DataDir returns path of data directory server uses
@@ -174,4 +175,8 @@ func (t *TestServerConfig) EnableWebSocket() {
 
 func (t *TestServerConfig) SetRestoreFile(path string) {
 	t.RestoreFile = path
+}
+
+func (t *TestServerConfig) SetBlockTime(blockTime uint64) {
+	t.BlockTime = blockTime
 }

--- a/e2e/framework/config.go
+++ b/e2e/framework/config.go
@@ -36,22 +36,23 @@ type TestServerConfig struct {
 	PremineAccts            []*SrvAccount // Accounts with existing balances (genesis accounts)
 	GenesisValidatorBalance *big.Int      // Genesis the balance for the validators
 	// List of initial staking addresses for the ValidatorSet SC with dev consensus
-	DevStakers     []types.Address
-	Consensus      ConsensusType        // Consensus MechanismType
-	Bootnodes      []string             // Bootnode Addresses
-	PriceLimit     *uint64              // Minimum gas price limit to enforce for acceptance into the pool
-	DevInterval    int                  // Dev consensus update interval [s]
-	EpochSize      uint64               // The epoch size in blocks for the IBFT layer
-	BlockGasLimit  uint64               // Block gas limit
-	BlockGasTarget uint64               // Gas target for new blocks
-	ShowsLog       bool                 // Flag specifying if logs are shown
-	IsPos          bool                 // Specifies the mechanism used for IBFT (PoA / PoS)
-	Signer         *crypto.EIP155Signer // Signer used for transactions
-	BridgeOwner    types.Address        // bridge contract owner
-	BridgeSigners  []types.Address      // bridge contract signers
-	IsWSEnable     bool                 // enable websocket or not
-	RestoreFile    string               // blockchain restore file
-	BlockTime      uint64               // minimum block generation time (in s)
+	DevStakers        []types.Address
+	Consensus         ConsensusType        // Consensus MechanismType
+	Bootnodes         []string             // Bootnode Addresses
+	PriceLimit        *uint64              // Minimum gas price limit to enforce for acceptance into the pool
+	DevInterval       int                  // Dev consensus update interval [s]
+	EpochSize         uint64               // The epoch size in blocks for the IBFT layer
+	BlockGasLimit     uint64               // Block gas limit
+	BlockGasTarget    uint64               // Gas target for new blocks
+	ShowsLog          bool                 // Flag specifying if logs are shown
+	IsPos             bool                 // Specifies the mechanism used for IBFT (PoA / PoS)
+	Signer            *crypto.EIP155Signer // Signer used for transactions
+	ValidatorSetOwner types.Address        // validatorset contract owner
+	BridgeOwner       types.Address        // bridge contract owner
+	BridgeSigners     []types.Address      // bridge contract signers
+	IsWSEnable        bool                 // enable websocket or not
+	RestoreFile       string               // blockchain restore file
+	BlockTime         uint64               // minimum block generation time (in s)
 }
 
 // DataDir returns path of data directory server uses
@@ -159,6 +160,10 @@ func (t *TestServerConfig) SetShowsLog(f bool) {
 // It controls the rate at which the validator set is updated
 func (t *TestServerConfig) SetEpochSize(epochSize uint64) {
 	t.EpochSize = epochSize
+}
+
+func (t *TestServerConfig) SetValidatorSetOwner(owner types.Address) {
+	t.ValidatorSetOwner = owner
 }
 
 func (t *TestServerConfig) SetBridgeOwner(owner types.Address) {

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -30,6 +30,10 @@ import (
 	empty "google.golang.org/protobuf/types/known/emptypb"
 )
 
+var (
+	DefaultTimeout = time.Minute
+)
+
 func EthToWei(ethValue int64) *big.Int {
 	return EthToWeiPrecise(ethValue, 18)
 }

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -437,6 +437,7 @@ func NewTestServers(t *testing.T, num int, conf func(*TestServerConfig)) []*Test
 		srv := NewTestServer(t, dataDir, conf)
 		srv.Config.SetBootnodes(bootnodes)
 		// do not forget to set the must options
+		srv.Config.SetValidatorSetOwner(owner)
 		srv.Config.SetBridgeOwner(owner)
 		srv.Config.SetBridgeSigners(signers)
 

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -437,7 +437,6 @@ func NewTestServers(t *testing.T, num int, conf func(*TestServerConfig)) []*Test
 		srv := NewTestServer(t, dataDir, conf)
 		srv.Config.SetBootnodes(bootnodes)
 		// do not forget to set the must options
-		srv.Config.SetValidatorSetOwner(owner)
 		srv.Config.SetBridgeOwner(owner)
 		srv.Config.SetBridgeSigners(signers)
 

--- a/e2e/framework/ibft.go
+++ b/e2e/framework/ibft.go
@@ -83,14 +83,16 @@ func NewIBFTServersManager(
 }
 
 func (m *IBFTServersManager) StartServers(ctx context.Context) {
-	for _, srv := range m.servers {
+	for i, srv := range m.servers {
 		if err := srv.Start(ctx); err != nil {
+			m.t.Logf("server %d failed to start: %+v", i, err)
 			m.t.Fatal(err)
 		}
 	}
 
-	for _, srv := range m.servers {
+	for i, srv := range m.servers {
 		if err := srv.WaitForReady(ctx); err != nil {
+			m.t.Logf("server %d couldn't advance block: %+v", i, err)
 			m.t.Fatal(err)
 		}
 	}

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -302,6 +302,11 @@ func (t *TestServer) GenerateGenesis() error {
 	blockGasLimit := strconv.FormatUint(t.Config.BlockGasLimit, 10)
 	args = append(args, "--block-gas-limit", blockGasLimit)
 
+	// add validatorset contract owner
+	if t.Config.ValidatorSetOwner != types.ZeroAddress {
+		args = append(args, "--validatorset-owner", t.Config.ValidatorSetOwner.String())
+	}
+
 	// add bridge contract owner
 	if t.Config.BridgeOwner != types.ZeroAddress {
 		args = append(args, "--bridge-owner", t.Config.BridgeOwner.String())

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -371,6 +371,11 @@ func (t *TestServer) Start(ctx context.Context) error {
 		args = append(args, "--block-gas-target", *types.EncodeUint64(t.Config.BlockGasTarget))
 	}
 
+	// block generation time, not dev consesus
+	if t.Config.BlockTime > 0 {
+		args = append(args, "--block-time", strconv.FormatUint(t.Config.BlockTime, 10))
+	}
+
 	t.ReleaseReservedPorts()
 
 	// Start the server

--- a/e2e/txpool_test.go
+++ b/e2e/txpool_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	"io"
 	"math/big"
 	"sync"
 	"testing"
@@ -18,7 +17,6 @@ import (
 	txpoolOp "github.com/dogechain-lab/dogechain/txpool/proto"
 	"github.com/dogechain-lab/dogechain/types"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/stretchr/testify/assert"
 	"github.com/umbracle/go-web3"
 )
@@ -27,36 +25,6 @@ var (
 	oneEth = framework.EthToWei(1)
 	signer = crypto.NewEIP155Signer(100)
 )
-
-func waitForBlock(t *testing.T, srv *framework.TestServer, expectedBlocks int, index int) int64 {
-	t.Helper()
-
-	systemClient := srv.Operator()
-	ctx, cancelFn := context.WithCancel(context.Background())
-	stream, err := systemClient.Subscribe(ctx, &empty.Empty{})
-
-	if err != nil {
-		cancelFn()
-		t.Fatalf("Unable to subscribe to blockchain events")
-	}
-
-	evnt, err := stream.Recv()
-	if errors.Is(err, io.EOF) {
-		t.Fatalf("Invalid stream close")
-	}
-
-	if err != nil {
-		t.Fatalf("Unable to read blockchain event")
-	}
-
-	if len(evnt.Added) != expectedBlocks {
-		t.Fatalf("Invalid number of blocks added")
-	}
-
-	cancelFn()
-
-	return evnt.Added[index].Number
-}
 
 type generateTxReqParams struct {
 	nonce         uint64
@@ -202,16 +170,22 @@ func TestTxPool_TransactionCoalescing(t *testing.T) {
 	referenceKey, referenceAddr := tests.GenerateKeyAndAddr(t)
 	defaultBalance := framework.EthToWei(10)
 
-	devInterval := 5
-
 	// Set up the test server
-	srvs := framework.NewTestServers(t, 1, func(config *framework.TestServerConfig) {
-		config.SetConsensus(framework.ConsensusDev)
-		config.SetSeal(true)
-		config.SetDevInterval(devInterval)
-		config.Premine(referenceAddr, defaultBalance)
-	})
-	srv := srvs[0]
+	ibftManager := framework.NewIBFTServersManager(
+		t,
+		1,
+		IBFTDirPrefix,
+		func(i int, config *framework.TestServerConfig) {
+			config.SetSeal(true)
+			config.Premine(referenceAddr, defaultBalance)
+			config.SetBlockTime(1)
+		})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	ibftManager.StartServers(ctx)
+
+	srv := ibftManager.GetServer(0)
 	client := srv.JSONRPC()
 
 	// Required default values
@@ -251,19 +225,44 @@ func TestTxPool_TransactionCoalescing(t *testing.T) {
 		return msg
 	}
 
+	// testTransaction is a helper structure for
+	// keeping track of test transaction execution
+	type testTransaction struct {
+		txHash web3.Hash // the transaction hash
+		block  *uint64   // the block the transaction was included in
+	}
+
+	testTransactions := make([]*testTransaction, 0)
+
 	// Add the transactions with the following nonce order
 	nonces := []uint64{0, 2}
 	for i := 0; i < len(nonces); i++ {
 		addReq := generateReq(nonces[i])
 
-		_, addErr := clt.AddTxn(context.Background(), addReq)
+		addCtx, addCtxCn := context.WithTimeout(context.Background(), framework.DefaultTimeout)
+
+		addResp, addErr := clt.AddTxn(addCtx, addReq)
 		if addErr != nil {
 			t.Fatalf("Unable to add txn, %v", addErr)
 		}
+
+		testTransactions = append(testTransactions, &testTransaction{
+			txHash: web3.HexToHash(addResp.TxHash),
+		})
+
+		addCtxCn()
 	}
 
-	// Wait for the state transition to be executed
-	_ = waitForBlock(t, srv, 1, 0)
+	// Wait for the first transaction to go through
+	ctx, cancelFn := context.WithTimeout(context.Background(), framework.DefaultTimeout)
+	defer cancelFn()
+
+	receipt, receiptErr := tests.WaitForReceipt(ctx, client.Eth(), testTransactions[0].txHash)
+	if receiptErr != nil {
+		t.Fatalf("unable to wait for receipt, %v", receiptErr)
+	}
+
+	testTransactions[0].block = &receipt.BlockNumber
 
 	// Get to account balance
 	// Only the first tx should've gone through
@@ -277,13 +276,32 @@ func TestTxPool_TransactionCoalescing(t *testing.T) {
 	// Add the transaction with the gap nonce value
 	addReq := generateReq(1)
 
-	_, addErr := clt.AddTxn(context.Background(), addReq)
+	addCtx, addCtxCn := context.WithTimeout(context.Background(), framework.DefaultTimeout)
+	defer addCtxCn()
+
+	addResp, addErr := clt.AddTxn(addCtx, addReq)
 	if addErr != nil {
 		t.Fatalf("Unable to add txn, %v", addErr)
 	}
 
-	// Wait for the state transition to be executed
-	_ = waitForBlock(t, srv, 1, 0)
+	testTransactions = append(testTransactions, &testTransaction{
+		txHash: web3.HexToHash(addResp.TxHash),
+	})
+
+	// Start from 1 since there was previously a txn with nonce 0
+	for i := 1; i < len(testTransactions); i++ {
+		// Wait for the first transaction to go through
+		ctx, cancelFn := context.WithTimeout(context.Background(), framework.DefaultTimeout)
+
+		receipt, receiptErr := tests.WaitForReceipt(ctx, client.Eth(), testTransactions[i].txHash)
+		if receiptErr != nil {
+			t.Fatalf("unable to wait for receipt, %v", receiptErr)
+		}
+
+		testTransactions[i].block = &receipt.BlockNumber
+
+		cancelFn()
+	}
 
 	// Now both the added tx and the shelved tx should've gone through
 	toAccountBalance = framework.GetAccountBalance(t, toAddress, client)
@@ -292,6 +310,9 @@ func TestTxPool_TransactionCoalescing(t *testing.T) {
 		toAccountBalance.String(),
 		"To address balance mismatch after gap transaction",
 	)
+
+	// Make sure the first transaction and the last transaction didn't get included in the same block
+	assert.NotEqual(t, *(testTransactions[0].block), *(testTransactions[2].block))
 }
 
 type testAccount struct {

--- a/network/server.go
+++ b/network/server.go
@@ -584,7 +584,7 @@ func (s *Server) Close() error {
 	err := s.host.Close()
 	s.dialQueue.Close()
 
-	if !s.config.NoDiscover {
+	if s.discovery != nil {
 		s.discovery.Close()
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -686,9 +686,9 @@ func (s *Server) JoinPeer(rawPeerMultiaddr string) error {
 
 // Close closes the Minimal server (blockchain, networking, consensus)
 func (s *Server) Close() {
-	// Close the blockchain layer
-	if err := s.blockchain.Close(); err != nil {
-		s.logger.Error("failed to close blockchain", "err", err.Error())
+	// Close the consensus layer
+	if err := s.consensus.Close(); err != nil {
+		s.logger.Error("failed to close consensus", "err", err.Error())
 	}
 
 	// Close the networking layer
@@ -696,9 +696,12 @@ func (s *Server) Close() {
 		s.logger.Error("failed to close networking", "err", err.Error())
 	}
 
-	// Close the consensus layer
-	if err := s.consensus.Close(); err != nil {
-		s.logger.Error("failed to close consensus", "err", err.Error())
+	// close the txpool's main loop
+	s.txpool.Close()
+
+	// Close the blockchain layer
+	if err := s.blockchain.Close(); err != nil {
+		s.logger.Error("failed to close blockchain", "err", err.Error())
 	}
 
 	// Close the state storage
@@ -711,9 +714,6 @@ func (s *Server) Close() {
 			s.logger.Error("Prometheus server shutdown error", err)
 		}
 	}
-
-	// close the txpool's main loop
-	s.txpool.Close()
 }
 
 // Entry is a backend configuration entry

--- a/state/executor.go
+++ b/state/executor.go
@@ -621,6 +621,15 @@ func (t *Transition) Call2(
 	value *big.Int,
 	gas uint64,
 ) *runtime.ExecutionResult {
+	code := t.state.GetCode(to)
+	if len(code) == 0 {
+		// might be caused by close db
+		t.logger.Info("transition Call2 stop due to empty code")
+
+		return &runtime.ExecutionResult{
+			Err: runtime.ErrCodeEmpty,
+		}
+	}
 	c := runtime.NewContractCall(1, caller, caller, to, value, gas, t.state.GetCode(to), input)
 
 	return t.applyCall(c, runtime.Call, t)

--- a/state/executor.go
+++ b/state/executor.go
@@ -637,6 +637,7 @@ func (t *Transition) Call2(
 			Err: runtime.ErrCodeEmpty,
 		}
 	}
+
 	c := runtime.NewContractCall(1, caller, caller, to, value, gas, t.state.GetCode(to), input)
 
 	return t.applyCall(c, runtime.Call, t)

--- a/state/immutable-trie/storage.go
+++ b/state/immutable-trie/storage.go
@@ -1,6 +1,7 @@
 package itrie
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/dogechain-lab/dogechain/helper/hex"
@@ -71,7 +72,9 @@ func (kv *KVStorage) Put(k, v []byte) {
 func (kv *KVStorage) Get(k []byte) ([]byte, bool) {
 	data, err := kv.db.Get(k, nil)
 	if err != nil {
-		if err.Error() == "leveldb: not found" {
+		if errors.Is(err, leveldb.ErrNotFound) {
+			return nil, false
+		} else if errors.Is(err, leveldb.ErrClosed) {
 			return nil, false
 		} else {
 			panic(err)

--- a/state/runtime/runtime.go
+++ b/state/runtime/runtime.go
@@ -107,6 +107,7 @@ var (
 	ErrDepth                    = errors.New("max call depth exceeded")
 	ErrExecutionReverted        = errors.New("execution was reverted")
 	ErrCodeStoreOutOfGas        = errors.New("contract creation code storage out of gas")
+	ErrCodeEmpty                = errors.New("contract code empty")
 )
 
 type CallType int

--- a/state/txn.go
+++ b/state/txn.go
@@ -420,7 +420,10 @@ func (txn *Txn) GetCode(addr types.Address) []byte {
 	}
 
 	code, _ := txn.state.GetCode(types.BytesToHash(object.Account.CodeHash))
-	txn.codeCache.Add(addr, code)
+	if len(code) > 0 {
+		// code might be empty when closed
+		txn.codeCache.Add(addr, code)
+	}
 
 	return code
 }


### PR DESCRIPTION
# Description

The close sequence was not appropriate. It closed the db first, which might be processing block written job. Then close network, etc.

This PR 
* Close consensus, network and txpool first, then stop blockchain executor processing block before close the db.
* Removes the `panic` logic when closed.
* Adds some nil check if we get empty code of a contract address.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

* Set up a MainNet node and join the network.
* Stop the server when syncing block. Repeat it several times.

In target branch, we'll get some logs below, which would never happen in the PR branch:

```
[SIGNAL] Caught signal: interrupt
Gracefully shutting down client...

panic: leveldb: closed

goroutine 157 [running]:
github.com/dogechain-lab/dogechain/state/immutable-trie.(*KVStorage).Get(0x0, {0xc042fb5600, 0xc047fda710, 0xc040e80580})
	/go/src/state/immutable-trie/storage.go:77 +0x96
github.com/dogechain-lab/dogechain/state/immutable-trie.GetNode({0xc042fb5600, 0x41473e5, 0xc047fda7c8}, {0x58acee8, 0xc000588380})
	/go/src/state/immutable-trie/storage.go:155 +0x88
github.com/dogechain-lab/dogechain/state/immutable-trie.(*Txn).lookup(0xc047fdaa60, {0x50a3680, 0xc040e80500}, {0xc0387666e3, 0xc0077bfec0, 0xc000588380})
	/go/src/state/immutable-trie/trie.go:274 +0x1c8
github.com/dogechain-lab/dogechain/state/immutable-trie.(*Txn).lookup(0xc047fdaa60, {0x512dfa0, 0xc0408c88c0}, {0xc0387666e2, 0xc000588380, 0x8})
	/go/src/state/immutable-trie/trie.go:313 +0x2ea
github.com/dogechain-lab/dogechain/state/immutable-trie.(*Txn).lookup(0xc047fdaa60, {0x50a3680, 0xc03d68f560}, {0xc0387666e2, 0x400dd94, 0x0})
	/go/src/state/immutable-trie/trie.go:283 +0x212
github.com/dogechain-lab/dogechain/state/immutable-trie.(*Txn).lookup(0xc047fdaa60, {0x512dfa0, 0xc0500a37c0}, {0xc0387666e1, 0x404ef32, 0x41})
	/go/src/state/immutable-trie/trie.go:313 +0x2ea
github.com/dogechain-lab/dogechain/state/immutable-trie.(*Txn).lookup(0xc047fdaa60, {0x512dfa0, 0xc03d212640}, {0xc0387666e0, 0x10100c047fdaa50, 0x32399218})
	/go/src/state/immutable-trie/trie.go:313 +0x2ea
github.com/dogechain-lab/dogechain/state/immutable-trie.(*Txn).Lookup(0xc047fdaa60, {0xc042fb5560, 0xc00006ed80, 0xc042fb5560})
	/go/src/state/immutable-trie/trie.go:262 +0x5b
github.com/dogechain-lab/dogechain/state/immutable-trie.(*Trie).Get(0xc00edf6b48, {0xc042fb5560, 0x413e370, 0xc00edf6a80})
	/go/src/state/immutable-trie/trie.go:105 +0x74
github.com/dogechain-lab/dogechain/state.(*StateObject).GetCommitedState(0xc00f05bec0, {0x14, 0x7, 0xac, 0x76, 0x1f, 0x93, 0x1f, 0xb7, 0x7a, ...})
	/go/src/state/state.go:131 +0xa4
github.com/dogechain-lab/dogechain/state.(*Txn).GetState(0xc0fa98e1b171005b, {0x10, 0xed, 0x1a, 0x8b, 0x2e, 0x90, 0x8b, 0xdd, 0x45, ...}, ...)
	/go/src/state/txn.go:365 +0x2a8
github.com/dogechain-lab/dogechain/state.(*Transition).GetStorage(0x20, {0x10, 0xed, 0x1a, 0x8b, 0x2e, 0x90, 0x8b, 0xdd, 0x45, ...}, ...)
	/go/src/state/executor.go:826 +0x7a
github.com/dogechain-lab/dogechain/state/runtime/evm.opSload(0xc047145320)
	/go/src/state/runtime/evm/instructions.go:481 +0x16c
github.com/dogechain-lab/dogechain/state/runtime/evm.(*state).Run(0xc047145320)
	/go/src/state/runtime/evm/state.go:245 +0x110
github.com/dogechain-lab/dogechain/state/runtime/evm.(*EVM).Run(0x6737740, 0xc00e58d3f0, {0x58ccde0, 0xc049fd6700}, 0xc049fd6730)
	/go/src/state/runtime/evm/evm.go:45 +0x15f
github.com/dogechain-lab/dogechain/state.(*Transition).run(0xc049fd6700, 0xb7dfd3f7c127e104, {0x58ccde0, 0xc049fd6700})
	/go/src/state/executor.go:632 +0x16f
github.com/dogechain-lab/dogechain/state.(*Transition).applyCall(0xc049fd6700, 0xc00e58d3f0, 0x0, {0x58ccde0, 0xc049fd6700})
	/go/src/state/executor.go:685 +0x2b3
github.com/dogechain-lab/dogechain/state.(*Transition).Callx(0xc039078a20, 0xf1, {0x58ccde0, 0xc049fd6700})
	/go/src/state/executor.go:855 +0x45
github.com/dogechain-lab/dogechain/state/runtime/evm.opCall.func1(0xc039078a20)
	/go/src/state/runtime/evm/instructions.go:1162 +0x2a4
github.com/dogechain-lab/dogechain/state/runtime/evm.(*state).Run(0xc039078a20)
	/go/src/state/runtime/evm/state.go:245 +0x110
github.com/dogechain-lab/dogechain/state/runtime/evm.(*EVM).Run(0x6737740, 0xc00e58d340, {0x58ccde0, 0xc049fd6700}, 0xc049fd6730)
	/go/src/state/runtime/evm/evm.go:45 +0x15f
github.com/dogechain-lab/dogechain/state.(*Transition).run(0xc049fd6700, 0xf4910367dd938a4d, {0x58ccde0, 0xc049fd6700})
	/go/src/state/executor.go:632 +0x16f
github.com/dogechain-lab/dogechain/state.(*Transition).applyCall(0xc049fd6700, 0xc00e58d340, 0x0, {0x58ccde0, 0xc049fd6700})
	/go/src/state/executor.go:685 +0x2b3
github.com/dogechain-lab/dogechain/state.(*Transition).Call2(0xc049fd6700, {0x6e, 0x72, 0xbc, 0x5f, 0x52, 0x40, 0x9a, 0x9d, 0x4d, ...}, ...)
	/go/src/state/executor.go:626 +0x265
github.com/dogechain-lab/dogechain/state.(*Transition).apply(0xc049fd6700, 0xc02ae6b7c0)
	/go/src/state/executor.go:585 +0xd0c
github.com/dogechain-lab/dogechain/state.(*Transition).Apply(0xc049fd6700, 0x6737740)
	/go/src/state/executor.go:394 +0x133
github.com/dogechain-lab/dogechain/state.(*Transition).Write(0xc049fd6700, 0xc010b60d20)
	/go/src/state/executor.go:253 +0x15d
github.com/dogechain-lab/dogechain/state.(*Executor).ProcessBlock(0x51f8520, {0x60, 0xeb, 0x1, 0xc6, 0x95, 0xe6, 0x61, 0x97, 0x38, ...}, ...)
	/go/src/state/executor.go:113 +0x107
github.com/dogechain-lab/dogechain/blockchain.(*Blockchain).executeBlockTransactions(0xc0000d2840, 0xc04c532f00)
	/go/src/blockchain/blockchain.go:847 +0x149
github.com/dogechain-lab/dogechain/blockchain.(*Blockchain).verifyBlockBody(0xc0000d2840, 0xc04c532f00)
	/go/src/blockchain/blockchain.go:792 +0x125
github.com/dogechain-lab/dogechain/blockchain.(*Blockchain).verifyBlock(0xc000f72c60, 0xc04c532f00)
	/go/src/blockchain/blockchain.go:706 +0x3c
github.com/dogechain-lab/dogechain/blockchain.(*Blockchain).VerifyFinalizedBlock(0xc0000d2840, 0xc04c532f00)
	/go/src/blockchain/blockchain.go:685 +0xa7
github.com/dogechain-lab/dogechain/protocol.(*Syncer).BulkSyncWithPeer(0xc00056e300, 0xc01925ea10, 0xc03c20e0c0)
	/go/src/protocol/syncer.go:619 +0x5b8
github.com/dogechain-lab/dogechain/consensus/ibft.(*Ibft).runSyncState(0xc000f72c60)
	/go/src/consensus/ibft/ibft.go:505 +0x144
github.com/dogechain-lab/dogechain/consensus/ibft.(*Ibft).runCycle(0xaf636)
	/go/src/consensus/ibft/ibft.go:440 +0x1dd
github.com/dogechain-lab/dogechain/consensus/ibft.(*Ibft).start(0xc000f72c60)
	/go/src/consensus/ibft/ibft.go:417 +0xe5
created by github.com/dogechain-lab/dogechain/consensus/ibft.(*Ibft).Start
	/go/src/consensus/ibft/ibft.go:221 +0x1c9
```