### PR TITLE
[leveldb] set DisableSeeksCompaction to true

### DIFF
--- a/helper/kvdb/builder.go
+++ b/helper/kvdb/builder.go
@@ -148,6 +148,7 @@ func NewLevelDBBuilder(logger hclog.Logger, path string) LevelDBBuilder {
 			WriteBuffer:            minLevelDBCache / 4 * opt.MiB,
 			Filter:                 filter.NewBloomFilter(DefaultLevelDBBloomKeyBits),
 			NoSync:                 false,
+			DisableSeeksCompaction: true,
 		},
 	}
 }


### PR DESCRIPTION
# Description

"Seems to be faster without seek compaction"

 see: https://github.com/ethereum/go-ethereum/issues/21069

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
