### PR TITLE
[jsonrpc] New server option for fine-grained control over endpoint namespaces

### DIFF
--- a/command/server/config.go
+++ b/command/server/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	GraphQLAddr              string     `json:"graphql_addr"`
 	JSONRPCBatchRequestLimit uint64     `json:"json_rpc_batch_request_limit" yaml:"json_rpc_batch_request_limit"`
 	JSONRPCBlockRangeLimit   uint64     `json:"json_rpc_block_range_limit" yaml:"json_rpc_block_range_limit"`
+	JSONNamespace            []string   `json:"json_namespace" yaml:"json_namespace"`
 	EnableWS                 bool       `json:"enable_ws"`
 }
 
@@ -100,6 +101,7 @@ func DefaultConfig() *Config {
 		EnableGraphQL:            false,
 		JSONRPCBatchRequestLimit: jsonrpc.DefaultJSONRPCBatchRequestLimit,
 		JSONRPCBlockRangeLimit:   jsonrpc.DefaultJSONRPCBlockRangeLimit,
+		JSONNamespace:            []string{string(jsonrpc.NamespaceAll)},
 		EnableWS:                 false,
 	}
 }

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	GraphQLAddr              string     `json:"graphql_addr"`
 	JSONRPCBatchRequestLimit uint64     `json:"json_rpc_batch_request_limit" yaml:"json_rpc_batch_request_limit"`
 	JSONRPCBlockRangeLimit   uint64     `json:"json_rpc_block_range_limit" yaml:"json_rpc_block_range_limit"`
-	JSONNamespace            []string   `json:"json_namespace" yaml:"json_namespace"`
+	JSONNamespace            string     `json:"json_namespace" yaml:"json_namespace"`
 	EnableWS                 bool       `json:"enable_ws"`
 }
 
@@ -101,7 +101,7 @@ func DefaultConfig() *Config {
 		EnableGraphQL:            false,
 		JSONRPCBatchRequestLimit: jsonrpc.DefaultJSONRPCBatchRequestLimit,
 		JSONRPCBlockRangeLimit:   jsonrpc.DefaultJSONRPCBlockRangeLimit,
-		JSONNamespace:            []string{string(jsonrpc.NamespaceAll)},
+		JSONNamespace:            string(jsonrpc.NamespaceAll),
 		EnableWS:                 false,
 	}
 }

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -47,6 +47,7 @@ const (
 	enableGraphQLFlag            = "enable-graphql"
 	jsonRPCBatchRequestLimitFlag = "json-rpc-batch-request-limit"
 	jsonRPCBlockRangeLimitFlag   = "json-rpc-block-range-limit"
+	jsonrpcNamespaceFlag         = "json-rpc-namespace"
 	enableWSFlag                 = "enable-ws"
 )
 
@@ -179,6 +180,7 @@ func (p *serverParams) generateConfig() *server.Config {
 			AccessControlAllowOrigin: p.corsAllowedOrigins,
 			BatchLengthLimit:         p.rawConfig.JSONRPCBatchRequestLimit,
 			BlockRangeLimit:          p.rawConfig.JSONRPCBlockRangeLimit,
+			JSONNamespace:            p.rawConfig.JSONNamespace,
 			EnableWS:                 p.rawConfig.EnableWS,
 		},
 		EnableGraphQL: p.rawConfig.EnableGraphQL,

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -3,6 +3,7 @@ package server
 import (
 	"errors"
 	"net"
+	"strings"
 
 	"github.com/hashicorp/go-hclog"
 
@@ -173,6 +174,8 @@ func (p *serverParams) generateConfig() *server.Config {
 		chainCfg.Params.BlockGasTarget = p.blockGasTarget
 	}
 
+	ns := strings.Split(p.rawConfig.JSONNamespace, ",")
+
 	return &server.Config{
 		Chain: chainCfg,
 		JSONRPC: &server.JSONRPC{
@@ -180,7 +183,7 @@ func (p *serverParams) generateConfig() *server.Config {
 			AccessControlAllowOrigin: p.corsAllowedOrigins,
 			BatchLengthLimit:         p.rawConfig.JSONRPCBatchRequestLimit,
 			BlockRangeLimit:          p.rawConfig.JSONRPCBlockRangeLimit,
-			JSONNamespace:            p.rawConfig.JSONNamespace,
+			JSONNamespace:            ns,
 			EnableWS:                 p.rawConfig.EnableWS,
 		},
 		EnableGraphQL: p.rawConfig.EnableGraphQL,

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -113,6 +113,13 @@ func setFlags(cmd *cobra.Command) {
 			false,
 			"the flag indicating that node enable graphql service",
 		)
+
+		cmd.Flags().StringArrayVar(
+			&params.rawConfig.JSONNamespace,
+			jsonrpcNamespaceFlag,
+			defaultConfig.JSONNamespace,
+			"the jsonrpc endpoint namespaces should be enabled (eth, net, web3, txpool, debug, or * for all)",
+		)
 	}
 
 	// leveldb flags

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -114,11 +114,12 @@ func setFlags(cmd *cobra.Command) {
 			"the flag indicating that node enable graphql service",
 		)
 
-		cmd.Flags().StringArrayVar(
+		cmd.Flags().StringVar(
 			&params.rawConfig.JSONNamespace,
 			jsonrpcNamespaceFlag,
 			defaultConfig.JSONNamespace,
-			"the jsonrpc endpoint namespaces should be enabled (eth, net, web3, txpool, debug, or * for all)",
+			"the jsonrpc endpoint namespaces should be enabled "+
+				"(eth, net, web3, txpool, debug. concatenate with commas or * for all)",
 		)
 	}
 

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -13,14 +13,15 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-type EndpointNamespace string
+type Namespace string
 
 const (
-	NamespaceEth    EndpointNamespace = "eth"
-	NamespaceNet    EndpointNamespace = "net"
-	NamespaceWeb3   EndpointNamespace = "web3"
-	NamespaceTxpool EndpointNamespace = "txpool"
-	NamespaceDebug  EndpointNamespace = "debug"
+	NamespaceEth    Namespace = "eth"
+	NamespaceNet    Namespace = "net"
+	NamespaceWeb3   Namespace = "web3"
+	NamespaceTxpool Namespace = "txpool"
+	NamespaceDebug  Namespace = "debug"
+	NamespaceAll    Namespace = "*"
 )
 
 type serviceData struct {
@@ -57,6 +58,7 @@ type Dispatcher struct {
 	chainID                 uint64
 	jsonRPCBatchLengthLimit uint64
 	priceLimit              uint64
+	namespaces              map[Namespace]struct{}
 }
 
 func newDispatcher(
@@ -66,25 +68,34 @@ func newDispatcher(
 	jsonRPCBatchLengthLimit uint64,
 	blockRangeLimit uint64,
 	priceLimit uint64,
+	enableNamespaces []Namespace,
 ) *Dispatcher {
 	d := &Dispatcher{
 		logger:                  logger.Named("dispatcher"),
 		chainID:                 chainID,
 		jsonRPCBatchLengthLimit: jsonRPCBatchLengthLimit,
 		priceLimit:              priceLimit,
+		namespaces:              make(map[Namespace]struct{}),
 	}
 
+	// map namespaces
+	for _, ns := range enableNamespaces {
+		d.namespaces[ns] = struct{}{}
+	}
+
+	// enable filter
 	if store != nil {
 		d.filterManager = NewFilterManager(logger, store, blockRangeLimit)
 		go d.filterManager.Run()
 	}
 
-	d.registerEndpoints(store)
+	d.initEndpoints(store)
+	d.registerEndpoints()
 
 	return d
 }
 
-func (d *Dispatcher) registerEndpoints(store JSONRPCStore) {
+func (d *Dispatcher) initEndpoints(store JSONRPCStore) {
 	d.endpoints.Eth = &Eth{
 		logger:        d.logger,
 		store:         store,
@@ -96,12 +107,34 @@ func (d *Dispatcher) registerEndpoints(store JSONRPCStore) {
 	d.endpoints.Web3 = &Web3{}
 	d.endpoints.TxPool = &TxPool{store}
 	d.endpoints.Debug = &Debug{store}
+}
 
-	d.registerService(string(NamespaceEth), d.endpoints.Eth)
-	d.registerService(string(NamespaceNet), d.endpoints.Net)
-	d.registerService(string(NamespaceWeb3), d.endpoints.Web3)
-	d.registerService(string(NamespaceTxpool), d.endpoints.TxPool)
-	d.registerService(string(NamespaceDebug), d.endpoints.Debug)
+func (d *Dispatcher) registerEndpoints() {
+	// enable all endpoints
+	if _, ok := d.namespaces[NamespaceAll]; ok {
+		d.registerService(string(NamespaceEth), d.endpoints.Eth)
+		d.registerService(string(NamespaceNet), d.endpoints.Net)
+		d.registerService(string(NamespaceWeb3), d.endpoints.Web3)
+		d.registerService(string(NamespaceTxpool), d.endpoints.TxPool)
+		d.registerService(string(NamespaceDebug), d.endpoints.Debug)
+
+		return
+	}
+
+	for ns := range d.namespaces {
+		switch ns {
+		case NamespaceEth:
+			d.registerService(string(ns), d.endpoints.Eth)
+		case NamespaceNet:
+			d.registerService(string(ns), d.endpoints.Net)
+		case NamespaceWeb3:
+			d.registerService(string(ns), d.endpoints.Web3)
+		case NamespaceTxpool:
+			d.registerService(string(ns), d.endpoints.TxPool)
+		case NamespaceDebug:
+			d.registerService(string(ns), d.endpoints.Debug)
+		}
+	}
 }
 
 func (d *Dispatcher) getFnHandler(req Request) (*serviceData, *funcData, Error) {

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -13,6 +13,16 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
+type EndpointNamespace string
+
+const (
+	NamespaceEth    EndpointNamespace = "eth"
+	NamespaceNet    EndpointNamespace = "net"
+	NamespaceWeb3   EndpointNamespace = "web3"
+	NamespaceTxpool EndpointNamespace = "txpool"
+	NamespaceDebug  EndpointNamespace = "debug"
+)
+
 type serviceData struct {
 	sv      reflect.Value
 	funcMap map[string]*funcData
@@ -87,11 +97,11 @@ func (d *Dispatcher) registerEndpoints(store JSONRPCStore) {
 	d.endpoints.TxPool = &TxPool{store}
 	d.endpoints.Debug = &Debug{store}
 
-	d.registerService("eth", d.endpoints.Eth)
-	d.registerService("net", d.endpoints.Net)
-	d.registerService("web3", d.endpoints.Web3)
-	d.registerService("txpool", d.endpoints.TxPool)
-	d.registerService("debug", d.endpoints.Debug)
+	d.registerService(string(NamespaceEth), d.endpoints.Eth)
+	d.registerService(string(NamespaceNet), d.endpoints.Net)
+	d.registerService(string(NamespaceWeb3), d.endpoints.Web3)
+	d.registerService(string(NamespaceTxpool), d.endpoints.TxPool)
+	d.registerService(string(NamespaceDebug), d.endpoints.Debug)
 }
 
 func (d *Dispatcher) getFnHandler(req Request) (*serviceData, *funcData, Error) {

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -58,7 +58,9 @@ func expectBatchJSONResult(data []byte, v interface{}) error {
 func TestDispatcher_HandleWebsocketConnection_EthSubscribe(t *testing.T) {
 	t.Run("clients should be able to receive \"newHeads\" event thru eth_subscribe", func(t *testing.T) {
 		store := newMockStore()
-		dispatcher := newDispatcher(hclog.NewNullLogger(), store, 0, 0, 0, 0)
+		dispatcher := newDispatcher(hclog.NewNullLogger(), store, 0, 0, 0, 0, []Namespace{
+			NamespaceEth,
+		})
 
 		mockConnection := &mockWsConn{
 			msgCh: make(chan []byte, 1),
@@ -94,7 +96,9 @@ func TestDispatcher_HandleWebsocketConnection_EthSubscribe(t *testing.T) {
 
 func TestDispatcher_WebsocketConnection_RequestFormats(t *testing.T) {
 	store := newMockStore()
-	dispatcher := newDispatcher(hclog.NewNullLogger(), store, 0, 0, 0, 0)
+	dispatcher := newDispatcher(hclog.NewNullLogger(), store, 0, 0, 0, 0, []Namespace{
+		NamespaceEth,
+	})
 
 	mockConnection := &mockWsConn{
 		msgCh: make(chan []byte, 1),
@@ -198,7 +202,7 @@ func (m *mockService) Filter(f LogQuery) (interface{}, error) {
 func TestDispatcherFuncDecode(t *testing.T) {
 	srv := &mockService{msgCh: make(chan interface{}, 10)}
 
-	dispatcher := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0, 0)
+	dispatcher := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0, 0, nil)
 	dispatcher.registerService("mock", srv)
 
 	handleReq := func(typ string, msg string) interface{} {
@@ -280,7 +284,9 @@ func TestDispatcherBatchRequest(t *testing.T) {
 		{
 			"leading-whitespace",
 			"test with leading whitespace (\"  \\t\\n\\n\\r\\)",
-			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0, 0),
+			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0, 0, []Namespace{
+				NamespaceAll,
+			}),
 			append([]byte{0x20, 0x20, 0x09, 0x0A, 0x0A, 0x0D}, []byte(`[
 				{"id":1,"jsonrpc":"2.0","method":"eth_getBalance","params":["0x1", true]},
                 {"id":2,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x2", true]},
@@ -296,7 +302,9 @@ func TestDispatcherBatchRequest(t *testing.T) {
 		{
 			"valid-batch-req",
 			"test with batch req length within batchRequestLengthLimit",
-			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0, 0),
+			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0, 0, []Namespace{
+				NamespaceEth,
+			}),
 			[]byte(`[
 				{"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
                 {"id":2,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
@@ -316,7 +324,9 @@ func TestDispatcherBatchRequest(t *testing.T) {
 		{
 			"invalid-batch-req",
 			"test with batch req length exceeding batchRequestLengthLimit",
-			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 3, 1000, 0),
+			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 3, 1000, 0, []Namespace{
+				NamespaceEth,
+			}),
 			[]byte(`[
                 {"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
                 {"id":2,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
@@ -330,7 +340,9 @@ func TestDispatcherBatchRequest(t *testing.T) {
 		{
 			"no-limits",
 			"test when limits are not set",
-			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0, 0),
+			newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 0, 0, 0, []Namespace{
+				NamespaceEth,
+			}),
 			[]byte(`[
                 {"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},
                 {"id":2,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true]},

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -63,6 +63,7 @@ type Config struct {
 	AccessControlAllowOrigin []string
 	BatchLengthLimit         uint64
 	BlockRangeLimit          uint64
+	JSONNamespaces           []Namespace
 	EnableWS                 bool
 	PriceLimit               uint64
 	Metrics                  *Metrics
@@ -80,6 +81,7 @@ func NewJSONRPC(logger hclog.Logger, config *Config) (*JSONRPC, error) {
 			config.BatchLengthLimit,
 			config.BlockRangeLimit,
 			config.PriceLimit,
+			config.JSONNamespaces,
 		),
 		metrics: NewDummyMetrics(config.Metrics),
 	}

--- a/jsonrpc/web3_endpoint_test.go
+++ b/jsonrpc/web3_endpoint_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 func TestWeb3EndpointSha3(t *testing.T) {
-	dispatcher := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 20, 1000, 0)
+	dispatcher := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 20, 1000, 0, []Namespace{
+		NamespaceWeb3,
+	})
 
 	resp, err := dispatcher.Handle([]byte(`{
 		"method": "web3_sha3",
@@ -25,7 +27,9 @@ func TestWeb3EndpointSha3(t *testing.T) {
 }
 
 func TestWeb3EndpointClientVersion(t *testing.T) {
-	dispatcher := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 20, 1000, 0)
+	dispatcher := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 20, 1000, 0, []Namespace{
+		NamespaceWeb3,
+	})
 
 	resp, err := dispatcher.Handle([]byte(`{
 		"method": "web3_clientVersion",

--- a/server/config.go
+++ b/server/config.go
@@ -70,6 +70,7 @@ type JSONRPC struct {
 	AccessControlAllowOrigin []string
 	BatchLengthLimit         uint64
 	BlockRangeLimit          uint64
+	JSONNamespace            []string
 	EnableWS                 bool
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -668,6 +668,12 @@ func (s *Server) setupJSONRPC() error {
 		Server:             s.network,
 	}
 
+	// format the jsonrpc endpoint namespaces
+	namespaces := make([]jsonrpc.Namespace, len(s.config.JSONRPC.JSONNamespace))
+	for i, s := range s.config.JSONRPC.JSONNamespace {
+		namespaces[i] = jsonrpc.Namespace(s)
+	}
+
 	conf := &jsonrpc.Config{
 		Store:                    hub,
 		Addr:                     s.config.JSONRPC.JSONRPCAddr,
@@ -675,6 +681,7 @@ func (s *Server) setupJSONRPC() error {
 		AccessControlAllowOrigin: s.config.JSONRPC.AccessControlAllowOrigin,
 		BatchLengthLimit:         s.config.JSONRPC.BatchLengthLimit,
 		BlockRangeLimit:          s.config.JSONRPC.BlockRangeLimit,
+		JSONNamespaces:           namespaces,
 		EnableWS:                 s.config.JSONRPC.EnableWS,
 		PriceLimit:               s.config.PriceLimit,
 		Metrics:                  s.serverMetrics.jsonrpc,


### PR DESCRIPTION
# Description

Sometimes, RPC providers don't want to provide all the endpoints, for some of them consuming performance.

This PR provides a new server command flag `json-rpc-namespace` to satisfy the requirement. It is backward compatible, by providing default `"*"` value for enabling all JSON RPC endpoints.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

# Documentation update

Would update the documentation once the new version bumped.