### PR TITLE
Use header gas limit when querying validators in pos

### DIFF
--- a/consensus/ibft/pos.go
+++ b/consensus/ibft/pos.go
@@ -207,7 +207,7 @@ func (pos *PoSMechanism) getNextValidators(header *types.Header) (validator.Vali
 		return nil, err
 	}
 
-	return validatorset.QueryValidators(transition, pos.ibft.validatorKeyAddr)
+	return validatorset.QueryValidators(transition, pos.ibft.validatorKeyAddr, header.GasLimit)
 }
 
 // updateSnapshotValidators updates validators in snapshot at given height

--- a/contracts/validatorset/query.go
+++ b/contracts/validatorset/query.go
@@ -28,7 +28,7 @@ const (
 
 const (
 	// Gas limit used when querying the validator set
-	_queryGasLimit uint64 = 2000000
+	_systemContractGasLimit uint64 = 2_000_000
 )
 
 var (
@@ -66,7 +66,7 @@ type TxQueryHandler interface {
 	Apply(*types.Transaction) (*runtime.ExecutionResult, error)
 }
 
-func QueryValidators(t TxQueryHandler, from types.Address) ([]types.Address, error) {
+func QueryValidators(t TxQueryHandler, from types.Address, gasLimit uint64) ([]types.Address, error) {
 	method := abis.ValidatorSetABI.Methods[_validatorsMethodName]
 
 	input, err := abis.EncodeTxMethod(method, nil)
@@ -80,7 +80,7 @@ func QueryValidators(t TxQueryHandler, from types.Address) ([]types.Address, err
 		Value:    big.NewInt(0),
 		Input:    input,
 		GasPrice: big.NewInt(0),
-		Gas:      _queryGasLimit,
+		Gas:      gasLimit,
 		Nonce:    t.GetNonce(from),
 	})
 
@@ -106,7 +106,7 @@ func MakeDepositTx(t NonceHub, from types.Address) (*types.Transaction, error) {
 	tx := &types.Transaction{
 		Nonce:    t.GetNonce(from),
 		GasPrice: big.NewInt(0),
-		Gas:      _queryGasLimit,
+		Gas:      _systemContractGasLimit,
 		To:       &systemcontracts.AddrValidatorSetContract,
 		Value:    nil,
 		Input:    input,
@@ -132,7 +132,7 @@ func MakeSlashTx(t NonceHub, from types.Address, needPunished types.Address) (*t
 	tx := &types.Transaction{
 		Nonce:    t.GetNonce(from),
 		GasPrice: big.NewInt(0),
-		Gas:      _queryGasLimit,
+		Gas:      _systemContractGasLimit,
 		To:       &systemcontracts.AddrValidatorSetContract,
 		Value:    nil,
 		Input:    input,

--- a/contracts/validatorset/query_test.go
+++ b/contracts/validatorset/query_test.go
@@ -183,7 +183,7 @@ func TestQueryValidators(t *testing.T) {
 					Value:    big.NewInt(0),
 					Input:    method.ID(),
 					GasPrice: big.NewInt(0),
-					Gas:      _queryGasLimit,
+					Gas:      _systemContractGasLimit,
 					Nonce:    10,
 				},
 			},
@@ -217,7 +217,7 @@ func TestQueryValidators(t *testing.T) {
 				},
 			}
 
-			res, err := QueryValidators(mock, tt.from)
+			res, err := QueryValidators(mock, tt.from, tt.mockArgs.tx.Gas)
 			if tt.succeed {
 				assert.NoError(t, err)
 			} else {


### PR DESCRIPTION
# Description

The `validators` query method would use more gas than we thought, then the whole network would stuck in building the ending block of an epoch.

The PR fixes it.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

## Testing

- [x] I have tested this code with the official test suite