### PR TITLE
Fix: routing table size use MaxPeers config

### DIFF
--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -33,6 +33,27 @@ func Min(a, b uint64) uint64 {
 	return b
 }
 
+func ClampInt64ToInt(v int64) int {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+
+	if v < math.MinInt32 {
+		return math.MinInt32
+	}
+
+	return int(v)
+}
+
+// MaxInt returns the strictly bigger int number
+func MaxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+
+	return b
+}
+
 // Max returns the strictly bigger number
 func Max(a, b uint64) uint64 {
 	if a > b {

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -33,6 +33,7 @@ func Min(a, b uint64) uint64 {
 	return b
 }
 
+// ClampInt64ToInt returns the int64 value clamped to the range of an int
 func ClampInt64ToInt(v int64) int {
 	if v > math.MaxInt32 {
 		return math.MaxInt32

--- a/network/server_discovery.go
+++ b/network/server_discovery.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"time"
 
+	helperCommon "github.com/dogechain-lab/dogechain/helper/common"
 	"github.com/dogechain-lab/dogechain/network/common"
 	"github.com/dogechain-lab/dogechain/network/discovery"
 	"github.com/dogechain-lab/dogechain/network/grpc"
@@ -192,7 +193,10 @@ func (s *Server) setupDiscovery() error {
 	keyID := kb.ConvertPeerID(s.host.ID())
 
 	routingTable, err := kb.NewRoutingTable(
-		defaultBucketSize,
+		helperCommon.MaxInt(
+			helperCommon.ClampInt64ToInt(s.config.MaxPeers),
+			defaultBucketSize,
+		),
 		keyID,
 		time.Minute,
 		s.host.Peerstore(),


### PR DESCRIPTION
# Description

Error logs:

```
dogechain.network.discovery: Failed to add new peer to routing
table: peer=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX err="peer rejected; insufficient capacity"
```

[network/server_discovery.go#L199](https://github.com/dogechain-lab/dogechain/blob/1f61163047e97792c4f5d1652f8ea42ad581b5ed/network/server_discovery.go#L199) use fixed value

[network/server_discovery.go#L211](https://github.com/dogechain-lab/dogechain/blob/1f61163047e97792c4f5d1652f8ea42ad581b5ed/network/server_discovery.go#L211)  add peer to dial queue from callback

In extreme cases, each peer will allocate a bucket, and cannot actively initiate a connection to a new peer when the capacity is insufficient



# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels

## Testing

- [X] I have tested this code with the official test suite
