### PR TITLE
[txpool] Fix deadlock when watching txpool status

### DIFF
--- a/txpool/account.go
+++ b/txpool/account.go
@@ -6,21 +6,21 @@ import (
 	"sync/atomic"
 	"time"
 
-	cmap "github.com/dogechain-lab/dogechain/helper/concurrentmap"
 	"github.com/dogechain-lab/dogechain/types"
 )
 
 // Thread safe map of all accounts registered by the pool.
 // Each account (value) is bound to one address (key).
 type accountsMap struct {
-	cmap  cmap.ConcurrentMap
+	// sync.Map is thread-safe and high performance.
+	// We should not use some simple locked implementation map for this comprecated usage,
+	// otherwise there might be deadlock.
+	cmap  sync.Map
 	count uint64
 }
 
 func newAccountsMap() *accountsMap {
-	return &accountsMap{
-		cmap: cmap.NewConcurrentMap(),
-	}
+	return &accountsMap{}
 }
 
 // Intializes an account for the given address.

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -13,7 +13,7 @@ import (
 // Each account (value) is bound to one address (key).
 type accountsMap struct {
 	// sync.Map is thread-safe and high performance.
-	// We should not use some simple locked implementation map for this comprecated usage,
+	// We should not use some simple locked implementation map for this complicate usage,
 	// otherwise there might be deadlock.
 	cmap  sync.Map
 	count uint64


### PR DESCRIPTION
# Description

The txpool would lockup and never be executable when adding transactions and watch node txpool status together. It is caused by `concurrentMap` lock, which is not implemented for complicate use cases.

The PR fixes it by rolling back to `sync.Map`.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

* Set up a 4 node validator network.
* Send 10-20 transactions per second to one of them.
* Query the node's txpool: `dogechain txpool status`.
* Repeat query 2-5 times.

The base branch would stuck and never yield blocks again.
In contrast, the PR branch would go on pretty well.