### PR TITLE
Fix the size of return value by eth_getStorageAt

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -419,8 +419,8 @@ func (e *Eth) GetStorageAt(
 	}
 	// Parse the RLP value
 	p := &fastrlp.Parser{}
-	v, err := p.Parse(result)
 
+	v, err := p.Parse(result)
 	if err != nil {
 		return argBytesPtr(types.ZeroHash[:]), nil
 	}
@@ -431,7 +431,8 @@ func (e *Eth) GetStorageAt(
 		return argBytesPtr(types.ZeroHash[:]), nil
 	}
 
-	return argBytesPtr(data), nil
+	// Pad to return 32 bytes data
+	return argBytesPtr(types.BytesToHash(data).Bytes()), nil
 }
 
 // GasPrice returns the average gas price based on the last x blocks


### PR DESCRIPTION
# Description

This PR makes `eth_getStorageAt` return 32 bytes data for any set storage.
For example, `eth_getStorageAt` in current Edge returns 4 bytes data for the storage where 2 uint16 values are stored. But other EVM chain always returns 32 bytes.

This PR is merging from PolygonEdge [PR 744](https://github.com/0xPolygon/polygon-edge/pull/744)

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

## Testing

- [x] I have tested this code with the official test suite