### PR TITLE
[ibft] Atomically overwrite snapshot meta file

### DIFF
--- a/consensus/ibft/snapshot.go
+++ b/consensus/ibft/snapshot.go
@@ -556,8 +556,15 @@ func writeDataStore(dir, filename string, obj interface{}) error {
 		return err
 	}
 
+	path := filepath.Join(dir, filename)
+
 	// mv the temporary file to the final file
-	if err := os.Rename(tmpFile.Name(), filepath.Join(dir, filename)); err != nil {
+	if err := os.Rename(tmpFile.Name(), path); err != nil {
+		return err
+	}
+
+	// chmod file to 0644
+	if err := os.Chmod(path, 0644); err != nil {
 		return err
 	}
 

--- a/consensus/ibft/snapshot.go
+++ b/consensus/ibft/snapshot.go
@@ -403,7 +403,7 @@ func (s *snapshotStore) loadFromPath(path string, l hclog.Logger) error {
 // saveToPath saves the snapshot store as a file to the specified path
 func (s *snapshotStore) saveToPath(path string) error {
 	// Write snapshots
-	if err := writeDataStore(filepath.Join(path, "snapshots"), s.list); err != nil {
+	if err := writeDataStore(path, "snapshots", s.list); err != nil {
 		return err
 	}
 
@@ -411,7 +411,7 @@ func (s *snapshotStore) saveToPath(path string) error {
 	meta := &snapshotMetadata{
 		LastBlock: s.lastNumber,
 	}
-	if err := writeDataStore(filepath.Join(path, "metadata"), meta); err != nil {
+	if err := writeDataStore(path, "metadata", meta); err != nil {
 		return err
 	}
 
@@ -532,14 +532,32 @@ func readDataStore(path string, obj interface{}) error {
 }
 
 // writeDataStore attempts to write the specific file to file storage
-func writeDataStore(path string, obj interface{}) error {
+func writeDataStore(dir, filename string, obj interface{}) error {
 	data, err := json.Marshal(obj)
 	if err != nil {
 		return err
 	}
 
-	//nolint:gosec
-	if err := ioutil.WriteFile(path, data, 0755); err != nil {
+	// atomically overwrite file
+	// https://stackoverflow.com/questions/30385225/is-there-an-os-independent-way-to-atomically-overwrite-a-file
+	// create a temporary file
+	tmpFile, err := os.CreateTemp(dir, filename+"*.tmp")
+	if err != nil {
+		return err
+	}
+
+	// write the data to the temporary file
+	if _, err := tmpFile.Write(data); err != nil {
+		return err
+	}
+
+	// close the temporary file
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+
+	// mv the temporary file to the final file
+	if err := os.Rename(tmpFile.Name(), filepath.Join(dir, filename)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Description

meta file `consensus/snapshots` and `consensus/metadata` is not atomically overwrite, data corruption risk when process killed

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

