### PR TITLE
Fix evm state test crash when not providing host

### DIFF
--- a/state/executor.go
+++ b/state/executor.go
@@ -220,15 +220,15 @@ type Transition struct {
 
 // SetEVMLogger sets a non nil tracer to it
 func (t *Transition) SetEVMLogger(logger runtime.EVMLogger) {
-	if logger != nil {
-		t.evmLogger = logger
+	t.evmLogger = logger
 
-		switch logger.(type) {
-		case *runtime.DummyLogger:
-			// do nothing
-		default:
-			t.needDebug = true
-		}
+	switch logger.(type) {
+	case nil:
+		t.needDebug = false
+	case *runtime.DummyLogger:
+		t.needDebug = false
+	default:
+		t.needDebug = true
 	}
 }
 

--- a/state/runtime/evm/state.go
+++ b/state/runtime/evm/state.go
@@ -55,7 +55,7 @@ type state struct {
 	code []byte
 	tmp  []byte
 
-	host   runtime.Host
+	host   runtime.Host      // must have field
 	msg    *runtime.Contract // change with msg
 	config *chain.ForksInTime
 
@@ -251,8 +251,10 @@ func (c *state) Run() (ret []byte, vmerr error) {
 
 	// only real tracer need
 	switch logger.(type) {
+	case nil:
+		needDebug = false
 	case *runtime.DummyLogger:
-		// do nothing
+		needDebug = false
 	default:
 		needDebug = true
 	}

--- a/state/runtime/evm/state_test.go
+++ b/state/runtime/evm/state_test.go
@@ -163,6 +163,7 @@ func Test_extendMemory(t *testing.T) {
 		// set config
 		cfg := chain.AllForksEnabled.At(0)
 		s.config = &cfg
+		s.host = &mockHost{}
 
 		// offset
 		memoryOffset := test.memoryOffset


### PR DESCRIPTION
# Description

Evm state test crash when `host` not provided. This PR fixes it.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually