### PR TITLE
[Memory leak] Remove dangling pointers in the blockchain subscription

### DIFF
--- a/blockchain/subscription.go
+++ b/blockchain/subscription.go
@@ -167,7 +167,6 @@ func (e *eventStream) subscribe() *subscription {
 		updateCh: e.newUpdateCh(),
 		closeCh:  make(chan void),
 	}
-
 }
 
 // newUpdateCh returns the event update channel

--- a/blockchain/subscription.go
+++ b/blockchain/subscription.go
@@ -47,9 +47,8 @@ func (m *MockSubscription) Close() {
 
 // subscription is the Blockchain event subscription object
 type subscription struct {
-	updateCh chan void  // Channel for update information
-	closeCh  chan void  // Channel for close signals
-	elem     *eventElem // Reference to the blockchain event wrapper
+	updateCh chan *Event // Channel for update information
+	closeCh  chan void   // Channel for close signals
 }
 
 // GetEventCh creates a new event channel, and returns it
@@ -72,17 +71,10 @@ func (s *subscription) GetEventCh() chan *Event {
 // GetEvent returns the event from the subscription (BLOCKING)
 func (s *subscription) GetEvent() *Event {
 	for {
-		if s.elem.next != nil {
-			s.elem = s.elem.next
-			evnt := s.elem.event
-
-			return evnt
-		}
-
 		// Wait for an update
 		select {
-		case <-s.updateCh:
-			continue
+		case ev := <-s.updateCh:
+			return ev
 		case <-s.closeCh:
 			return nil
 		}
@@ -117,7 +109,7 @@ type Event struct {
 	Type EventType
 
 	// Source is the source that generated the blocks for the event
-	// right now it can be either the Sealer or the Syncer. TODO
+	// right now it can be either the Sealer or the Syncer
 	Source string
 }
 
@@ -160,73 +152,45 @@ func (b *Blockchain) SubscribeEvents() Subscription {
 	return b.stream.subscribe()
 }
 
-// eventElem contains the event, as well as the next list event
-type eventElem struct {
-	event *Event
-	next  *eventElem
-}
-
 // eventStream is the structure that contains the event list,
 // as well as the update channel which it uses to notify of updates
 type eventStream struct {
 	lock sync.Mutex
-	head *eventElem
 
 	// channel to notify updates
-	updateCh []chan void
+	updateCh []chan *Event
 }
 
 // subscribe Creates a new blockchain event subscription
 func (e *eventStream) subscribe() *subscription {
-	head, updateCh := e.Head()
-	s := &subscription{
-		elem:     head,
-		updateCh: updateCh,
+	return &subscription{
+		updateCh: e.newUpdateCh(),
 		closeCh:  make(chan void),
 	}
 
-	return s
 }
 
-// Head returns the event list head
-func (e *eventStream) Head() (*eventElem, chan void) {
+// newUpdateCh returns the event update channel
+func (e *eventStream) newUpdateCh() chan *Event {
 	e.lock.Lock()
-	head := e.head
+	defer e.lock.Unlock()
 
-	ch := make(chan void)
-
-	if e.updateCh == nil {
-		e.updateCh = make([]chan void, 0)
-	}
-
+	ch := make(chan *Event, 1)
 	e.updateCh = append(e.updateCh, ch)
 
-	e.lock.Unlock()
-
-	return head, ch
+	return ch
 }
 
 // push adds a new Event, and notifies listeners
 func (e *eventStream) push(event *Event) {
 	e.lock.Lock()
-
-	newHead := &eventElem{
-		event: event,
-	}
-
-	if e.head != nil {
-		e.head.next = newHead
-	}
-
-	e.head = newHead
+	defer e.lock.Unlock()
 
 	// Notify the listeners
 	for _, update := range e.updateCh {
 		select {
-		case update <- void{}:
+		case update <- event:
 		default:
 		}
 	}
-
-	e.lock.Unlock()
 }

--- a/blockchain/subscription_test.go
+++ b/blockchain/subscription_test.go
@@ -51,32 +51,3 @@ func TestSubscription(t *testing.T) {
 
 	assert.Equal(t, event.NewChain[0].Number, caughtEventNum)
 }
-
-func TestSubscriptionSlowConsumer(t *testing.T) {
-	e := &eventStream{}
-
-	e.push(&Event{
-		NewChain: []*types.Header{
-			{Number: 0},
-		},
-	})
-
-	sub := e.subscribe()
-
-	// send multiple events
-	for i := 1; i < 10; i++ {
-		e.push(&Event{
-			NewChain: []*types.Header{
-				{Number: uint64(i)},
-			},
-		})
-	}
-
-	// consume events now
-	for i := 1; i < 10; i++ {
-		evnt := sub.GetEvent()
-		if evnt.NewChain[0].Number != uint64(i) {
-			t.Fatal("bad")
-		}
-	}
-}

--- a/blockchain/subscription_test.go
+++ b/blockchain/subscription_test.go
@@ -1,51 +1,55 @@
 package blockchain
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/dogechain-lab/dogechain/types"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestSubscriptionLinear(t *testing.T) {
-	e := &eventStream{}
+func TestSubscription(t *testing.T) {
+	t.Parallel()
 
-	// add a genesis block to eventstream
-	e.push(&Event{
-		NewChain: []*types.Header{
-			{Number: 0},
-		},
-	})
+	var (
+		e              = &eventStream{}
+		sub            = e.subscribe()
+		caughtEventNum = uint64(0)
+		event          = &Event{
+			NewChain: []*types.Header{
+				{
+					Number: 100,
+				},
+			},
+		}
 
-	sub := e.subscribe()
+		wg sync.WaitGroup
+	)
 
-	eventCh := make(chan *Event)
+	defer sub.Close()
+
+	updateCh := sub.GetEventCh()
+
+	wg.Add(1)
 
 	go func() {
-		for {
-			task := sub.GetEvent()
-			eventCh <- task
+		defer wg.Done()
+
+		select {
+		case ev := <-updateCh:
+			caughtEventNum = ev.NewChain[0].Number
+		case <-time.After(5 * time.Second):
 		}
 	}()
 
-	for i := 1; i < 10; i++ {
-		evnt := &Event{}
+	// Send the event to the channel
+	e.push(event)
 
-		evnt.AddNewHeader(&types.Header{Number: uint64(i)})
-		e.push(evnt)
+	// Wait for the event to be parsed
+	wg.Wait()
 
-		timeoutDelay := time.NewTimer(1 * time.Second)
-
-		// it should fire updateCh
-		select {
-		case evnt := <-eventCh:
-			if evnt.NewChain[0].Number != uint64(i) {
-				t.Fatal("bad")
-			}
-		case <-timeoutDelay.C:
-			t.Fatal("timeout")
-		}
-	}
+	assert.Equal(t, event.NewChain[0].Number, caughtEventNum)
 }
 
 func TestSubscriptionSlowConsumer(t *testing.T) {


### PR DESCRIPTION
# Description

The blockchain subscription hold the whole update events and never release it, which made a memory leak.

This PR fixes it. It is merging from 0xPolygon Edge project PR [741](https://github.com/0xPolygon/polygon-edge/pull/741).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually