### PR TITLE
[hardfork] Create a devnet only pre-portland hard fork

### DIFF
--- a/chain/params.go
+++ b/chain/params.go
@@ -32,8 +32,9 @@ type Forks struct {
 	EIP150         *Fork `json:"EIP150,omitempty"`
 	EIP158         *Fork `json:"EIP158,omitempty"`
 	EIP155         *Fork `json:"EIP155,omitempty"`
-	Portland       *Fork `json:"portland,omitempty"` // bridge hardfork
-	Detroit        *Fork `json:"detroit,omitempty"`  // pos hardfork
+	Preportland    *Fork `json:"pre-portland,omitempty"` // test hardfork only in some test networks
+	Portland       *Fork `json:"portland,omitempty"`     // bridge hardfork
+	Detroit        *Fork `json:"detroit,omitempty"`      // pos hardfork
 }
 
 func (f *Forks) on(ff *Fork, block uint64) bool {
@@ -84,6 +85,10 @@ func (f *Forks) IsPortland(block uint64) bool {
 	return f.active(f.Portland, block)
 }
 
+func (f *Forks) IsDetroit(block uint64) bool {
+	return f.active(f.Detroit, block)
+}
+
 func (f *Forks) At(block uint64) ForksInTime {
 	return ForksInTime{
 		Homestead:      f.active(f.Homestead, block),
@@ -94,9 +99,14 @@ func (f *Forks) At(block uint64) ForksInTime {
 		EIP150:         f.active(f.EIP150, block),
 		EIP158:         f.active(f.EIP158, block),
 		EIP155:         f.active(f.EIP155, block),
+		Preportland:    f.active(f.Preportland, block),
 		Portland:       f.active(f.Portland, block),
 		Detroit:        f.active(f.Detroit, block),
 	}
+}
+
+func (f *Forks) IsOnPreportland(block uint64) bool {
+	return f.on(f.Preportland, block)
 }
 
 func (f *Forks) IsOnPortland(block uint64) bool {
@@ -136,6 +146,7 @@ type ForksInTime struct {
 	EIP150,
 	EIP158,
 	EIP155,
+	Preportland,
 	Portland,
 	Detroit bool
 }
@@ -149,6 +160,7 @@ var AllForksEnabled = &Forks{
 	Constantinople: NewFork(0),
 	Petersburg:     NewFork(0),
 	Istanbul:       NewFork(0),
+	Preportland:    NewFork(10000),
 	Portland:       NewFork(10222),
 	Detroit:        NewFork(40562),
 }

--- a/contracts/upgrader/upgrader.go
+++ b/contracts/upgrader/upgrader.go
@@ -1,7 +1,9 @@
+//nolint:lll
 package upgrader
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/dogechain-lab/dogechain/chain"
 	"github.com/dogechain-lab/dogechain/contracts/systemcontracts"
@@ -15,7 +17,8 @@ type UpgradeConfig struct {
 	ContractAddr       types.Address
 	CommitURL          string
 	Code               string
-	DefaultInitStorage map[types.Hash]types.Hash // the initial storage must be backward compatible
+	DefaultInitStorage map[types.Hash]types.Hash  // the initial storage must be backward compatible
+	Rebalance          map[types.Address]*big.Int // deprecated, only active in test network
 }
 
 type Upgrade struct {
@@ -38,6 +41,8 @@ const (
 var (
 	GenesisHash types.Hash
 	//upgrade config
+	// pre-portland. deprecated in devnet
+	_prePortlandUpgrade = make(map[string]*Upgrade)
 	// portland
 	_portlandUpgrade = make(map[string]*Upgrade)
 	// detroit
@@ -45,8 +50,26 @@ var (
 )
 
 func init() {
-	//nolint:lll
-	// porland upgrade config
+	// pre-portland upgrade
+	_testInt, _ := new(big.Int).SetString("55000000000000000000", 0)
+	_prePortlandUpgradeContent := &Upgrade{
+		UpgradeName: "pre-portland",
+		Configs: []*UpgradeConfig{
+			{
+				Rebalance: map[types.Address]*big.Int{
+					types.StringToAddress("0x1b051e5D1548326284493BfA380E02C3C149Da4E"): _testInt,
+					types.StringToAddress("0xa516CF76d083b4cBe93Ebdfb85FbE72aFfFb7a0c"): big.NewInt(0),
+					types.StringToAddress("0xC7aD3276180f8dfb628d975473a81Af2836CDf2b"): big.NewInt(0),
+					types.StringToAddress("0x521299a363f1847863e4a6c68c91df722d149c3b"): big.NewInt(0),
+					types.StringToAddress("0x3a9185A6b49617cC2d5BE65aF199B73f24834F4f"): big.NewInt(0),
+				},
+			},
+		},
+	}
+	// network supports pre-portland hardfork
+	_prePortlandUpgrade[devNet] = _prePortlandUpgradeContent
+
+	// portland upgrade
 	_portlandUpgradeCfg := &Upgrade{
 		UpgradeName: "portland",
 		Configs: []*UpgradeConfig{
@@ -116,6 +139,15 @@ func UpgradeSystem(
 		network = mainNet
 	}
 
+	// only upgrade pre-portland once
+	if forks.IsOnPreportland(blockNumber) {
+		up, ok := _prePortlandUpgrade[network]
+		if ok {
+			applySystemContractUpgrade(up, blockNumber, txn, forks,
+				logger.With("upgrade", up.UpgradeName, "network", network))
+		}
+	}
+
 	// only upgrade portland once
 	if forks.IsOnPortland(blockNumber) {
 		up, ok := _portlandUpgrade[network]
@@ -155,15 +187,23 @@ func applySystemContractUpgrade(
 	for _, cfg := range upgrade.Configs {
 		logger.Info(fmt.Sprintf("Upgrade contract %s to commit %s", cfg.ContractAddr.String(), cfg.CommitURL))
 
+		// parse hex code
 		newContractCode, err := hex.DecodeHex(cfg.Code)
 		if err != nil {
 			panic(fmt.Errorf("failed to decode new contract code: %w", err))
 		}
 
+		// set system contract code
 		txn.SetCode(cfg.ContractAddr, newContractCode)
 
+		// initialize system contract storage if neccessary
 		for k, v := range cfg.DefaultInitStorage {
 			txn.SetStorage(cfg.ContractAddr, k, v, &forksInTime)
+		}
+
+		// deprecated. Re-set account balance in test cases
+		for account, balance := range cfg.Rebalance {
+			txn.SetBalance(account, balance)
 		}
 	}
 }

--- a/contracts/upgrader/upgrader.go
+++ b/contracts/upgrader/upgrader.go
@@ -196,7 +196,7 @@ func applySystemContractUpgrade(
 		// set system contract code
 		txn.SetCode(cfg.ContractAddr, newContractCode)
 
-		// initialize system contract storage if neccessary
+		// initialize system contract storage if necessary
 		for k, v := range cfg.DefaultInitStorage {
 			txn.SetStorage(cfg.ContractAddr, k, v, &forksInTime)
 		}

--- a/contracts/upgrader/upgrader.go
+++ b/contracts/upgrader/upgrader.go
@@ -27,10 +27,12 @@ type Upgrade struct {
 
 const (
 	MainNetChainID = 2000
+	DevNetChainID  = 668
 )
 
 const (
 	mainNet = "Mainnet"
+	devNet  = "Devnet"
 )
 
 var (
@@ -44,7 +46,8 @@ var (
 
 func init() {
 	//nolint:lll
-	_portlandUpgrade[mainNet] = &Upgrade{
+	// porland upgrade config
+	_portlandUpgradeCfg := &Upgrade{
 		UpgradeName: "portland",
 		Configs: []*UpgradeConfig{
 			{
@@ -54,8 +57,13 @@ func init() {
 			},
 		},
 	}
+	// networks support portland upgrade
+	_portlandUpgrade[mainNet] = _portlandUpgradeCfg
+	_portlandUpgrade[devNet] = _portlandUpgradeCfg
+
+	// detroit hardfork
 	//nolint:lll
-	_detroitUpgrade[mainNet] = &Upgrade{
+	_detroitUpgradeContent := &Upgrade{
 		UpgradeName: "detroit",
 		Configs: []*UpgradeConfig{
 			{
@@ -81,6 +89,9 @@ func init() {
 			},
 		},
 	}
+	// network supports detroit upgrade
+	_detroitUpgrade[mainNet] = _detroitUpgradeContent
+	_detroitUpgrade[devNet] = _detroitUpgradeContent
 }
 
 func UpgradeSystem(
@@ -97,6 +108,8 @@ func UpgradeSystem(
 	var network string
 
 	switch chainID {
+	case DevNetChainID:
+		network = devNet
 	case MainNetChainID:
 		fallthrough
 	default:
@@ -105,16 +118,20 @@ func UpgradeSystem(
 
 	// only upgrade portland once
 	if forks.IsOnPortland(blockNumber) {
-		up := _portlandUpgrade[network]
-		applySystemContractUpgrade(up, blockNumber, txn, forks,
-			logger.With("upgrade", up.UpgradeName, "network", network))
+		up, ok := _portlandUpgrade[network]
+		if ok { // only upgrade network needs to be upgraded
+			applySystemContractUpgrade(up, blockNumber, txn, forks,
+				logger.With("upgrade", up.UpgradeName, "network", network))
+		}
 	}
 
 	// only upgrade detroit once
 	if forks.IsOnDetroit(blockNumber) {
-		up := _detroitUpgrade[network]
-		applySystemContractUpgrade(up, blockNumber, txn, forks,
-			logger.With("upgrade", up.UpgradeName, "network", network))
+		up, ok := _detroitUpgrade[network]
+		if ok { // only upgrade network needs to be upgraded
+			applySystemContractUpgrade(up, blockNumber, txn, forks,
+				logger.With("upgrade", up.UpgradeName, "network", network))
+		}
 	}
 }
 


### PR DESCRIPTION
# Description

A newer node in the `devnet` could not sync to the latest block, which verify block failed on height `1062992`.

The hard fork was brought up to the network a little rushed, which is named `portland`, too.

This PR fixes it. We rename it to the `pre-portland` and it is only available in some test networks.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

* Set up a new `devnet` node, and join in the network.
* Watch if it can catch up to the latest block height.

It works in this branch, but fail in the base branch.