### PR TITLE
Hotfix/slice out of range

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -93,7 +93,11 @@ var dirPaths = []string{
 //
 // If log file can't be created, it returns an error
 func newFileLogger(config *Config) (hclog.Logger, error) {
-	logFileWriter, err := os.Create(config.LogFilePath)
+	logFileWriter, err := os.OpenFile(
+		config.LogFilePath,
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND,
+		os.ModeAppend,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("could not create log file, %w", err)
 	}

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -818,36 +818,36 @@ func opReturnDataCopy(c *state) {
 		return
 	}
 
+	// check data offset overflow
+	if !dataOffset.IsUint64() {
+		c.exit(errGasUintOverflow)
+
+		return
+	}
+
 	// check gas
 	if !c.consumeGas(((length.Uint64() + 31) / 32) * copyGas) {
 		return
 	}
 
-	// check data offset negative
-	if dataOffset.Sign() < 0 {
-		c.exit(errGasUintOverflow)
-
-		return
-	}
-
-	// check end exceeds uint64
-	end := big.NewInt(0).Add(dataOffset, length)
-	if !end.IsUint64() {
-		c.exit(errGasUintOverflow)
+	// check dataEnd exceeds uint64
+	dataEnd := length.Add(dataOffset, length)
+	if !dataEnd.IsUint64() {
+		c.exit(errReturnDataOutOfBounds)
 
 		return
 	}
 
 	// check return data out of range
-	size := end.Uint64()
-	if uint64(len(c.returnData)) < size {
+	dataEndIndex := dataEnd.Uint64()
+	if uint64(len(c.returnData)) < dataEndIndex {
 		c.exit(errReturnDataOutOfBounds)
 
 		return
 	}
 
 	// copy data
-	data := c.returnData[dataOffset.Uint64():size]
+	data := c.returnData[dataOffset.Uint64():dataEndIndex]
 	copy(c.memory[memOffset.Uint64():], data)
 }
 

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -826,7 +826,7 @@ func opReturnDataCopy(c *state) {
 	// check data offset negative
 	if dataOffset.Sign() < 0 {
 		c.exit(errGasUintOverflow)
-	
+
 		return
 	}
 

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -419,7 +419,7 @@ func opMStore(c *state) {
 	offset := c.pop()
 	val := c.pop()
 
-	if !c.checkMemory(offset, wordSize) {
+	if !c.extendMemory(offset, wordSize) {
 		return
 	}
 
@@ -452,7 +452,7 @@ func opMStore8(c *state) {
 	offset := c.pop()
 	val := c.pop()
 
-	if !c.checkMemory(offset, one) {
+	if !c.extendMemory(offset, one) {
 		return
 	}
 
@@ -757,7 +757,7 @@ func opExtCodeCopy(c *state) {
 	codeOffset := c.pop()
 	length := c.pop()
 
-	if !c.checkMemory(memOffset, length) {
+	if !c.extendMemory(memOffset, length) {
 		return
 	}
 
@@ -788,7 +788,7 @@ func opCallDataCopy(c *state) {
 	dataOffset := c.pop()
 	length := c.pop()
 
-	if !c.checkMemory(memOffset, length) {
+	if !c.extendMemory(memOffset, length) {
 		return
 	}
 
@@ -814,7 +814,7 @@ func opReturnDataCopy(c *state) {
 	length := c.pop()
 
 	// ensure memory size
-	if !c.checkMemory(memOffset, length) {
+	if !c.extendMemory(memOffset, length) {
 		return
 	}
 
@@ -856,7 +856,7 @@ func opCodeCopy(c *state) {
 	dataOffset := c.pop()
 	length := c.pop()
 
-	if !c.checkMemory(memOffset, length) {
+	if !c.extendMemory(memOffset, length) {
 		return
 	}
 
@@ -1213,7 +1213,7 @@ func (c *state) buildCallContract(op OpCode) (*runtime.Contract, uint64, uint64,
 		return nil, 0, 0, nil
 	}
 	// Check if the memory return offsets are out of bounds
-	if !c.checkMemory(retOffset, retSize) {
+	if !c.extendMemory(retOffset, retSize) {
 		return nil, 0, 0, nil
 	}
 

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -476,6 +476,33 @@ func Test_opReturnDataCopy(t *testing.T) {
 			},
 		},
 		{
+			name:   "should return error if gas not enough",
+			config: &allEnabledForks,
+			initState: &state{
+				stack: []*big.Int{
+					big.NewInt(10), // length
+					big.NewInt(0),  // dataOffset
+					big.NewInt(0),  // memOffset
+				},
+				sp:  3,
+				gas: 3,
+			},
+			resultState: &state{
+				config: &allEnabledForks,
+				stack: []*big.Int{
+					big.NewInt(10),
+					big.NewInt(0),
+					big.NewInt(0),
+				},
+				memory:      make([]byte, int(wordSize.Int64())),
+				sp:          0,
+				lastGasCost: 3,
+				gas:         0,
+				stop:        true,
+				err:         errOutOfGas,
+			},
+		},
+		{
 			name:   "should copy data from returnData to memory",
 			config: &allEnabledForks,
 			initState: &state{

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -13,6 +13,8 @@ import (
 
 var (
 	two = big.NewInt(2)
+
+	allEnabledForks = chain.AllForksEnabled.At(0)
 )
 
 type cases2To1 []struct {
@@ -375,6 +377,197 @@ func TestCreate(t *testing.T) {
 			assert.Equal(t, tt.resultState.memory, s.memory, "memory in state after execution is not correct")
 			assert.Equal(t, tt.resultState.stop, s.stop, "stop in state after execution is not correct")
 			assert.Equal(t, tt.resultState.err, s.err, "err in state after execution is not correct")
+		})
+	}
+}
+
+func Test_opReturnDataCopy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		config      *chain.ForksInTime
+		initState   *state
+		resultState *state
+	}{
+		{
+			name: "should return error if Byzantium is not applied",
+			config: &chain.ForksInTime{
+				Byzantium: false,
+			},
+			initState: &state{},
+			resultState: &state{
+				config: &chain.ForksInTime{
+					Byzantium: false,
+				},
+				stop: true,
+				err:  errOpCodeNotFound,
+			},
+		},
+		{
+			name:   "should return error if memOffset is negative",
+			config: &allEnabledForks,
+			initState: &state{
+				stack: []*big.Int{
+					big.NewInt(0),  // length
+					big.NewInt(0),  // dataOffset
+					big.NewInt(-1), // memOffset
+				},
+				sp: 3,
+			},
+			resultState: &state{
+				config: &allEnabledForks,
+				stack: []*big.Int{
+					big.NewInt(0),
+					big.NewInt(0),
+					big.NewInt(-1),
+				},
+				sp:   0,
+				stop: true,
+				err:  errGasUintOverflow,
+			},
+		},
+		{
+			name:   "should return error if dataOffset is negative",
+			config: &allEnabledForks,
+			initState: &state{
+				stack: []*big.Int{
+					big.NewInt(1),  // length
+					big.NewInt(-1), // dataOffset
+					big.NewInt(0),  // memOffset
+				},
+				sp:     3,
+				memory: make([]byte, 1),
+			},
+			resultState: &state{
+				config: &allEnabledForks,
+				stack: []*big.Int{
+					big.NewInt(1),
+					big.NewInt(-1),
+					big.NewInt(0),
+				},
+				sp:     0,
+				memory: make([]byte, 1),
+				stop:   true,
+				err:    errGasUintOverflow,
+			},
+		},
+		{
+			name:   "should return error if length is negative",
+			config: &allEnabledForks,
+			initState: &state{
+				stack: []*big.Int{
+					big.NewInt(-1), // length
+					big.NewInt(0),  // dataOffset
+					big.NewInt(0),  // memOffset
+				},
+				sp: 3,
+			},
+			resultState: &state{
+				config: &allEnabledForks,
+				stack: []*big.Int{
+					big.NewInt(-1),
+					big.NewInt(0),
+					big.NewInt(0),
+				},
+				sp:   0,
+				stop: true,
+				err:  errGasUintOverflow,
+			},
+		},
+		{
+			name:   "should copy data from returnData to memory",
+			config: &allEnabledForks,
+			initState: &state{
+				stack: []*big.Int{
+					big.NewInt(1), // length
+					big.NewInt(0), // dataOffset
+					big.NewInt(0), // memOffset
+				},
+				sp:         3,
+				returnData: []byte{0xff},
+				memory:     []byte{0x0},
+				gas:        10,
+			},
+			resultState: &state{
+				config: &allEnabledForks,
+				stack: []*big.Int{
+					big.NewInt(1),
+					big.NewInt(0),
+					big.NewInt(0),
+				},
+				sp:          0,
+				returnData:  []byte{0xff},
+				memory:      []byte{0xff},
+				gas:         7,
+				lastGasCost: 0,
+				stop:        false,
+				err:         nil,
+			},
+		},
+		{
+			name:   "should expand memory and copy data returnData",
+			config: &allEnabledForks,
+			initState: &state{
+				stack: []*big.Int{
+					big.NewInt(5), // length
+					big.NewInt(1), // dataOffset
+					big.NewInt(2), // memOffset
+				},
+				sp:         3,
+				returnData: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+				memory:     []byte{0x11, 0x22},
+				gas:        20,
+			},
+			resultState: &state{
+				config: &allEnabledForks,
+				stack: []*big.Int{
+					big.NewInt(6), // updated for end index
+					big.NewInt(1),
+					big.NewInt(2),
+				},
+				sp:         0,
+				returnData: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+				memory: append(
+					// 1 word (32 bytes)
+					[]byte{0x11, 0x22, 0x02, 0x03, 0x04, 0x05, 0x06},
+					make([]byte, 25)...,
+				),
+				gas:         14,
+				lastGasCost: 3,
+				stop:        false,
+				err:         nil,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			state, closeFn := getState()
+			defer closeFn()
+
+			state.gas = test.initState.gas
+			state.sp = test.initState.sp
+			state.stack = test.initState.stack
+			state.memory = test.initState.memory
+			state.returnData = test.initState.returnData
+			state.config = test.config
+
+			// assign nil to some fields in cached state object
+			state.code = nil
+			state.host = nil
+			state.msg = nil
+			state.evm = nil
+			state.bitmap = bitmap{}
+			state.ret = nil
+
+			opReturnDataCopy(state)
+
+			assert.Equal(t, test.resultState, state)
 		})
 	}
 }

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -304,14 +304,14 @@ func (c *state) Len() int {
 }
 
 func (c *state) checkMemory(offset, size *big.Int) bool {
-	if size.Sign() == 0 {
-		return true
-	}
-
 	if !offset.IsUint64() || !size.IsUint64() {
 		c.exit(errGasUintOverflow)
 
 		return false
+	}
+
+	if size.Sign() == 0 {
+		return true
 	}
 
 	o := offset.Uint64()

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -303,7 +303,7 @@ func (c *state) Len() int {
 	return len(c.memory)
 }
 
-func (c *state) checkMemory(offset, size *big.Int) bool {
+func (c *state) extendMemory(offset, size *big.Int) bool {
 	if !offset.IsUint64() || !size.IsUint64() {
 		c.exit(errGasUintOverflow)
 
@@ -356,7 +356,7 @@ func (c *state) get2(dst []byte, offset, length *big.Int) ([]byte, bool) {
 		return nil, true
 	}
 
-	if !c.checkMemory(offset, length) {
+	if !c.extendMemory(offset, length) {
 		return nil, false
 	}
 

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -59,7 +59,7 @@ type state struct {
 	config *chain.ForksInTime
 
 	// memory
-	memory      []byte
+	memory      []byte // increase capacity by words (1 word = 32 bytes). cap = len. but offset not equal to length
 	lastGasCost uint64
 
 	// stack
@@ -292,7 +292,8 @@ func (c *state) checkMemory(offset, size *big.Int) bool {
 		return false
 	}
 
-	if newSize, m := o+s, uint64(len(c.memory)); m < newSize {
+	// correct usage: use memory capacity instead of length
+	if newSize, mCap := o+s, uint64(cap(c.memory)); mCap < newSize {
 		w := (newSize + 31) / 32
 		newCost := 3*w + w*w/512
 		cost := newCost - c.lastGasCost

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -292,8 +292,7 @@ func (c *state) checkMemory(offset, size *big.Int) bool {
 		return false
 	}
 
-	// correct usage: use memory capacity instead of length
-	if newSize, mCap := o+s, uint64(cap(c.memory)); mCap < newSize {
+	if newSize, mCap := o+s, uint64(len(c.memory)); mCap < newSize {
 		w := (newSize + 31) / 32
 		newCost := 3*w + w*w/512
 		cost := newCost - c.lastGasCost

--- a/state/runtime/evm/state_test.go
+++ b/state/runtime/evm/state_test.go
@@ -1,8 +1,10 @@
 package evm
 
 import (
+	"math/big"
 	"testing"
 
+	"github.com/dogechain-lab/dogechain/chain"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -107,4 +109,99 @@ func TestOpcodeNotFound(t *testing.T) {
 
 	_, err := s.Run()
 	assert.Equal(t, errOpCodeNotFound, err)
+}
+
+func TestCheckMemory(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		memoryOffset           int64
+		dataOffset             int64
+		dataLength             int64
+		expectedLengthBefore   int
+		expectedCapacityBefore int
+		expectedLengthAfter    int
+		expectedCapacityAfter  int
+	}{
+		{
+			name:                   "no need to extend memory",
+			memoryOffset:           10,
+			dataOffset:             0,
+			dataLength:             16,
+			expectedLengthBefore:   32,
+			expectedCapacityBefore: 32,
+			expectedLengthAfter:    32,
+			expectedCapacityAfter:  32,
+		},
+		{
+			name:                   "need to extend memory",
+			memoryOffset:           32,
+			dataOffset:             0,
+			dataLength:             1,
+			expectedLengthBefore:   32,
+			expectedCapacityBefore: 32,
+			expectedLengthAfter:    64,
+			expectedCapacityAfter:  64,
+		},
+		{
+			name:                   "data partial copy",
+			memoryOffset:           32,
+			dataOffset:             10,
+			dataLength:             36,
+			expectedLengthBefore:   32,
+			expectedCapacityBefore: 32,
+			expectedLengthAfter:    96,
+			expectedCapacityAfter:  96,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Setenv("name", test.name)
+
+		s, closeFn := getState()
+		defer closeFn()
+
+		// set config
+		cfg := chain.AllForksEnabled.At(0)
+		s.config = &cfg
+
+		// offset
+		memoryOffset := test.memoryOffset
+		dataOffset := test.dataOffset
+		dataLength := test.dataLength
+
+		// gas and code
+		s.gas = 1000
+		s.code = []byte{RETURNDATACOPY}
+
+		s.returnData = make([]byte, (dataOffset + dataLength))
+		for i := int64(dataOffset); i < dataLength; i++ {
+			s.returnData[i] = byte(i)
+		}
+
+		// initial state, which might set memory in other opcode
+		v := s.checkMemory(big.NewInt(0), big.NewInt(memoryOffset))
+		assert.True(t, v)
+		assert.Equal(t, test.expectedLengthBefore, len(s.memory))
+		assert.Equal(t, test.expectedCapacityBefore, cap(s.memory))
+
+		// LIFO
+		s.push(big.NewInt(dataLength))   // data length
+		s.push(big.NewInt(dataOffset))   // data offset
+		s.push(big.NewInt(memoryOffset)) // memory offset
+
+		// run opcode
+		_, err := s.Run()
+		assert.NoError(t, err)
+		assert.Len(t, s.returnData, int(test.dataOffset+test.dataLength))
+
+		// final state
+		assert.Equal(t, test.expectedLengthAfter, len(s.memory))
+		assert.Equal(t, test.expectedCapacityAfter, cap(s.memory))
+		assert.Equal(
+			t,
+			s.memory[memoryOffset:memoryOffset+dataLength],
+			s.returnData[test.dataOffset:test.dataOffset+test.dataLength],
+		)
+	}
+
 }

--- a/state/runtime/evm/state_test.go
+++ b/state/runtime/evm/state_test.go
@@ -174,7 +174,7 @@ func TestCheckMemory(t *testing.T) {
 		s.code = []byte{RETURNDATACOPY}
 
 		s.returnData = make([]byte, (dataOffset + dataLength))
-		for i := int64(dataOffset); i < dataLength; i++ {
+		for i := dataOffset; i < dataLength; i++ {
 			s.returnData[i] = byte(i)
 		}
 
@@ -203,5 +203,4 @@ func TestCheckMemory(t *testing.T) {
 			s.returnData[test.dataOffset:test.dataOffset+test.dataLength],
 		)
 	}
-
 }

--- a/state/runtime/evm/state_test.go
+++ b/state/runtime/evm/state_test.go
@@ -111,7 +111,7 @@ func TestOpcodeNotFound(t *testing.T) {
 	assert.Equal(t, errOpCodeNotFound, err)
 }
 
-func TestCheckMemory(t *testing.T) {
+func Test_extendMemory(t *testing.T) {
 	testCases := []struct {
 		name                   string
 		memoryOffset           int64
@@ -179,7 +179,7 @@ func TestCheckMemory(t *testing.T) {
 		}
 
 		// initial state, which might set memory in other opcode
-		v := s.checkMemory(big.NewInt(0), big.NewInt(memoryOffset))
+		v := s.extendMemory(big.NewInt(0), big.NewInt(memoryOffset))
 		assert.True(t, v)
 		assert.Equal(t, test.expectedLengthBefore, len(s.memory))
 		assert.Equal(t, test.expectedCapacityBefore, cap(s.memory))


### PR DESCRIPTION
# Description

The evm crash due to out of range copy in `evm.opReturnDataCopy`. The crash log is blow.

This PR fixes it.

```
Oct  2 15:07:33 dogechain-validator dogechain[312072]: panic: runtime error: slice bounds out of range [128:128+96]
Oct  2 15:07:33 dogechain-validator dogechain[312072]: goroutine 33 [running]:
Oct  2 15:07:33 dogechain-validator dogechain[312072]: github.com/dogechain-lab/dogechain/state/runtime/evm.opReturnDataCopy(0xc047dc8480)
Oct  2 15:07:33 dogechain-validator dogechain[312072]: #011/go/src/state/runtime/evm/instructions.go:841 +0x3b0
Oct  2 15:07:33 dogechain-validator dogechain[312072]: github.com/dogechain-lab/dogechain/state/runtime/evm.(*state).Run(0xc047dc8480)
Oct  2 15:07:33 dogechain-validator dogechain[312072]: #011/go/src/state/runtime/evm/state.go:245 +0x110
Oct  2 15:07:33 dogechain-validator dogechain[312072]: github.com/dogechain-lab/dogechain/state/runtime/evm.(*EVM).Run(0x2cf8650, 0xc04b9c7340, {0x1e073e0, 0xc03c77ba00}, 0xc03c77ba30)
Oct  2 15:07:33 dogechain-validator dogechain[312072]: #011/go/src/state/runtime/evm/evm.go:45 +0x15f
Oct  2 15:07:33 dogechain-validator dogechain[312072]: github.com/dogechain-lab/dogechain/state.(*Transition).run(0xc03c77ba00, 0x33abfdbd9f0c5423, {0x1e073e0, 0xc03c77ba00})
Oct  2 15:07:33 dogechain-validator dogechain[312072]: #011/go/src/state/executor.go:632 +0x16f
Oct  2 15:07:33 dogechain-validator dogechain[312072]: github.com/dogechain-lab/dogechain/state.(*Transition).applyCall(0xc03c77ba00, 0xc04b9c7340, 0x0, {0x1e073e0, 0xc03c77ba00})
Oct  2 15:07:33 dogechain-validator dogechain[312072]: #011/go/src/state/executor.go:685 +0x2b3
Oct  2 15:07:33 dogechain-validator dogechain[312072]: github.com/dogechain-lab/dogechain/state.(*Transition).Callx(0xc043c4efc0, 0xf1, {0x1e073e0, 0xc03c77ba00})
Oct  2 15:07:33 dogechain-validator dogechain[312072]: #011/go/src/state/executor.go:855 +0x45
Oct  2 15:07:33 dogechain-validator dogechain[312072]: github.com/dogechain-lab/dogechain/state/runtime/evm.opCall.func1(0xc043c4efc0)
Oct  2 15:07:33 dogechain-validator dogechain[312072]: #011/go/src/state/runtime/evm/instructions.go:1162 +0x2a4
Oct  2 15:07:33 dogechain-validator dogechain[312072]: github.com/dogechain-lab/dogechain/state/runtime/evm.(*state).Run(0xc043c4efc0)
Oct  2 15:07:33 dogechain-validator dogechain[312072]: #011/go/src/state/runtime/evm/state.go:245 +0x110
Oct  2 15:07:33 dogechain-validator dogechain[312072]: github.com/dogechain-lab/dogechain/state/runtime/evm.(*EVM).Run(0x2cf8650, 0xc04b9c6bb0, {0x1e073e0, 0xc03c77ba00}, 0xc03c77ba30)
Oct  2 15:07:33 dogechain-validator dogechain[312072]: #011/go/src/state/runtime/evm/evm.go:45 +0x15f
Oct  2 15:07:33 dogechain-validator dogechain[312072]: github.com/dogechain-lab/dogechain/state.(*Transition).run(0xc03c77ba00, 0x3b6cc2a6dcceefff, {0x1e073e0, 0xc03c77ba00})
Oct  2 15:07:33 dogechain-validator dogechain[312072]: #011/go/src/state/executor.go:632 +0x16f
Oct  2 15:07:33 dogechain-validator dogechain[312072]: github.com/dogechain-lab/dogechain/state.(*Transition).applyCall(0xc03c77ba00, 0xc04b9c6bb0, 0x0, {0x1e073e0, 0xc03c77ba00})
Oct  2 15:07:33 dogechain-validator dogechain[312072]: #011/go/src/state/executor.go:685 +0x2b3
Oct  2 15:07:33 dogechain-validator dogechain[312072]: github.com/dogechain-lab/dogechain/state.(*Transition).Call2(0xc03c77ba00, {0x3c, 0xd6, 0x51, 0x4c, 0x97, 0xda, 0xf9, 0xa, 0xff, ...}, ...)
Oct  2 15:07:33 dogechain-validator dogechain[312072]: #011/go/src/state/executor.go:626 +0x265
Oct  2 15:07:33 dogechain-validator dogechain[312072]: github.com/dogechain-lab/dogechain/state.(*Transition).apply(0xc03c77ba00, 0xc042fc35e0)
Oct  2 15:07:33 dogechain-validator dogechain[312072]: #011/go/src/state/executor.go:585 +0xd0c
```

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually