### PR TITLE
Add support for better client version details

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,7 @@ jobs:
           go-version: 1.17.x
 
       - name: Build Dogechain
-        # run: go build -tags netgo -ldflags="-s -w -linkmode external -extldflags "-static" -X \"github.com/dogechain-lab/dogechain/versioning.Version=${GITHUB_REF_NAME}\" -X \"github.com/dogechain-lab/dogechain/versioning.Commit=${GITHUB_SHA}\"" && tar -czvf dogechain.tar.gz dogechain
-        run: go build -a -o dogechain . && tar -czvf dogechain.tar.gz dogechain
+        run: go build -ldflags="-X \"github.com/dogechain-lab/dogechain/versioning.Version=${GITHUB_REF_NAME}\" -X \"github.com/dogechain-lab/dogechain/versioning.Commit=${GITHUB_SHA}\"" -a -o dogechain . && tar -czvf dogechain.tar.gz dogechain
         env:
           CGO_ENABLED: 0
           CC: gcc

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,13 @@ protoc:
 .PHONY: build
 build:
 	$(eval LATEST_VERSION = $(shell git describe --tags --abbrev=0))
-	$(eval COMMIT_HASH = $(shell git rev-parse --short HEAD))
+	$(eval COMMIT_HASH = $(shell git rev-parse HEAD))
 	$(eval DATE = $(shell date +'%Y-%m-%d_%T'))
-	go build -o dogechain -ldflags="-X 'github.com/dogechain-lab/dogechain/versioning.Version=$(LATEST_VERSION)+$(COMMIT_HASH)+$(DATE)'" main.go
+	go build -o dogechain -ldflags="\
+		-X 'github.com/dogechain-lab/dogechain/versioning.Version=$(LATEST_VERSION)'\
+		-X 'github.com/dogechain-lab/dogechain/versioning.Commit=$(COMMIT_HASH)'\
+		-X 'github.com/dogechain-lab/dogechain/versioning.BuildTime=$(DATE)'" \
+	main.go
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ protoc:
 build:
 	$(eval LATEST_VERSION = $(shell git describe --tags --abbrev=0))
 	$(eval COMMIT_HASH = $(shell git rev-parse HEAD))
-	$(eval DATE = $(shell date +'%Y-%m-%d_%T'))
+	$(eval DATE = $(shell date -u +'%Y-%m-%dT%TZ'))
 	go build -o dogechain -ldflags="\
 		-X 'github.com/dogechain-lab/dogechain/versioning.Version=$(LATEST_VERSION)'\
 		-X 'github.com/dogechain-lab/dogechain/versioning.Commit=$(COMMIT_HASH)'\

--- a/command/version/result.go
+++ b/command/version/result.go
@@ -1,9 +1,27 @@
 package version
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dogechain-lab/dogechain/command/helper"
+)
+
 type VersionResult struct {
-	Version string `json:"version"`
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	BuildTime string `json:"buildTime"`
 }
 
 func (r *VersionResult) GetOutput() string {
-	return r.Version
+	var s strings.Builder
+
+	s.WriteString("Dogechain\n")
+	s.WriteString(helper.FormatKV([]string{
+		fmt.Sprintf("Version|%s", r.Version),
+		fmt.Sprintf("Commit|%s", r.Commit),
+		fmt.Sprintf("Build Time|%s", r.BuildTime),
+	}))
+
+	return s.String()
 }

--- a/command/version/version.go
+++ b/command/version/version.go
@@ -21,7 +21,9 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 	outputter.SetCommandResult(
 		&VersionResult{
-			Version: versioning.Version,
+			Version:   versioning.Version,
+			Commit:    versioning.Commit,
+			BuildTime: versioning.BuildTime,
 		},
 	)
 }

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -104,7 +104,7 @@ func (d *Dispatcher) initEndpoints(store JSONRPCStore) {
 		priceLimit:    d.priceLimit,
 	}
 	d.endpoints.Net = &Net{store, d.chainID}
-	d.endpoints.Web3 = &Web3{}
+	d.endpoints.Web3 = &Web3{d.chainID}
 	d.endpoints.TxPool = &TxPool{store}
 	d.endpoints.Debug = &Debug{store}
 }

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -285,16 +285,16 @@ func (j *JSONRPC) handle(w http.ResponseWriter, req *http.Request) {
 	case http.MethodOptions:
 		// nothing to return
 	default:
-		_, _ = w.Write([]byte("method " + req.Method + " not allowed"))
 		j.metrics.Errors.Add(1.0)
+		w.Write([]byte("method " + req.Method + " not allowed"))
 	}
 }
 
 func (j *JSONRPC) handleJSONRPCRequest(w http.ResponseWriter, req *http.Request) {
 	data, err := io.ReadAll(req.Body)
 	if err != nil {
-		_, _ = w.Write([]byte(err.Error()))
 		j.metrics.Errors.Add(1.0)
+		w.Write([]byte(err.Error()))
 
 		return
 	}
@@ -307,13 +307,13 @@ func (j *JSONRPC) handleJSONRPCRequest(w http.ResponseWriter, req *http.Request)
 	// handle request
 	resp, err := j.dispatcher.Handle(data)
 
-	j.metrics.ResponseTime.Observe(float64(time.Since(startT).Seconds()))
+	j.metrics.ResponseTime.Observe(time.Since(startT).Seconds())
 
 	if err != nil {
-		_, _ = w.Write([]byte(err.Error()))
 		j.metrics.Errors.Add(1.0)
+		w.Write([]byte(err.Error()))
 	} else {
-		_, _ = w.Write(resp)
+		w.Write(resp)
 	}
 
 	j.logger.Debug("handle", "response", string(resp))
@@ -334,12 +334,12 @@ func (j *JSONRPC) handleGetRequest(writer io.Writer) {
 
 	resp, err := json.Marshal(data)
 	if err != nil {
-		_, _ = writer.Write([]byte(err.Error()))
 		j.metrics.Errors.Add(1.0)
+		writer.Write([]byte(err.Error()))
 	}
 
 	if _, err = writer.Write(resp); err != nil {
-		_, _ = writer.Write([]byte(err.Error()))
 		j.metrics.Errors.Add(1.0)
+		writer.Write([]byte(err.Error()))
 	}
 }

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -35,6 +35,10 @@ func (s serverType) String() string {
 	}
 }
 
+const (
+	_authoritativeChainName = "Dogechain"
+)
+
 // JSONRPC is an API backend
 type JSONRPC struct {
 	logger     hclog.Logger
@@ -327,7 +331,7 @@ type GetResponse struct {
 
 func (j *JSONRPC) handleGetRequest(writer io.Writer) {
 	data := &GetResponse{
-		Name:    "Dogechain",
+		Name:    _authoritativeChainName,
 		ChainID: j.config.ChainID,
 		Version: versioning.Version,
 	}

--- a/jsonrpc/jsonrpc_test.go
+++ b/jsonrpc/jsonrpc_test.go
@@ -1,10 +1,14 @@
 package jsonrpc
 
 import (
+	"bytes"
+	"encoding/json"
 	"net"
 	"testing"
 
 	"github.com/dogechain-lab/dogechain/helper/tests"
+	"github.com/dogechain-lab/dogechain/versioning"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/hashicorp/go-hclog"
 )
@@ -26,4 +30,38 @@ func TestHTTPServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func Test_handleGetRequest(t *testing.T) {
+	var (
+		chainName = _authoritativeChainName
+		chainID   = uint64(200)
+	)
+
+	jsonRPC := &JSONRPC{
+		config: &Config{
+			ChainID: chainID,
+		},
+	}
+
+	mockWriter := bytes.NewBuffer(nil)
+
+	jsonRPC.handleGetRequest(mockWriter)
+
+	response := &GetResponse{}
+
+	assert.NoError(
+		t,
+		json.Unmarshal(mockWriter.Bytes(), response),
+	)
+
+	assert.Equal(
+		t,
+		&GetResponse{
+			Name:    chainName,
+			ChainID: chainID,
+			Version: versioning.Version,
+		},
+		response,
+	)
 }

--- a/jsonrpc/web3_endpoint.go
+++ b/jsonrpc/web3_endpoint.go
@@ -9,11 +9,19 @@ import (
 )
 
 // Web3 is the web3 jsonrpc endpoint
-type Web3 struct{}
+type Web3 struct {
+	chainID uint64
+}
+
+var _clientVersionTemplate = "dogechain [chain-id: %d] [version: %s]"
 
 // ClientVersion returns the version of the web3 client (web3_clientVersion)
 func (w *Web3) ClientVersion() (interface{}, error) {
-	return fmt.Sprintf("dogechain [%s]", versioning.Version), nil
+	return fmt.Sprintf(
+		_clientVersionTemplate,
+		w.chainID,
+		versioning.Version,
+	), nil
 }
 
 // Sha3 returns Keccak-256 (not the standardized SHA3-256) of the given data

--- a/jsonrpc/web3_endpoint_test.go
+++ b/jsonrpc/web3_endpoint_test.go
@@ -27,9 +27,19 @@ func TestWeb3EndpointSha3(t *testing.T) {
 }
 
 func TestWeb3EndpointClientVersion(t *testing.T) {
-	dispatcher := newDispatcher(hclog.NewNullLogger(), newMockStore(), 0, 20, 1000, 0, []Namespace{
-		NamespaceWeb3,
-	})
+	chainID := uint64(100)
+
+	dispatcher := newDispatcher(
+		hclog.NewNullLogger(),
+		newMockStore(),
+		chainID,
+		20,
+		1000,
+		0,
+		[]Namespace{
+			NamespaceWeb3,
+		},
+	)
 
 	resp, err := dispatcher.Handle([]byte(`{
 		"method": "web3_clientVersion",
@@ -40,5 +50,11 @@ func TestWeb3EndpointClientVersion(t *testing.T) {
 	var res string
 
 	assert.NoError(t, expectJSONResult(resp, &res))
-	assert.Contains(t, res, fmt.Sprintf("dogechain [%v]", versioning.Version))
+	assert.Contains(t, res,
+		fmt.Sprintf(
+			_clientVersionTemplate,
+			chainID,
+			versioning.Version,
+		),
+	)
 }

--- a/versioning/versioning.go
+++ b/versioning/versioning.go
@@ -1,9 +1,11 @@
 package versioning
 
+// Embedded by --ldflags on build time
+// Versioning should follow the SemVer guidelines
+// https://semver.org/
 var (
 	// Version is the main version at the moment.
-	// Embedded by --ldflags on build time
-	// Versioning should follow the SemVer guidelines
-	// https://semver.org/
-	Version = "v0.1.0"
+	Version   string // the main version at the moment
+	Commit    string // the git commit that the binary was built on
+	BuildTime string // the timestamp of the build
 )


### PR DESCRIPTION
# Description

This PR resolves a pending issue that doesn't return proper chain information on the client version.

It removes the base `GET` endpoint to the JSON-RPC layer, as it's not by the standard, nor should it be supported.
Users should use the `web3_clientVersion` endpoint instead, that is outlined in the specification.

The PR is merging from PolygonEdge [PR 672](https://github.com/0xPolygon/polygon-edge/pull/672)

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

## Testing

- [x] I have tested this code with the official test suite