### PR TITLE
Create state abstraction boundaries for write-ops in the state transition

### DIFF
--- a/state/executor.go
+++ b/state/executor.go
@@ -76,7 +76,8 @@ func (e *Executor) WriteGenesis(alloc map[types.Address]*chain.GenesisAccount) t
 		}
 	}
 
-	_, root := txn.Commit(false)
+	objs := txn.Commit(false)
+	_, root := snap.Commit(objs)
 
 	return types.BytesToHash(root)
 }
@@ -346,7 +347,8 @@ func (t *Transition) Write(txn *types.Transaction) error {
 			receipt.SetStatus(types.ReceiptSuccess)
 		}
 	} else {
-		ss, aux := t.state.Commit(t.config.EIP155)
+		objs := t.state.Commit(t.config.EIP155)
+		ss, aux := t.state.snapshot.Commit(objs)
 		t.state = NewTxn(t.auxState, ss)
 		root = aux
 		receipt.Root = types.BytesToHash(root)
@@ -424,7 +426,8 @@ func (t *Transition) handleBridgeLogs(msg *types.Transaction, logs []*types.Log)
 
 // Commit commits the final result
 func (t *Transition) Commit() (Snapshot, types.Hash) {
-	s2, root := t.state.Commit(t.config.EIP155)
+	objs := t.state.Commit(t.config.EIP155)
+	s2, root := t.state.snapshot.Commit(objs)
 
 	return s2, types.BytesToHash(root)
 }

--- a/state/testing.go
+++ b/state/testing.go
@@ -94,13 +94,13 @@ func testDeleteCommonStateRoot(t *testing.T, buildPreState buildPreState) {
 	txn.SetState(addr2, hash1, hash1)
 	txn.SetState(addr2, hash2, hash1)
 
-	snap2, _ := txn.Commit(false)
+	snap2, _ := snap.Commit(txn.Commit(false))
 	txn2 := newTxn(state, snap2)
 
 	txn2.SetState(addr1, hash0, hash0)
 	txn2.SetState(addr1, hash1, hash0)
 
-	snap3, _ := txn2.Commit(false)
+	snap3, _ := snap2.Commit(txn2.Commit(false))
 
 	txn3 := newTxn(state, snap3)
 	assert.Equal(t, hash1, txn3.GetState(addr1, hash2))
@@ -121,7 +121,7 @@ func testWriteState(t *testing.T, buildPreState buildPreState) {
 	assert.Equal(t, hash1, txn.GetState(addr1, hash1))
 	assert.Equal(t, hash2, txn.GetState(addr1, hash2))
 
-	snap, _ = txn.Commit(false)
+	snap, _ = snap.Commit(txn.Commit(false))
 
 	txn = newTxn(state, snap)
 	assert.Equal(t, hash1, txn.GetState(addr1, hash1))
@@ -136,7 +136,7 @@ func testWriteEmptyState(t *testing.T, buildPreState buildPreState) {
 
 	// Without EIP150 the data is added
 	txn.SetState(addr1, hash1, hash0)
-	snap, _ = txn.Commit(false)
+	snap, _ = snap.Commit(txn.Commit(false))
 
 	txn = newTxn(state, snap)
 	assert.True(t, txn.Exist(addr1))
@@ -146,7 +146,7 @@ func testWriteEmptyState(t *testing.T, buildPreState buildPreState) {
 
 	// With EIP150 the empty data is removed
 	txn.SetState(addr1, hash1, hash0)
-	snap, _ = txn.Commit(true)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
@@ -163,7 +163,7 @@ func testUpdateStateWithEmpty(t *testing.T, buildPreState buildPreState) {
 
 	// TODO, test with false (should not be deleted)
 	// TODO, test with balance on the account and nonce
-	snap, _ = txn.Commit(true)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
@@ -177,7 +177,7 @@ func testSuicideAccountInPreState(t *testing.T, buildPreState buildPreState) {
 
 	txn := newTxn(state, snap)
 	txn.Suicide(addr1)
-	snap, _ = txn.Commit(true)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
@@ -195,7 +195,7 @@ func testSuicideAccount(t *testing.T, buildPreState buildPreState) {
 	// Note, even if has commit suicide it still exists in the current txn
 	assert.True(t, txn.Exist(addr1))
 
-	snap, _ = txn.Commit(true)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
@@ -216,7 +216,7 @@ func testSuicideAccountWithData(t *testing.T, buildPreState buildPreState) {
 	txn.SetState(addr1, hash1, hash1)
 
 	txn.Suicide(addr1)
-	snap, _ = txn.Commit(true)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 
@@ -239,7 +239,7 @@ func testSuicideCoinbase(t *testing.T, buildPreState buildPreState) {
 	txn := newTxn(state, snap)
 	txn.Suicide(addr1)
 	txn.AddSealingReward(addr1, big.NewInt(10))
-	snap, _ = txn.Commit(true)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 	assert.Equal(t, big.NewInt(10), txn.GetBalance(addr1))
@@ -293,7 +293,7 @@ func testChangePrestateAccountBalanceToZero(t *testing.T, buildPreState buildPre
 
 	txn := newTxn(state, snap)
 	txn.SetBalance(addr1, big.NewInt(0))
-	snap, _ = txn.Commit(true)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))
@@ -307,7 +307,7 @@ func testChangeAccountBalanceToZero(t *testing.T, buildPreState buildPreState) {
 	txn := newTxn(state, snap)
 	txn.SetBalance(addr1, big.NewInt(10))
 	txn.SetBalance(addr1, big.NewInt(0))
-	snap, _ = txn.Commit(true)
+	snap, _ = snap.Commit(txn.Commit(true))
 
 	txn = newTxn(state, snap)
 	assert.False(t, txn.Exist(addr1))

--- a/state/txn.go
+++ b/state/txn.go
@@ -597,7 +597,8 @@ func (txn *Txn) CleanDeleteObjects(deleteEmptyObjects bool) {
 	txn.txn.Delete(refundIndex)
 }
 
-func (txn *Txn) Commit(deleteEmptyObjects bool) (Snapshot, []byte) {
+// func (txn *Txn) Commit(deleteEmptyObjects bool) (Snapshot, []byte) {
+func (txn *Txn) Commit(deleteEmptyObjects bool) []*Object {
 	txn.CleanDeleteObjects(deleteEmptyObjects)
 
 	x := txn.txn.Commit()
@@ -644,7 +645,5 @@ func (txn *Txn) Commit(deleteEmptyObjects bool) (Snapshot, []byte) {
 		return false
 	})
 
-	t, hash := txn.snapshot.Commit(objs)
-
-	return t, hash
+	return objs
 }

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -47,7 +47,7 @@ func RunSpecificTest(t *testing.T, file string, c stateCase, name, fork string, 
 		t.Fatal(err)
 	}
 
-	s, _, pastRoot := buildState(c.Pre)
+	s, snapshot, pastRoot := buildState(c.Pre)
 	forks := config.At(uint64(env.Number))
 
 	xxx := state.NewExecutor(&chain.Params{Forks: config, ChainID: 1}, s, hclog.NewNullLogger())
@@ -74,7 +74,9 @@ func RunSpecificTest(t *testing.T, file string, c stateCase, name, fork string, 
 	// mining rewards
 	txn.AddSealingReward(env.Coinbase, big.NewInt(0))
 
-	_, root := txn.Commit(forks.EIP158)
+	objs := txn.Commit(forks.EIP155)
+	_, root := snapshot.Commit(objs)
+
 	if !bytes.Equal(root, p.Root.Bytes()) {
 		t.Fatalf(
 			"root mismatch (%s %s %s %d): expected %s but found %s",

--- a/tests/testing.go
+++ b/tests/testing.go
@@ -243,7 +243,8 @@ func buildState(
 		}
 	}
 
-	snap, root := txn.Commit(false)
+	objs := txn.Commit(false)
+	snap, root := snap.Commit(objs)
 
 	return s, snap, types.BytesToHash(root)
 }


### PR DESCRIPTION
# Description

`State Transition Function` should not call `Commit` from the `Snapshot` interface and should only return the entries in the state that have been updated. Then, as part of another workflow, these entries would be updated in the `merkle trie`.

The PR is merging from Polygon Edge [PR 753](https://github.com/0xPolygon/polygon-edge/pull/753)

# Changes include

- [x] New feature (non-breaking change that adds functionality)

## Testing

- [x] I have tested this code with the official test suite