### PR TITLE
[Cmd] Set server command seal flag default to false

### DIFF
--- a/command/server/server.go
+++ b/command/server/server.go
@@ -182,7 +182,7 @@ func setFlags(cmd *cobra.Command) {
 		cmd.Flags().BoolVar(
 			&params.rawConfig.ShouldSeal,
 			sealFlag,
-			true,
+			false,
 			"the flag indicating that the client should seal blocks",
 		)
 


### PR DESCRIPTION
# Description

The default value of seal flag was set to true, which means that a full node has to handle gossip transactions even they don't need it. Then massive transactions flood the node's `txpool`, and they'll print out huge amount `insufficient funds` logs .

This PR sets the flag default to false, makes it quiet and restoring calm.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

# Documentation update

Will upgrade the documentation once it merged.

# Additional comments

Associated issue: #156 