### PR TITLE
Fix: e2e defunct process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ lint:
 
 .PHONY: test
 test:
-	PATH=$(shell pwd):${PATH} go test -coverprofile coverage.out -timeout 28m ./...
+	PATH=$(shell pwd):${PATH} go test -count=1 -coverprofile coverage.out -timeout 28m ./...
 
 .PHONY: generate-bsd-licenses
 generate-bsd-licenses:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint:
 	golangci-lint run -c lint-rule.yaml --timeout=2m
 
 .PHONY: test
-test:
+test: build
 	PATH=$(shell pwd):${PATH} go test -count=1 -coverprofile coverage.out -timeout 28m ./...
 
 .PHONY: generate-bsd-licenses

--- a/e2e/framework/cmd.go
+++ b/e2e/framework/cmd.go
@@ -7,6 +7,10 @@ import (
 	"os/exec"
 )
 
+func registerPID(cmd *exec.Cmd) {
+	// ignore
+}
+
 func execCommand(workdir, name string, args ...string) *exec.Cmd {
 	cmd := exec.Command(binaryName, args...)
 	cmd.Dir = workdir

--- a/e2e/framework/cmd.go
+++ b/e2e/framework/cmd.go
@@ -1,0 +1,19 @@
+//go:build !linux
+// +build !linux
+
+package framework
+
+import (
+	"os/exec"
+)
+
+func execCommand(workdir, name string, args ...string) *exec.Cmd {
+	cmd := exec.Command(binaryName, args...)
+	cmd.Dir = workdir
+
+	return cmd
+}
+
+func processKill(cmd *exec.Cmd) error {
+	return cmd.Process.Kill()
+}

--- a/e2e/framework/cmd_linux.go
+++ b/e2e/framework/cmd_linux.go
@@ -1,0 +1,24 @@
+//go:build linux
+// +build linux
+
+package framework
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func execCommand(workdir, name string, args ...string) *exec.Cmd {
+	cmd := exec.Command(binaryName, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+		Pgid:    0,
+	}
+	cmd.Dir = workdir
+
+	return cmd
+}
+
+func processKill(cmd *exec.Cmd) error {
+	return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+}

--- a/e2e/framework/cmd_linux.go
+++ b/e2e/framework/cmd_linux.go
@@ -4,9 +4,37 @@
 package framework
 
 import (
+	"errors"
+	"os"
 	"os/exec"
+	"os/signal"
 	"syscall"
 )
+
+var pids = []int{}
+
+func init() {
+	go func() {
+		// wait os.Interrupt signal
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+
+		for sig := range c {
+			if sig == os.Interrupt {
+				// kill the whole process group
+				for _, pid := range pids {
+					_ = syscall.Kill(-pid, syscall.SIGKILL)
+				}
+			}
+
+			os.Exit(1)
+		}
+	}()
+}
+
+func registerPID(cmd *exec.Cmd) {
+	pids = append(pids, cmd.Process.Pid)
+}
 
 func execCommand(workdir, name string, args ...string) *exec.Cmd {
 	cmd := exec.Command(binaryName, args...)
@@ -20,5 +48,11 @@ func execCommand(workdir, name string, args ...string) *exec.Cmd {
 }
 
 func processKill(cmd *exec.Cmd) error {
-	return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	// kill the whole process group
+	err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	if errors.Is(syscall.ESRCH, err) {
+		return nil
+	}
+
+	return err
 }

--- a/e2e/framework/cmd_unix.go
+++ b/e2e/framework/cmd_unix.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris zos
 
 package framework
 

--- a/e2e/framework/cmd_windows.go
+++ b/e2e/framework/cmd_windows.go
@@ -1,5 +1,5 @@
-//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !windows && !zos
-// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris,!windows,!zos
+//go:build windows
+// +build windows
 
 package framework
 

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -388,6 +388,7 @@ func FindAvailablePorts(n, from, to int) ([]ReservedPort, error) {
 		newPort := FindAvailablePort(nextFrom, to)
 		if newPort == nil {
 			nextFrom = nextFrom + 1
+
 			continue
 		}
 

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -381,18 +381,14 @@ func FindAvailablePort(from, to int) *ReservedPort {
 }
 
 func FindAvailablePorts(n, from, to int) ([]ReservedPort, error) {
-	ports := make([]ReservedPort, 0, n)
+	ports := []ReservedPort{}
 	nextFrom := from
 
 	for i := 0; i < n; i++ {
 		newPort := FindAvailablePort(nextFrom, to)
 		if newPort == nil {
-			// Close current reserved ports
-			for _, p := range ports {
-				p.Close()
-			}
-
-			return nil, errors.New("couldn't reserve required number of ports")
+			nextFrom = nextFrom + 1
+			continue
 		}
 
 		ports = append(ports, *newPort)

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -387,7 +387,7 @@ func FindAvailablePorts(n, from, to int) ([]ReservedPort, error) {
 	for i := 0; i < n; i++ {
 		newPort := FindAvailablePort(nextFrom, to)
 		if newPort == nil {
-			nextFrom = nextFrom + 1
+			nextFrom++
 
 			continue
 		}

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -383,6 +383,8 @@ func (t *TestServer) Start(ctx context.Context) error {
 		return err
 	}
 
+	registerPID(t.cmd)
+
 	// fix defunct process
 	go func() {
 		_ = t.cmd.Wait()

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -385,7 +385,7 @@ func (t *TestServer) Start(ctx context.Context) error {
 
 	// fix defunct process
 	go func() {
-		t.cmd.Wait()
+		_ = t.cmd.Wait()
 	}()
 
 	_, err := tests.RetryUntilTimeout(ctx, func() (interface{}, bool) {

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -156,22 +156,10 @@ func (t *TestServer) IBFTOperator() ibftOp.IbftOperatorClient {
 	return ibftOp.NewIbftOperatorClient(conn)
 }
 
-func (t *TestServer) ReleaseReservedPorts() {
-	for _, p := range t.Config.ReservedPorts {
-		if err := p.Close(); err != nil {
-			t.t.Error(err)
-		}
-	}
-
-	t.Config.ReservedPorts = nil
-}
-
 func (t *TestServer) Stop() {
 	if t.cmd != nil {
 		if err := processKill(t.cmd); err != nil {
 			t.t.Error(err)
-		} else {
-			t.ReleaseReservedPorts()
 		}
 	}
 }
@@ -367,8 +355,6 @@ func (t *TestServer) Start(ctx context.Context) error {
 	if t.Config.BlockGasTarget != 0 {
 		args = append(args, "--block-gas-target", *types.EncodeUint64(t.Config.BlockGasTarget))
 	}
-
-	t.ReleaseReservedPorts()
 
 	// Start the server
 	t.cmd = execCommand(t.Config.RootDir, binaryName, args...)

--- a/jsonrpc/mocks_test.go
+++ b/jsonrpc/mocks_test.go
@@ -72,6 +72,9 @@ func (m *mockStore) emitEvent(evnt *mockEvent) {
 		OldChain: []*types.Header{},
 	}
 
+	m.receiptsLock.Lock()
+	defer m.receiptsLock.Unlock()
+
 	for _, i := range evnt.NewChain {
 		m.receipts[i.header.Hash] = i.receipts
 		bEvnt.NewChain = append(bEvnt.NewChain, i.header)

--- a/protocol/testing.go
+++ b/protocol/testing.go
@@ -51,7 +51,10 @@ func CreateSyncer(t *testing.T, blockchain blockchainShim, serverCfg *func(c *ne
 	}
 
 	srv, createErr := network.CreateServer(&network.CreateServerParams{
-		ConfigCallback: *serverCfg,
+		ConfigCallback: func(c *network.Config) {
+			c.DataDir = t.TempDir()
+			(*serverCfg)(c)
+		},
 	})
 	if createErr != nil {
 		t.Fatalf("Unable to create networking server, %v", createErr)


### PR DESCRIPTION
# Description

* fix e2e test created defunct process
* Unix environment kill process group
* fix `protocol/testing.go` data directory path empty (use `t.TempDir()` temp directory)
* fix `mockStore.GetReceiptsByHash` concurrent error
* never use the same port

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

