### PR TITLE
[sycner] Remove different network peer

### DIFF
--- a/network/server.go
+++ b/network/server.go
@@ -600,9 +600,9 @@ func (s *Server) Close() error {
 	return err
 }
 
-// newProtoConnection opens up a new stream on the set protocol to the peer,
+// NewProtoConnection opens up a new stream on the set protocol to the peer,
 // and returns a reference to the connection
-func (s *Server) newProtoConnection(protocol string, peerID peer.ID) (*rawGrpc.ClientConn, error) {
+func (s *Server) NewProtoConnection(protocol string, peerID peer.ID) (*rawGrpc.ClientConn, error) {
 	s.protocolsLock.Lock()
 	defer s.protocolsLock.Unlock()
 

--- a/network/server_discovery.go
+++ b/network/server_discovery.go
@@ -74,7 +74,7 @@ func (s *Server) NewDiscoveryClient(peerID peer.ID) (proto.DiscoveryClient, erro
 	}
 
 	// Create a new stream connection and return it
-	protoStream, err := s.newProtoConnection(common.DiscProto, peerID)
+	protoStream, err := s.NewProtoConnection(common.DiscProto, peerID)
 	if err != nil {
 		return nil, err
 	}
@@ -83,15 +83,15 @@ func (s *Server) NewDiscoveryClient(peerID peer.ID) (proto.DiscoveryClient, erro
 	// since they are referenced later on,
 	// if they are not temporary
 	if !isTemporaryDial {
-		s.saveProtocolStream(common.DiscProto, protoStream, peerID)
+		s.SaveProtocolStream(common.DiscProto, protoStream, peerID)
 	}
 
 	return proto.NewDiscoveryClient(protoStream), nil
 }
 
-// saveProtocolStream saves the protocol stream to the peer
+// SaveProtocolStream saves the protocol stream to the peer
 // protocol stream reference [Thread safe]
-func (s *Server) saveProtocolStream(
+func (s *Server) SaveProtocolStream(
 	protocol string,
 	stream *rawGrpc.ClientConn,
 	peerID peer.ID,

--- a/network/server_identity.go
+++ b/network/server_identity.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"math/big"
+
 	"github.com/dogechain-lab/dogechain/network/common"
 	peerEvent "github.com/dogechain-lab/dogechain/network/event"
 	"github.com/dogechain-lab/dogechain/network/grpc"
@@ -8,13 +10,15 @@ import (
 	"github.com/dogechain-lab/dogechain/network/proto"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
+	kbucket "github.com/libp2p/go-libp2p-kbucket"
+	"github.com/libp2p/go-libp2p-kbucket/keyspace"
 	rawGrpc "google.golang.org/grpc"
 )
 
 // NewIdentityClient returns a new identity service client connection
 func (s *Server) NewIdentityClient(peerID peer.ID) (proto.IdentityClient, error) {
 	// Create a new stream connection and return it
-	protoStream, err := s.newProtoConnection(common.IdentityProto, peerID)
+	protoStream, err := s.NewProtoConnection(common.IdentityProto, peerID)
 	if err != nil {
 		return nil, err
 	}
@@ -129,4 +133,11 @@ func (s *Server) registerIdentityService(identityService *identity.IdentityServi
 	grpcStream.Serve()
 
 	s.RegisterProtocol(common.IdentityProto, grpcStream)
+}
+
+func (s *Server) GetPeerDistance(peerID peer.ID) *big.Int {
+	nodeKey := keyspace.Key{Space: keyspace.XORKeySpace, Bytes: kbucket.ConvertPeerID(s.AddrInfo().ID)}
+	peerKey := keyspace.Key{Space: keyspace.XORKeySpace, Bytes: kbucket.ConvertPeerID(peerID)}
+
+	return nodeKey.Distance(peerKey)
 }

--- a/protocol/sync_peer.go
+++ b/protocol/sync_peer.go
@@ -77,23 +77,11 @@ type SyncPeer struct {
 
 	// peer kademlia distance with current node
 	distance *big.Int
-	// peer syncing speed, bytes per second
-	syncingSpeed uint64
 }
 
 // Distance returns the kademlia distance from current peer
 func (s *SyncPeer) Distance() *big.Int {
 	return s.distance
-}
-
-// UpdateSyncingSpeed sets the syncing speed in bytes per second
-func (s *SyncPeer) UpdateSyncingSpeed(speed uint64) {
-	s.syncingSpeed = speed
-}
-
-// SyncingSpeed returns syncing speed in bytes per second
-func (s *SyncPeer) SyncingSpeed() uint64 {
-	return s.syncingSpeed
 }
 
 // Number returns the latest peer block height

--- a/protocol/sync_peer.go
+++ b/protocol/sync_peer.go
@@ -74,6 +74,26 @@ type SyncPeer struct {
 	enqueueLock sync.Mutex
 	enqueue     minNumBlockQueue
 	enqueueCh   chan struct{}
+
+	// peer kademlia distance with current node
+	distance *big.Int
+	// peer syncing speed, bytes per second
+	syncingSpeed uint64
+}
+
+// Distance returns the kademlia distance from current peer
+func (s *SyncPeer) Distance() *big.Int {
+	return s.distance
+}
+
+// UpdateSyncingSpeed sets the syncing speed in bytes per second
+func (s *SyncPeer) UpdateSyncingSpeed(speed uint64) {
+	s.syncingSpeed = speed
+}
+
+// SyncingSpeed returns syncing speed in bytes per second
+func (s *SyncPeer) SyncingSpeed() uint64 {
+	return s.syncingSpeed
 }
 
 // Number returns the latest peer block height

--- a/protocol/sync_peer.go
+++ b/protocol/sync_peer.go
@@ -74,14 +74,6 @@ type SyncPeer struct {
 	enqueueLock sync.Mutex
 	enqueue     minNumBlockQueue
 	enqueueCh   chan struct{}
-
-	// peer kademlia distance with current node
-	distance *big.Int
-}
-
-// Distance returns the kademlia distance from current peer
-func (s *SyncPeer) Distance() *big.Int {
-	return s.distance
 }
 
 // Number returns the latest peer block height

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -337,7 +337,7 @@ func (s *Syncer) BestPeer() *SyncPeer {
 
 		peerBlockNumber := syncPeer.Number()
 		// compare block height
-		if peerBlockNumber > bestBlockNumber {
+		if bestPeer == nil || peerBlockNumber > bestBlockNumber {
 			bestPeer = syncPeer
 			bestBlockNumber = peerBlockNumber
 		} else if peerBlockNumber == bestBlockNumber &&

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -340,9 +340,6 @@ func (s *Syncer) BestPeer() *SyncPeer {
 		if bestPeer == nil || peerBlockNumber > bestBlockNumber {
 			bestPeer = syncPeer
 			bestBlockNumber = peerBlockNumber
-		} else if peerBlockNumber == bestBlockNumber &&
-			syncPeer.Distance().Cmp(bestPeer.Distance()) < 0 { // compare the distance
-			bestPeer = syncPeer
 		}
 
 		return true
@@ -390,7 +387,6 @@ func (s *Syncer) AddPeer(peerID peer.ID) error {
 		status:    status,
 		enqueue:   make(minNumBlockQueue, 0, maxEnqueueSize+1),
 		enqueueCh: make(chan struct{}),
-		distance:  s.server.GetPeerDistance(peerID),
 	})
 
 	return nil

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -364,6 +364,27 @@ func (s *Syncer) BestPeer() *SyncPeer {
 	return bestPeer
 }
 
+func (s *Syncer) UpdateSyncingSpeed(peerID peer.ID, speed uint64) {
+	s.logger.Debug(
+		"update peer speed",
+		"peer",
+		peerID,
+		"speed(bytes per second)",
+		speed,
+	)
+
+	if peer, ok := s.peers.Load(peerID); ok {
+		syncPeer, ok := peer.(*SyncPeer)
+		if !ok {
+			s.logger.Error("invalid sync peer type cast")
+
+			return
+		}
+
+		syncPeer.UpdateSyncingSpeed(speed)
+	}
+}
+
 // AddPeer establishes new connection with the given peer
 func (s *Syncer) AddPeer(peerID peer.ID) error {
 	if _, ok := s.peers.Load(peerID); ok {

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -633,6 +633,8 @@ func (s *Syncer) BulkSyncWithPeer(p *SyncPeer, newBlockHandler func(block *types
 			// Verify and write the data locally
 			for _, block := range sk.blocks {
 				if err := s.blockchain.VerifyFinalizedBlock(block); err != nil {
+					s.server.DisconnectFromPeer(p.peer, "Different network due to hard fork")
+
 					return fmt.Errorf("unable to verify block, %w", err)
 				}
 


### PR DESCRIPTION
# Description

The remote peer was not removed even if it was another (private) network, and it might bring annoying messages to current node.

The PR fixes the issue, disconnect those different network peers, and gives a more reasonable way of finding `BestPeer`: compare distance when peers' block numbers are same.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

1. Deploy a 4-nodes pos network, but only bring up 3 nodes.
2. Modify the last node with different `portland` hard fork height in `Genesis`.
3. Bring the last node up.

The PR branch node would reject the block and disconnect peers. In contrast, the base branch node do not disconnect peers, but instead try to query blocks over and over.