### PR TITLE
[txpool] remove read lock, fix dead lock

### DIFF
--- a/helper/concurrentmap/concurrent_map.go
+++ b/helper/concurrentmap/concurrent_map.go
@@ -88,11 +88,12 @@ func (m *concurrentMap) Delete(key interface{}) {
 }
 
 func (m *concurrentMap) Range(f func(key, value interface{}) bool) {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
+	keys := m.Keys()
 
-	for key, value := range m.m {
-		if !f(key, value) {
+	for _, key := range keys {
+		load, _ := m.Load(key)
+
+		if !f(key, load) {
 			break
 		}
 	}

--- a/helper/concurrentmap/concurrent_map_test.go
+++ b/helper/concurrentmap/concurrent_map_test.go
@@ -1,6 +1,8 @@
 package concurrentmap
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestConcurrentMap(t *testing.T) {
 	cmap := NewConcurrentMap()

--- a/helper/concurrentmap/concurrent_map_test.go
+++ b/helper/concurrentmap/concurrent_map_test.go
@@ -52,6 +52,11 @@ func TestConcurrentMap(t *testing.T) {
 			t.Error("Range() failed")
 		}
 
+		// test re-entrant deadlock
+		k, _ := key.(string)
+		v, _ := value.(string)
+		cmap.Store(k+"-re", v+"-re")
+
 		return true
 	})
 

--- a/protocol/syncer_test.go
+++ b/protocol/syncer_test.go
@@ -702,15 +702,7 @@ func createSyncers(count int, servers []*network.Server, blockStores []*mockBloc
 
 // numSyncPeers returns the number of sync peers
 func numSyncPeers(syncer *Syncer) int64 {
-	num := 0
-
-	syncer.peers.Range(func(key, value interface{}) bool {
-		num++
-
-		return true
-	})
-
-	return int64(num)
+	return int64(syncer.peers.Len())
 }
 
 // WaitUntilSyncPeersNumber waits until the number of sync peers reaches a certain number, otherwise it times out


### PR DESCRIPTION
# Description

PR #241 alternative plan, `concurrentMap.Range()` is read lock, but `txpool` exist dead lock, trying to modify while iterate,this is bad use cases

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
