### PR TITLE
Feature: export leveldb parameter

### DIFF
--- a/command/server/params.go
+++ b/command/server/params.go
@@ -14,15 +14,19 @@ import (
 )
 
 const (
-	configFlag                   = "config"
-	genesisPathFlag              = "chain"
-	dataDirFlag                  = "data-dir"
-	leveldbCacheFlag             = "leveldb.cache-size"
-	leveldbHandlesFlag           = "leveldb.handles"
-	leveldbBloomKeyBitsFlag      = "leveldb.bloom-bits"
-	leveldbTableSizeFlag         = "leveldb.table-size"
-	leveldbTotalTableSizeFlag    = "leveldb.total-table-size"
-	leveldbNoSyncFlag            = "leveldb.nosync"
+	configFlag      = "config"
+	genesisPathFlag = "chain"
+	dataDirFlag     = "data-dir"
+
+	leveldbCacheFlag               = "leveldb.cache-size"
+	leveldbHandlesFlag             = "leveldb.handles"
+	leveldbBloomKeyBitsFlag        = "leveldb.bloom-bits"
+	leveldbTableSizeFlag           = "leveldb.table-size"
+	leveldbTableSizeMultiplierFlag = "leveldb.table-size-multi"
+	leveldbTotalTableSizeFlag      = "leveldb.total-table-size"
+	leveldbDisableCompressionFlag  = "leveldb.disable-compression"
+	leveldbNoSyncFlag              = "leveldb.nosync"
+
 	libp2pAddressFlag            = "libp2p"
 	prometheusAddressFlag        = "prometheus"
 	natFlag                      = "nat"
@@ -78,7 +82,11 @@ type serverParams struct {
 	leveldbBloomKeyBits   int
 	leveldbTableSize      int
 	leveldbTotalTableSize int
-	leveldbNoSync         bool
+
+	leveldbTableSizeMultiplier float64
+
+	leveldbDisableCompression bool
+	leveldbNoSync             bool
 
 	libp2pAddress     *net.TCPAddr
 	prometheusAddress *net.TCPAddr
@@ -212,12 +220,14 @@ func (p *serverParams) generateConfig() *server.Config {
 		SecretsManager:        p.secretsConfig,
 		RestoreFile:           p.getRestoreFilePath(),
 		LeveldbOptions: &server.LeveldbOptions{
-			CacheSize:           p.leveldbCacheSize,
-			Handles:             p.leveldbHandles,
-			BloomKeyBits:        p.leveldbBloomKeyBits,
-			CompactionTableSize: p.leveldbTableSize,
-			CompactionTotalSize: p.leveldbTotalTableSize,
-			NoSync:              p.leveldbNoSync,
+			CacheSize:                     p.leveldbCacheSize,
+			Handles:                       p.leveldbHandles,
+			BloomKeyBits:                  p.leveldbBloomKeyBits,
+			CompactionTableSize:           p.leveldbTableSize,
+			CompactionTotalSize:           p.leveldbTotalTableSize,
+			CompactionTableSizeMultiplier: p.leveldbTableSizeMultiplier,
+			DisbableCompression:           p.leveldbDisableCompression,
+			NoSync:                        p.leveldbNoSync,
 		},
 		BlockTime:    p.rawConfig.BlockTime,
 		LogLevel:     hclog.LevelFromString(p.rawConfig.LogLevel),

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -152,6 +152,20 @@ func setFlags(cmd *cobra.Command) {
 			"limits leveldb total size of 'sorted table' for each level in MB",
 		)
 
+		cmd.Flags().Float64Var(
+			&params.leveldbTableSizeMultiplier,
+			leveldbTableSizeMultiplierFlag,
+			kvdb.DefaultLevelDBCompactionTableSizeMultiplier,
+			"set leveldb SST table size multiplier",
+		)
+
+		cmd.Flags().BoolVar(
+			&params.leveldbDisableCompression,
+			leveldbDisableCompressionFlag,
+			kvdb.DefaultLevelDBDisableCompression,
+			"disable leveldb compression",
+		)
+
 		cmd.Flags().BoolVar(
 			&params.leveldbNoSync,
 			leveldbNoSyncFlag,

--- a/server/config.go
+++ b/server/config.go
@@ -56,6 +56,10 @@ type LeveldbOptions struct {
 	BloomKeyBits        int
 	CompactionTableSize int
 	CompactionTotalSize int
+
+	CompactionTableSizeMultiplier float64
+
+	DisbableCompression bool
 	NoSync              bool
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -142,6 +142,8 @@ func newLevelDBBuilder(logger hclog.Logger, config *Config, path string) kvdb.Le
 		SetBloomKeyBits(config.LeveldbOptions.BloomKeyBits).
 		SetCompactionTableSize(config.LeveldbOptions.CompactionTableSize).
 		SetCompactionTotalSize(config.LeveldbOptions.CompactionTotalSize).
+		SetCompactionTotalSizeMultiplier(config.LeveldbOptions.CompactionTableSizeMultiplier).
+		SetDisableCompression(config.LeveldbOptions.DisbableCompression).
 		SetNoSync(config.LeveldbOptions.NoSync)
 
 	return leveldbBuilder


### PR DESCRIPTION
# Description

* export `CompactionTableSizeMultiplier`, Control the file number of per-level
* export `Compression` config (in  btrfs/zfs system, transparent file compression better)

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code
