### PR TITLE
[network] increase pubsub message buffers

### DIFF
--- a/network/gossip.go
+++ b/network/gossip.go
@@ -21,8 +21,8 @@ const (
 	subscribeOutputBufferSize = 1024
 )
 
-// max worker number (min 1 and max 32)
-var workerNum = int(common.Min(common.Max(uint64(runtime.NumCPU()), 1), 32))
+// max worker number (min 2 and max 64)
+var workerNum = int(common.Min(common.Max(uint64(runtime.NumCPU()), 2), 64))
 
 type Topic struct {
 	logger hclog.Logger
@@ -74,7 +74,7 @@ func (t *Topic) readLoop(sub *pubsub.Subscription, handler func(obj interface{})
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
 
-	workqueue := make(chan proto.Message, workerNum)
+	workqueue := make(chan proto.Message, workerNum*4)
 	defer close(workqueue)
 
 	t.wg.Add(1)

--- a/network/server.go
+++ b/network/server.go
@@ -38,7 +38,7 @@ const (
 	// validateBufferSize is the size of validate buffers in go-libp2p-pubsub
 	// we should have enough capacity of the queue
 	// because when queue is full, validation is throttled and new messages are dropped.
-	validateBufferSize = 1024
+	validateBufferSize = subscribeOutputBufferSize * 2
 )
 
 const (


### PR DESCRIPTION
# Description

* increase gossip topic subscribe worker buffer size
* increase libp2p message validate buffer size

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

* Set up a four-node `dogechain` private network.
* Use the tool to send transactions (1000/s)
