### PR TITLE
Fix disable default debug vars

### DIFF
--- a/command/helper/helper.go
+++ b/command/helper/helper.go
@@ -249,6 +249,13 @@ func RegisterPprofFlag(cmd *cobra.Command) {
 	)
 }
 
+// GetPprofFlag extracts the
+func GetPprofFlag(cmd *cobra.Command) bool {
+	v, _ := cmd.Flags().GetBool(command.PprofFlag)
+
+	return v
+}
+
 // ParseGraphQLAddress parses the passed in GraphQL address
 func ParseGraphQLAddress(graphqlAddress string) (*url.URL, error) {
 	return url.ParseRequestURI(graphqlAddress)

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -34,7 +34,8 @@ type Config struct {
 	JSONRPCBatchRequestLimit uint64     `json:"json_rpc_batch_request_limit" yaml:"json_rpc_batch_request_limit"`
 	JSONRPCBlockRangeLimit   uint64     `json:"json_rpc_block_range_limit" yaml:"json_rpc_block_range_limit"`
 	JSONNamespace            string     `json:"json_namespace" yaml:"json_namespace"`
-	EnableWS                 bool       `json:"enable_ws"`
+	EnableWS                 bool       `json:"enable_ws" yaml:"enable_ws"`
+	EnablePprof              bool       `json:"enable_pprof" yaml:"enable_pprof"`
 }
 
 // Telemetry holds the config details for metric services.
@@ -103,6 +104,7 @@ func DefaultConfig() *Config {
 		JSONRPCBlockRangeLimit:   jsonrpc.DefaultJSONRPCBlockRangeLimit,
 		JSONNamespace:            string(jsonrpc.NamespaceAll),
 		EnableWS:                 false,
+		EnablePprof:              false,
 	}
 }
 

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -174,6 +174,7 @@ func (p *serverParams) generateConfig() *server.Config {
 		chainCfg.Params.BlockGasTarget = p.blockGasTarget
 	}
 
+	// namespace
 	ns := strings.Split(p.rawConfig.JSONNamespace, ",")
 
 	return &server.Config{
@@ -185,12 +186,14 @@ func (p *serverParams) generateConfig() *server.Config {
 			BlockRangeLimit:          p.rawConfig.JSONRPCBlockRangeLimit,
 			JSONNamespace:            ns,
 			EnableWS:                 p.rawConfig.EnableWS,
+			EnablePprof:              p.rawConfig.EnablePprof,
 		},
 		EnableGraphQL: p.rawConfig.EnableGraphQL,
 		GraphQL: &server.GraphQL{
 			GraphQLAddr:              p.graphqlAddress,
 			AccessControlAllowOrigin: p.corsAllowedOrigins,
 			BlockRangeLimit:          p.rawConfig.JSONRPCBlockRangeLimit,
+			EnablePprof:              p.rawConfig.EnablePprof,
 		},
 		GRPCAddr:   p.grpcAddress,
 		LibP2PAddr: p.libp2pAddress,

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -459,6 +459,9 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		log.Println("Child process ", os.Getpid(), "ValidatorKey len: ", len(params.validatorKey))
 	}
 
+	// pprof flag
+	params.rawConfig.EnablePprof = helper.GetPprofFlag(cmd)
+
 	if err := runServerLoop(params.generateConfig(), outputter); err != nil {
 		outputter.SetError(err)
 		outputter.WriteOutput()

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -27,6 +27,7 @@ type Config struct {
 	ChainID                  uint64
 	AccessControlAllowOrigin []string
 	BlockRangeLimit          uint64
+	EnablePProf              bool
 }
 
 // GraphQLStore defines all the methods required
@@ -73,7 +74,16 @@ func (svc *GraphQLService) setupHTTP() error {
 		return err
 	}
 
-	mux := http.DefaultServeMux
+	var mux *http.ServeMux
+	if svc.config.EnablePProf {
+		// debug feature enabled
+		mux = http.DefaultServeMux
+	} else {
+		// NewServeMux must be used, as it disables all debug features.
+		// For some strange reason, with DefaultServeMux debug/vars is always enabled (but not debug/pprof).
+		// If pprof need to be enabled, this should be DefaultServeMux
+		mux = http.NewServeMux()
+	}
 
 	// The middleware factory returns a handler, so we need to wrap the handler function properly.
 	graphqlHandler := http.HandlerFunc(svc.handler.ServeHTTP)

--- a/server/config.go
+++ b/server/config.go
@@ -72,10 +72,12 @@ type JSONRPC struct {
 	BlockRangeLimit          uint64
 	JSONNamespace            []string
 	EnableWS                 bool
+	EnablePprof              bool
 }
 
 type GraphQL struct {
 	GraphQLAddr              *net.TCPAddr
 	AccessControlAllowOrigin []string
 	BlockRangeLimit          uint64
+	EnablePprof              bool
 }

--- a/server/server.go
+++ b/server/server.go
@@ -685,6 +685,7 @@ func (s *Server) setupJSONRPC() error {
 		JSONNamespaces:           namespaces,
 		EnableWS:                 s.config.JSONRPC.EnableWS,
 		PriceLimit:               s.config.PriceLimit,
+		EnablePProf:              s.config.JSONRPC.EnablePprof,
 		Metrics:                  s.serverMetrics.jsonrpc,
 	}
 
@@ -720,6 +721,7 @@ func (s *Server) setupGraphQL() error {
 		ChainID:                  uint64(s.config.Chain.Params.ChainID),
 		AccessControlAllowOrigin: s.config.GraphQL.AccessControlAllowOrigin,
 		BlockRangeLimit:          s.config.GraphQL.BlockRangeLimit,
+		EnablePProf:              s.config.GraphQL.EnablePprof,
 	}
 
 	srv, err := graphql.NewGraphQLService(s.logger, conf)


### PR DESCRIPTION
# Description

For some reason, `debug/vars` URL endpoint on the `json-rpc` http API is enabled by default when `DefaultServeMux` is used, even though `expvar` package is not imported anywhere.

This presents a potential security issue and needs to be disabled by using `NewServeMux` function, instead of `DefaultServeMux`.

The PR is merging from PolygonEdge [PR 745](https://github.com/0xPolygon/polygon-edge/pull/745)

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

## Testing

- [x] I have tested this code manually

### Manual tests

Compile binary from this branch and query `debug/vars` GET endpoint on JSON-RPC API. For example: `localhost:8545/debug/vars`. You should get the default GET output.