### PR TITLE
[blockchain] Remove unused storage snapshot functions

### DIFF
--- a/blockchain/storage/kvstorage/kvstorage.go
+++ b/blockchain/storage/kvstorage/kvstorage.go
@@ -219,23 +219,6 @@ func (s *KeyValueStorage) ReadBody(hash types.Hash) (*types.Body, error) {
 	return body, err
 }
 
-// SNAPSHOTS //
-
-// WriteSnapshot writes the snapshot to the DB
-func (s *KeyValueStorage) WriteSnapshot(hash types.Hash, blob []byte) error {
-	return s.set(SNAPSHOTS, hash.Bytes(), blob)
-}
-
-// ReadSnapshot reads the snapshot from the DB
-func (s *KeyValueStorage) ReadSnapshot(hash types.Hash) ([]byte, bool) {
-	data, ok := s.get(SNAPSHOTS, hash.Bytes())
-	if !ok {
-		return []byte{}, false
-	}
-
-	return data, true
-}
-
 // RECEIPTS //
 
 // WriteReceipts writes the receipts

--- a/blockchain/storage/storage.go
+++ b/blockchain/storage/storage.go
@@ -35,9 +35,6 @@ type Storage interface {
 	WriteBody(hash types.Hash, body *types.Body) error
 	ReadBody(hash types.Hash) (*types.Body, error)
 
-	WriteSnapshot(hash types.Hash, blob []byte) error
-	ReadSnapshot(hash types.Hash) ([]byte, bool)
-
 	WriteReceipts(hash types.Hash, receipts []*types.Receipt) error
 	ReadReceipts(hash types.Hash) ([]*types.Receipt, error)
 

--- a/blockchain/storage/testing.go
+++ b/blockchain/storage/testing.go
@@ -470,8 +470,6 @@ type readHeaderDelegate func(types.Hash) (*types.Header, error)
 type writeCanonicalHeaderDelegate func(*types.Header, *big.Int) error
 type writeBodyDelegate func(types.Hash, *types.Body) error
 type readBodyDelegate func(types.Hash) (*types.Body, error)
-type writeSnapshotDelegate func(types.Hash, []byte) error
-type readSnapshotDelegate func(types.Hash) ([]byte, bool)
 type writeReceiptsDelegate func(types.Hash, []*types.Receipt) error
 type readReceiptsDelegate func(types.Hash) ([]*types.Receipt, error)
 type writeTxLookupDelegate func(types.Hash, types.Hash) error
@@ -494,8 +492,6 @@ type MockStorage struct {
 	writeCanonicalHeaderFn writeCanonicalHeaderDelegate
 	writeBodyFn            writeBodyDelegate
 	readBodyFn             readBodyDelegate
-	writeSnapshotFn        writeSnapshotDelegate
-	readSnapshotFn         readSnapshotDelegate
 	writeReceiptsFn        writeReceiptsDelegate
 	readReceiptsFn         readReceiptsDelegate
 	writeTxLookupFn        writeTxLookupDelegate
@@ -685,30 +681,6 @@ func (m *MockStorage) ReadBody(hash types.Hash) (*types.Body, error) {
 
 func (m *MockStorage) HookReadBody(fn readBodyDelegate) {
 	m.readBodyFn = fn
-}
-
-func (m *MockStorage) WriteSnapshot(hash types.Hash, blob []byte) error {
-	if m.writeSnapshotFn != nil {
-		return m.writeSnapshotFn(hash, blob)
-	}
-
-	return nil
-}
-
-func (m *MockStorage) HookWriteSnapshot(fn writeSnapshotDelegate) {
-	m.writeSnapshotFn = fn
-}
-
-func (m *MockStorage) ReadSnapshot(hash types.Hash) ([]byte, bool) {
-	if m.readSnapshotFn != nil {
-		return m.readSnapshotFn(hash)
-	}
-
-	return []byte{}, true
-}
-
-func (m *MockStorage) HookReadSnapshot(fn readSnapshotDelegate) {
-	m.readSnapshotFn = fn
 }
 
 func (m *MockStorage) WriteReceipts(hash types.Hash, receipts []*types.Receipt) error {


### PR DESCRIPTION
# Description

This PR removes the `Snapshot` functions from the storage which have been long **deprecated**.

The PR is merging from PolygonEdge [PR 830](https://github.com/0xPolygon/polygon-edge/pull/830)

## Testing

- [x] I have tested this code with the official test suite