### PR TITLE
[leveldb] default parameter change

### DIFF
--- a/helper/kvdb/builder.go
+++ b/helper/kvdb/builder.go
@@ -149,7 +149,8 @@ func NewLevelDBBuilder(logger hclog.Logger, path string) LevelDBBuilder {
 			CompactionTableSizeMultiplier: 1.1, // scale size up 1.1 multiple in next level
 			Filter:                        filter.NewBloomFilter(DefaultLevelDBBloomKeyBits),
 			NoSync:                        false,
-			BlockSize:                     64 * opt.KiB, // default 4kb, but one key-value pair need 0.5kb
+			BlockSize:                     256 * opt.KiB, // default 4kb, but one key-value pair need 0.5kb
+			FilterBaseLg:                  18,            // as well as 2mb
 		},
 	}
 }

--- a/helper/kvdb/builder.go
+++ b/helper/kvdb/builder.go
@@ -20,8 +20,8 @@ const (
 	DefaultLevelDBCache               = 1024 // 1 GiB
 	DefaultLevelDBHandles             = 512  // files handles to leveldb open files
 	DefaultLevelDBBloomKeyBits        = 2048 // bloom filter bits (256 bytes)
-	DefaultLevelDBCompactionTableSize = 8    // 8  MiB
-	DefaultLevelDBCompactionTotalSize = 32   // 32 MiB
+	DefaultLevelDBCompactionTableSize = 4    // 8  MiB
+	DefaultLevelDBCompactionTotalSize = 40   // 32 MiB
 	DefaultLevelDBNoSync              = false
 )
 
@@ -141,13 +141,15 @@ func NewLevelDBBuilder(logger hclog.Logger, path string) LevelDBBuilder {
 		logger: logger,
 		path:   path,
 		options: &opt.Options{
-			OpenFilesCacheCapacity: minLevelDBHandles,
-			CompactionTableSize:    DefaultLevelDBCompactionTableSize * opt.MiB,
-			CompactionTotalSize:    DefaultLevelDBCompactionTotalSize * opt.MiB,
-			BlockCacheCapacity:     minLevelDBCache / 2 * opt.MiB,
-			WriteBuffer:            minLevelDBCache / 4 * opt.MiB,
-			Filter:                 filter.NewBloomFilter(DefaultLevelDBBloomKeyBits),
-			NoSync:                 false,
+			OpenFilesCacheCapacity:        minLevelDBHandles,
+			CompactionTableSize:           DefaultLevelDBCompactionTableSize * opt.MiB,
+			CompactionTotalSize:           DefaultLevelDBCompactionTotalSize * opt.MiB,
+			BlockCacheCapacity:            minLevelDBCache / 2 * opt.MiB,
+			WriteBuffer:                   minLevelDBCache / 4 * opt.MiB,
+			CompactionTableSizeMultiplier: 1.1, // scale size up 1.1 multiple in next level
+			Filter:                        filter.NewBloomFilter(DefaultLevelDBBloomKeyBits),
+			NoSync:                        false,
+			BlockSize:                     64 * opt.KiB, // default 4kb, but one key-value pair need 0.5kb
 		},
 	}
 }

--- a/helper/kvdb/builder.go
+++ b/helper/kvdb/builder.go
@@ -65,12 +65,10 @@ type leveldbBuilder struct {
 func (builder *leveldbBuilder) SetCacheSize(cacheSize int) LevelDBBuilder {
 	cacheSize = max(cacheSize, minLevelDBCache)
 
-	builder.options.BlockCacheCapacity = (cacheSize / 2) * opt.MiB
-	builder.options.WriteBuffer = (cacheSize / 4) * opt.MiB
+	builder.options.BlockCacheCapacity = cacheSize * opt.MiB
 
 	builder.logger.Info("leveldb",
-		"BlockCacheCapacity", fmt.Sprintf("%d Mib", cacheSize/2),
-		"WriteBuffer", fmt.Sprintf("%d Mib", cacheSize/4),
+		"BlockCacheCapacity", fmt.Sprintf("%d Mib", cacheSize),
 	)
 
 	return builder
@@ -98,9 +96,11 @@ func (builder *leveldbBuilder) SetBloomKeyBits(bloomKeyBits int) LevelDBBuilder 
 
 func (builder *leveldbBuilder) SetCompactionTableSize(compactionTableSize int) LevelDBBuilder {
 	builder.options.CompactionTableSize = compactionTableSize * opt.MiB
+	builder.options.WriteBuffer = builder.options.CompactionTableSize * 2
 
 	builder.logger.Info("leveldb",
 		"CompactionTableSize", fmt.Sprintf("%d Mib", compactionTableSize),
+		"WriteBuffer", fmt.Sprintf("%d Mib", builder.options.WriteBuffer/opt.MiB),
 	)
 
 	return builder
@@ -144,8 +144,8 @@ func NewLevelDBBuilder(logger hclog.Logger, path string) LevelDBBuilder {
 			OpenFilesCacheCapacity:        minLevelDBHandles,
 			CompactionTableSize:           DefaultLevelDBCompactionTableSize * opt.MiB,
 			CompactionTotalSize:           DefaultLevelDBCompactionTotalSize * opt.MiB,
-			BlockCacheCapacity:            minLevelDBCache / 2 * opt.MiB,
-			WriteBuffer:                   minLevelDBCache / 4 * opt.MiB,
+			BlockCacheCapacity:            minLevelDBCache * opt.MiB,
+			WriteBuffer:                   (DefaultLevelDBCompactionTableSize * 2) * opt.MiB,
 			CompactionTableSizeMultiplier: 1.1, // scale size up 1.1 multiple in next level
 			Filter:                        filter.NewBloomFilter(DefaultLevelDBBloomKeyBits),
 			NoSync:                        false,

--- a/helper/kvdb/builder.go
+++ b/helper/kvdb/builder.go
@@ -20,8 +20,8 @@ const (
 	DefaultLevelDBCache               = 1024 // 1 GiB
 	DefaultLevelDBHandles             = 512  // files handles to leveldb open files
 	DefaultLevelDBBloomKeyBits        = 2048 // bloom filter bits (256 bytes)
-	DefaultLevelDBCompactionTableSize = 4    // 8  MiB
-	DefaultLevelDBCompactionTotalSize = 40   // 32 MiB
+	DefaultLevelDBCompactionTableSize = 4    // 4  MiB
+	DefaultLevelDBCompactionTotalSize = 40   // 40 MiB
 	DefaultLevelDBNoSync              = false
 )
 

--- a/helper/kvdb/builder.go
+++ b/helper/kvdb/builder.go
@@ -150,7 +150,7 @@ func NewLevelDBBuilder(logger hclog.Logger, path string) LevelDBBuilder {
 			Filter:                        filter.NewBloomFilter(DefaultLevelDBBloomKeyBits),
 			NoSync:                        false,
 			BlockSize:                     256 * opt.KiB, // default 4kb, but one key-value pair need 0.5kb
-			FilterBaseLg:                  18,            // as well as 2mb
+			FilterBaseLg:                  19,            // 512kb
 		},
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -141,7 +141,8 @@ func newLevelDBBuilder(logger hclog.Logger, config *Config, path string) kvdb.Le
 		path,
 	)
 
-	leveldbBuilder.SetCacheSize(config.LeveldbOptions.CacheSize).
+	// trie cache + blockchain cache = config.LeveldbOptions.CacheSize / 2
+	leveldbBuilder.SetCacheSize(config.LeveldbOptions.CacheSize / 2).
 		SetHandles(config.LeveldbOptions.Handles).
 		SetBloomKeyBits(config.LeveldbOptions.BloomKeyBits).
 		SetCompactionTableSize(config.LeveldbOptions.CompactionTableSize).


### PR DESCRIPTION
# Description

1. use snapshot restore is very slow, `trie` database is lot of random reads, need limit single sstable size, bad news is the number of files will swell
2. key-value pair need 0.5kb space (average, no compression), but leveldb block size default 4kb, one block store 8 key-value pair,is very inefficient, expand to 256kb (max 512 key-value pair, no compression)

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

1. use `dogechain backup` create snapshot
3. use `dogechain server --restore [snapshot] ......` restore server (empty data directory)
