### PR TITLE
[ibft] Banish transactions due to abnormal long time execution

### DIFF
--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -215,8 +215,8 @@ func (p *genesisParams) initConsensusEngineConfig() {
 func (p *genesisParams) initIBFTEngineMap(mechanism ibft.MechanismType) {
 	p.consensusEngineConfig = map[string]interface{}{
 		string(server.IBFTConsensus): map[string]interface{}{
-			"type":      mechanism,
-			"epochSize": p.epochSize,
+			ibft.KeyType:      mechanism,
+			ibft.KeyEpochSize: p.epochSize,
 		},
 	}
 }

--- a/consensus/ibft/hooks.go
+++ b/consensus/ibft/hooks.go
@@ -6,6 +6,12 @@ import (
 	"github.com/dogechain-lab/dogechain/helper/common"
 )
 
+const (
+	KeyType                   = "type"
+	KeyEpochSize              = "epochSize"
+	KeyBanishAbnormalContract = "banishAbnormalContract"
+)
+
 // Define the type of the IBFT consensus
 
 type MechanismType string

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -778,8 +778,12 @@ func (i *Ibft) writeTransactions(gasLimit uint64, transition transitionInterface
 		transactions = append(transactions, tx)
 	}
 
-	//nolint:lll
-	i.logger.Info("executed txns", "failed ", failedTxCount, "successful", successTxCount, "remaining in pool", i.txpool.Length())
+	i.logger.Info(
+		"executed txns", "failed ",
+		failedTxCount, "successful",
+		successTxCount, "remaining in pool",
+		i.txpool.Length(),
+	)
 
 	return transactions
 }

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -789,7 +789,7 @@ func (i *Ibft) writeTransactions(gasLimit uint64, transition transitionInterface
 }
 
 func (i *Ibft) shouldBanishTx(tx *types.Transaction) bool {
-	if !i.banishAbnormalContract || tx.To != nil {
+	if !i.banishAbnormalContract || tx.To == nil {
 		return false
 	}
 

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -850,7 +850,9 @@ func TestWriteTransactions(t *testing.T) {
 			m.txpool = mockTxPool
 			mockTransition := setupMockTransition(test, mockTxPool)
 
-			included := m.writeTransactions(1000, mockTransition)
+			endTime := time.Now().Add(time.Second)
+
+			included := m.writeTransactions(1000, mockTransition, endTime)
 
 			assert.Equal(t, uint64(test.params.expectedTxPoolLength), m.txpool.Length())
 			assert.Equal(t, test.params.expectedFailReceiptsWritten, len(mockTransition.failReceiptsWritten))

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -1209,17 +1209,18 @@ func newMockIbft(t *testing.T, accounts []string, account string) *mockIbft {
 	}
 
 	ibft := &Ibft{
-		logger:           hclog.NewNullLogger(),
-		config:           &consensus.Config{},
-		blockchain:       m,
-		validatorKey:     addr.priv,
-		validatorKeyAddr: addr.Address(),
-		closeCh:          make(chan struct{}),
-		updateCh:         make(chan struct{}),
-		operator:         &operator{},
-		state:            newState(),
-		epochSize:        DefaultEpochSize,
-		metrics:          consensus.NilMetrics(),
+		logger:              hclog.NewNullLogger(),
+		config:              &consensus.Config{},
+		blockchain:          m,
+		validatorKey:        addr.priv,
+		validatorKeyAddr:    addr.Address(),
+		closeCh:             make(chan struct{}),
+		updateCh:            make(chan struct{}),
+		operator:            &operator{},
+		state:               newState(),
+		epochSize:           DefaultEpochSize,
+		metrics:             consensus.NilMetrics(),
+		exhaustingContracts: make(map[types.Address]struct{}),
 	}
 
 	initIbftMechanism(PoA, ibft)
@@ -1692,9 +1693,7 @@ func Test_shouldBanishTx(t *testing.T) {
 
 	i := newMockIbft(t, []string{"A", "B", "C", "D"}, "A")
 	i.Ibft.banishAbnormalContract = true
-	i.Ibft.exhaustingContracts = map[types.Address]struct{}{
-		addr2: {},
-	}
+	i.Ibft.exhaustingContracts[addr2] = struct{}{}
 
 	assert.True(t, i.shouldBanishTx(mockTx))
 }

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"math/big"
 	"testing"
 	"time"
 
@@ -1673,4 +1674,29 @@ func TestGetIBFTForks(t *testing.T) {
 			assert.Equal(t, testcase.err, err)
 		})
 	}
+}
+
+func Test_shouldBanishTx(t *testing.T) {
+	var (
+		addr1 = types.StringToAddress("1")
+		addr2 = types.StringToAddress("2")
+	)
+
+	mockTx := &types.Transaction{
+		Nonce:    0,
+		GasPrice: big.NewInt(1000),
+		Gas:      defaultBlockGasLimit,
+		To:       &addr2,
+		Value:    big.NewInt(10),
+		Input:    []byte{'m', 'o', 'k', 'e'},
+		From:     addr1,
+	}
+
+	i := newMockIbft(t, []string{"A", "B", "C", "D"}, "A")
+	i.Ibft.banishAbnormalContract = true
+	i.Ibft.exhaustingContracts = map[types.Address]struct{}{
+		addr2: {},
+	}
+
+	assert.True(t, i.shouldBanishTx(mockTx))
 }

--- a/state/executor.go
+++ b/state/executor.go
@@ -252,7 +252,7 @@ func (t *Transition) Write(txn *types.Transaction) error {
 
 	result, e := t.Apply(msg)
 	if e != nil {
-		t.logger.Error("failed to apply tx", "err", e)
+		t.logger.Debug("failed to apply tx", "err", e)
 
 		return e
 	}


### PR DESCRIPTION
# Description

Some project created a lot of spam transactions and consumed all the gas in the block, which makes the whole network junk and hard to sync due to its heavy I/O consuming.

The PR fixed it by banishing all transactions called to some exhausting contracts, and mark a contract once the execution time exceeds a block time.

Besides, we create a new option in `IBFT` consensus to enable/disable banishing. Any validators could decide whether tolerating these I/O consuming transactions or not.

# Changes include

- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)

## Testing

- [x] I have tested this code with the official test suite