### PR TITLE
[network] Check peerid, block self connect self

### DIFF
--- a/network/identity/identity.go
+++ b/network/identity/identity.go
@@ -19,6 +19,7 @@ const PeerID = "peerID"
 var (
 	ErrInvalidChainID   = errors.New("invalid chain ID")
 	ErrNoAvailableSlots = errors.New("no available Slots")
+	ErrSelfConnection   = errors.New("self connection")
 )
 
 // networkingServer defines the base communication interface between
@@ -172,6 +173,9 @@ func (i *IdentityService) handleConnected(peerID peer.ID, direction network.Dire
 		)
 	}
 
+	// self peer ID
+	selfPeerID := i.hostID.Pretty()
+
 	// Construct the response status
 	status := i.constructStatus(peerID)
 
@@ -184,6 +188,10 @@ func (i *IdentityService) handleConnected(peerID peer.ID, direction network.Dire
 	// Validate that the peers are working on the same chain
 	if status.Chain != resp.Chain {
 		return ErrInvalidChainID
+	}
+
+	if selfPeerID == resp.Metadata[PeerID] {
+		return ErrSelfConnection
 	}
 
 	// If this is a NOT temporary connection, save it


### PR DESCRIPTION
# Description

IdentityService check `Hello` response result, if `peerId` equal to self `peerId` (if peer is echo response), return error, don't add peer to pools

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
