### PR TITLE
[network] Fix bootnode re-discovery issue(Upstream PR 0xPolygon#775)

### DIFF
--- a/network/discovery/discovery.go
+++ b/network/discovery/discovery.go
@@ -76,6 +76,9 @@ type networkingServer interface {
 	// RemoveTemporaryDial removes a peer from the temporary dial map
 	RemoveTemporaryDial(peerID peer.ID)
 
+	// TemporaryDialPeer dials the peer temporarily
+	TemporaryDialPeer(peerAddrInfo *peer.AddrInfo)
+
 	// CONNECTION INFORMATION //
 
 	// HasFreeConnectionSlot checks if there is an available connection slot for the set direction [Thread safe]
@@ -300,6 +303,7 @@ func (d *DiscoveryService) regularPeerDiscovery() {
 		return
 	}
 
+	d.logger.Debug("running regular peer discovery", "peer", peerID.String())
 	// Try to discover the peers connected to the reference peer
 	if err := d.attemptToFindPeers(*peerID); err != nil {
 		d.logger.Error(
@@ -312,7 +316,7 @@ func (d *DiscoveryService) regularPeerDiscovery() {
 	}
 }
 
-// bootnodeDiscovery queries a random (unconnected) bootnode for new peers
+// bootnodePeerDiscovery queries a random (unconnected) bootnode for new peers
 // and adds them to the routing table
 func (d *DiscoveryService) bootnodePeerDiscovery() {
 	if !d.baseServer.HasFreeConnectionSlot(network.DirOutbound) {
@@ -331,7 +335,6 @@ func (d *DiscoveryService) bootnodePeerDiscovery() {
 		// Get a random unconnected bootnode from the bootnode set
 		bootnode = d.baseServer.GetRandomBootnode()
 		if bootnode == nil {
-			// No bootnodes available
 			return
 		}
 
@@ -361,10 +364,16 @@ func (d *DiscoveryService) bootnodePeerDiscovery() {
 		}
 	}()
 
+	// Make sure we are peered with a bootnode
+	d.baseServer.TemporaryDialPeer(bootnode)
+
 	// Find peers from the referenced bootnode
 	foundNodes, err := d.findPeersCall(bootnode.ID, true)
 	if err != nil {
-		d.logger.Error("Unable to execute bootnode peer discovery, %w", err)
+		d.logger.Error("Unable to execute bootnode peer discovery",
+			"bootnode", bootnode.ID.String(),
+			"err", err.Error(),
+		)
 
 		return
 	}

--- a/network/server.go
+++ b/network/server.go
@@ -47,8 +47,8 @@ const (
 
 	DefaultLibp2pPort int = 1478
 
-	MinimumPeerConnections int64 = 1
 	MinimumBootNodes       int   = 1
+	MinimumPeerConnections int64 = 1
 )
 
 var (
@@ -267,7 +267,7 @@ func (s *Server) Start() error {
 	}
 
 	go s.runDial()
-	go s.checkPeerConnections()
+	go s.keepAliveMinimumPeerConnections()
 
 	// watch for disconnected peers
 	s.host.Network().Notify(&network.NotifyBundle{
@@ -323,8 +323,9 @@ func (s *Server) setupBootnodes() error {
 	return nil
 }
 
-// checkPeerCount will attempt to make new connections if the active peer count is lesser than the specified limit.
-func (s *Server) checkPeerConnections() {
+// keepAliveMinimumPeerConnections will attempt to make new connections
+// if the active peer count is lesser than the specified limit.
+func (s *Server) keepAliveMinimumPeerConnections() {
 	delay := time.NewTimer(10 * time.Second)
 
 	for {
@@ -338,7 +339,11 @@ func (s *Server) checkPeerConnections() {
 
 		if s.numPeers() < MinimumPeerConnections {
 			if s.config.NoDiscover || !s.bootnodes.hasBootnodes() {
-				//TODO: dial peers from the peerstore
+				// dial unconnected peer
+				randPeer := s.GetRandomPeer()
+				if randPeer != nil && !s.IsConnected(*randPeer) {
+					s.addToDialQueue(s.GetPeerInfo(*randPeer), common.PriorityRandomDial)
+				}
 			} else {
 				randomNode := s.GetRandomBootnode()
 				s.addToDialQueue(randomNode, common.PriorityRandomDial)
@@ -402,11 +407,11 @@ func (s *Server) runDial() {
 
 			s.logger.Debug(fmt.Sprintf("Dialing peer [%s] as local [%s]", peerInfo.String(), s.host.ID()))
 
-			if !s.isConnected(peerInfo.ID) {
+			if !s.IsConnected(peerInfo.ID) {
 				// the connection process is async because it involves connection (here) +
 				// the handshake done in the identity service.
 				if err := s.host.Connect(context.Background(), *peerInfo); err != nil {
-					s.logger.Debug("failed to dial", "addr", peerInfo.String(), "err", err)
+					s.logger.Debug("failed to dial", "addr", peerInfo.String(), "err", err.Error())
 
 					s.emitEvent(peerInfo.ID, peerEvent.PeerFailedToConnect)
 				}
@@ -456,7 +461,7 @@ func (s *Server) hasPeer(peerID peer.ID) bool {
 }
 
 // isConnected checks if the networking server is connected to a peer
-func (s *Server) isConnected(peerID peer.ID) bool {
+func (s *Server) IsConnected(peerID peer.ID) bool {
 	return s.host.Network().Connectedness(peerID) == network.Connected
 }
 

--- a/network/server.go
+++ b/network/server.go
@@ -345,8 +345,10 @@ func (s *Server) keepAliveMinimumPeerConnections() {
 					s.addToDialQueue(s.GetPeerInfo(*randPeer), common.PriorityRandomDial)
 				}
 			} else {
-				randomNode := s.GetRandomBootnode()
-				s.addToDialQueue(randomNode, common.PriorityRandomDial)
+				// dial random unconnected bootnode
+				if randomNode := s.GetRandomBootnode(); randomNode != nil {
+					s.addToDialQueue(randomNode, common.PriorityRandomDial)
+				}
 			}
 		}
 	}

--- a/network/server_discovery.go
+++ b/network/server_discovery.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -15,10 +14,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/peerstore"
 	kb "github.com/libp2p/go-libp2p-kbucket"
 	rawGrpc "google.golang.org/grpc"
-)
-
-var (
-	errPeerDisconnected = errors.New("peer disconnected before the discovery client was initialized")
 )
 
 // GetRandomBootnode fetches a random bootnode that's currently
@@ -68,8 +63,9 @@ func (s *Server) NewDiscoveryClient(peerID peer.ID) (proto.DiscoveryClient, erro
 
 	// Check if there is a peer connection at this point in time,
 	// as there might have been a disconnection previously
-	if !s.isConnected(peerID) && !isTemporaryDial {
-		return nil, errPeerDisconnected
+	if !s.IsConnected(peerID) && !isTemporaryDial {
+		return nil, fmt.Errorf("could not initialize new discovery client - peer [%s] not connected",
+			peerID.String())
 	}
 
 	// Check if there is an active stream connection already
@@ -244,6 +240,11 @@ func (s *Server) setupDiscovery() error {
 	s.discovery = discoveryService
 
 	return nil
+}
+
+func (s *Server) TemporaryDialPeer(peerAddrInfo *peer.AddrInfo) {
+	s.logger.Debug("creating new temporary dial to peer", "peer", peerAddrInfo.ID)
+	s.addToDialQueue(peerAddrInfo, common.PriorityRandomDial)
 }
 
 // registerDiscoveryService registers the discovery protocol to be available

--- a/network/testing/testing.go
+++ b/network/testing/testing.go
@@ -42,6 +42,7 @@ type MockNetworkingServer struct {
 	getRandomPeerFn            getRandomPeerDelegate
 	fetchAndSetTemporaryDialFn fetchAndSetTemporaryDialDelegate
 	removeTemporaryDialFn      removeTemporaryDialDelegate
+	temporaryDialPeerFn        temporaryDialPeerDelegate
 }
 
 func NewMockNetworkingServer() *MockNetworkingServer {
@@ -85,6 +86,17 @@ type getPeerInfoDelegate func(peer.ID) *peer.AddrInfo
 type getRandomPeerDelegate func() *peer.ID
 type fetchAndSetTemporaryDialDelegate func(peer.ID, bool) bool
 type removeTemporaryDialDelegate func(peer.ID)
+type temporaryDialPeerDelegate func(peerAddrInfo *peer.AddrInfo)
+
+func (m *MockNetworkingServer) TemporaryDialPeer(peerAddrInfo *peer.AddrInfo) {
+	if m.temporaryDialPeerFn != nil {
+		m.temporaryDialPeerFn(peerAddrInfo)
+	}
+}
+
+func (m *MockNetworkingServer) HookTemporaryDialPeer(fn temporaryDialPeerDelegate) {
+	m.temporaryDialPeerFn = fn
+}
 
 func (m *MockNetworkingServer) NewIdentityClient(peerID peer.ID) (proto.IdentityClient, error) {
 	if m.newIdentityClientFn != nil {


### PR DESCRIPTION
# Description

From [0xPolygon#775](https://github.com/0xPolygon/polygon-edge/pull/775)

***
Right now, in a running network, once the bootnodes lose all of its peers (server restart, network issues or similar) it does not get back any peers, without restarting all the nodes.
There is a go routine that is supposed to ping random bootnode for the list of its peers, but the bootnodes stay disconnected from the rest of the network.

One can test this very easily, run a 4-node cluster with 1 bootnode. 
Keep all the nodes running but restart the bootnode. 
Once the bootnode goes back online, it will never join the network and it will always have 0 peers.
***

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Run a 4-node cluster with 1 bootnode. Restart or power cycle the bootnode only.
After the bootnode comes back online, after a while (no more than 60s), it should start peering with all the other nodes.
