### PR TITLE
[protocol] breaking: protocol add prefix and check peer protocol

### DIFF
--- a/command/common.go
+++ b/command/common.go
@@ -3,6 +3,7 @@ package command
 const (
 	ConsensusFlag  = "consensus"
 	NoDiscoverFlag = "no-discover"
+	CheckProtocols = "check-protocols"
 	BootnodeFlag   = "bootnode"
 	LogLevelFlag   = "log-level"
 )

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -45,6 +45,7 @@ type Telemetry struct {
 // Network defines the network configuration params
 type Network struct {
 	NoDiscover       bool   `json:"no_discover"`
+	CheckProtocols   bool   `json:"check_protocols,omitempty"`
 	Libp2pAddr       string `json:"libp2p_addr"`
 	NatAddr          string `json:"nat_addr"`
 	DNSAddr          string `json:"dns_addr"`
@@ -79,6 +80,7 @@ func DefaultConfig() *Config {
 		BlockGasTarget: "0x0", // Special value signaling the parent gas limit should be applied
 		Network: &Network{
 			NoDiscover:       defaultNetworkConfig.NoDiscover,
+			CheckProtocols:   defaultNetworkConfig.CheckProtocols,
 			MaxPeers:         defaultNetworkConfig.MaxPeers,
 			MaxOutboundPeers: defaultNetworkConfig.MaxOutboundPeers,
 			MaxInboundPeers:  defaultNetworkConfig.MaxInboundPeers,

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -199,6 +199,7 @@ func (p *serverParams) generateConfig() *server.Config {
 		},
 		Network: &network.Config{
 			NoDiscover:       p.rawConfig.Network.NoDiscover,
+			CheckProtocols:   p.rawConfig.Network.CheckProtocols,
 			Addr:             p.libp2pAddress,
 			NatAddr:          p.natAddress,
 			DNS:              p.dnsAddress,

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -226,6 +226,13 @@ func setFlags(cmd *cobra.Command) {
 			"prevent the client from discovering other peers (default: false)",
 		)
 
+		cmd.Flags().BoolVar(
+			&params.rawConfig.Network.CheckProtocols,
+			command.CheckProtocols,
+			defaultConfig.Network.CheckProtocols,
+			"check peer protocols (default: false)",
+		)
+
 		cmd.Flags().Int64Var(
 			&params.rawConfig.Network.MaxPeers,
 			maxPeersFlag,

--- a/network/common/common.go
+++ b/network/common/common.go
@@ -3,10 +3,11 @@ package common
 import (
 	"errors"
 	"fmt"
-	"github.com/libp2p/go-libp2p-core/peer"
-	"github.com/multiformats/go-multiaddr"
 	"regexp"
 	"strings"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
 )
 
 type DialPriority uint64
@@ -14,11 +15,6 @@ type DialPriority uint64
 const (
 	PriorityRequestedDial DialPriority = 1
 	PriorityRandomDial    DialPriority = 10
-)
-
-const (
-	DiscProto     = "/disc/0.1"
-	IdentityProto = "/id/0.1"
 )
 
 // DNSRegex is a regex string to match against a valid dns/dns4/dns6 addr

--- a/network/common/protocol.go
+++ b/network/common/protocol.go
@@ -1,0 +1,11 @@
+package common
+
+type ProtocolId string
+
+const (
+	ProtocolPrefix = "/dogechain"
+
+	DiscProto     ProtocolId = ProtocolPrefix + "/disc/0.1"
+	IdentityProto ProtocolId = ProtocolPrefix + "/id/0.1"
+	SyncerV1Proto ProtocolId = ProtocolPrefix + "/syncer/0.1"
+)

--- a/network/common/protocol.go
+++ b/network/common/protocol.go
@@ -1,11 +1,11 @@
 package common
 
-type ProtocolId string
+type ProtocolID string
 
 const (
 	ProtocolPrefix = "/dogechain"
 
-	DiscProto     ProtocolId = ProtocolPrefix + "/disc/0.1"
-	IdentityProto ProtocolId = ProtocolPrefix + "/id/0.1"
-	SyncerV1Proto ProtocolId = ProtocolPrefix + "/syncer/0.1"
+	DiscProto     ProtocolID = ProtocolPrefix + "/disc/0.1"
+	IdentityProto ProtocolID = ProtocolPrefix + "/id/0.1"
+	SyncerV1Proto ProtocolID = ProtocolPrefix + "/syncer/0.1"
 )

--- a/network/config.go
+++ b/network/config.go
@@ -11,6 +11,7 @@ import (
 // Config details the params for the base networking server
 type Config struct {
 	NoDiscover       bool                   // flag indicating if the discovery mechanism should be turned on
+	CheckProtocols   bool                   // flag indicating if the protocols should be checked
 	Addr             *net.TCPAddr           // the base address
 	NatAddr          *net.TCPAddr           // the NAT address
 	DNS              multiaddr.Multiaddr    // the DNS address
@@ -26,7 +27,8 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		// The discovery service is turned on by default
-		NoDiscover: false,
+		NoDiscover:     false,
+		CheckProtocols: false,
 		// Addresses are bound to localhost by default
 		Addr: &net.TCPAddr{
 			IP:   net.ParseIP("127.0.0.1"),

--- a/network/discovery/discovery.go
+++ b/network/discovery/discovery.go
@@ -48,7 +48,7 @@ type networkingServer interface {
 	NewDiscoveryClient(peerID peer.ID) (proto.DiscoveryClient, error)
 
 	// CloseProtocolStream closes a protocol stream to the peer
-	CloseProtocolStream(protocol string, peerID peer.ID) error
+	CloseProtocolStream(protocol common.ProtocolId, peerID peer.ID) error
 
 	// PEER MANIPULATION //
 

--- a/network/discovery/discovery.go
+++ b/network/discovery/discovery.go
@@ -48,7 +48,7 @@ type networkingServer interface {
 	NewDiscoveryClient(peerID peer.ID) (proto.DiscoveryClient, error)
 
 	// CloseProtocolStream closes a protocol stream to the peer
-	CloseProtocolStream(protocol common.ProtocolId, peerID peer.ID) error
+	CloseProtocolStream(protocol common.ProtocolID, peerID peer.ID) error
 
 	// PEER MANIPULATION //
 

--- a/network/discovery/discovery_test.go
+++ b/network/discovery/discovery_test.go
@@ -120,7 +120,7 @@ func TestDiscoveryService_BootnodePeerDiscovery(t *testing.T) {
 			})
 
 			// Define the protocol stream closing hook
-			server.HookCloseProtocolStream(func(s string, id peer.ID) error {
+			server.HookCloseProtocolStream(func(s common.ProtocolId, id peer.ID) error {
 				if id == randomBootnode.ID {
 					// Make sure the correct temporary stream is closed
 					streamClosed = true

--- a/network/discovery/discovery_test.go
+++ b/network/discovery/discovery_test.go
@@ -120,7 +120,7 @@ func TestDiscoveryService_BootnodePeerDiscovery(t *testing.T) {
 			})
 
 			// Define the protocol stream closing hook
-			server.HookCloseProtocolStream(func(s common.ProtocolId, id peer.ID) error {
+			server.HookCloseProtocolStream(func(s common.ProtocolID, id peer.ID) error {
 				if id == randomBootnode.ID {
 					// Make sure the correct temporary stream is closed
 					streamClosed = true

--- a/network/identity/identity_test.go
+++ b/network/identity/identity_test.go
@@ -7,6 +7,7 @@ import (
 	cmap "github.com/dogechain-lab/dogechain/helper/concurrentmap"
 	"github.com/dogechain-lab/dogechain/network/proto"
 	networkTesting "github.com/dogechain-lab/dogechain/network/testing"
+	"github.com/dogechain-lab/dogechain/versioning"
 	"github.com/hashicorp/go-hclog"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -63,7 +64,8 @@ func TestTemporaryDial(t *testing.T) {
 				return &proto.Status{
 					Chain: 0,
 					Metadata: map[string]string{
-						PeerID: "TestPeer1",
+						PeerID:      "TestPeer1",
+						AppIdentity: versioning.AppName,
 					},
 					TemporaryDial: true, // make sure the dial is temporary
 				}, nil
@@ -145,7 +147,8 @@ func TestHandshake_Errors(t *testing.T) {
 				return &proto.Status{
 					Chain: responderChainID,
 					Metadata: map[string]string{
-						PeerID: "TestPeer1",
+						PeerID:      "TestPeer1",
+						AppIdentity: versioning.AppName,
 					},
 					TemporaryDial: false,
 				}, nil

--- a/network/server.go
+++ b/network/server.go
@@ -487,7 +487,7 @@ func (s *Server) CheckPeerMatchProtocols(peerID peer.ID) bool {
 
 	// check peer supports dogechain protocols
 	for _, peerProtocol := range peerProtocols {
-		if strings.Index(peerProtocol, common.ProtocolPrefix) >= 0 {
+		if strings.HasPrefix(peerProtocol, common.ProtocolPrefix) {
 			return true
 		}
 	}

--- a/network/server.go
+++ b/network/server.go
@@ -474,6 +474,10 @@ func (s *Server) GetProtocols(peerID peer.ID) ([]string, error) {
 }
 
 func (s *Server) CheckPeerMatchProtocols(peerID peer.ID) bool {
+	if !s.config.CheckProtocols {
+		return true
+	}
+
 	peerProtocols, err := s.GetProtocols(peerID)
 	if err != nil {
 		return false

--- a/network/server.go
+++ b/network/server.go
@@ -75,7 +75,7 @@ type Server struct {
 
 	discovery *discovery.DiscoveryService // service used for discovering other peers
 
-	protocols     map[common.ProtocolId]Protocol // supported protocols
+	protocols     map[common.ProtocolID]Protocol // supported protocols
 	protocolsLock sync.Mutex                     // lock for the supported protocols map
 
 	secretsManager secrets.SecretsManager // secrets manager for networking keys
@@ -148,7 +148,7 @@ func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 		dialQueue:        dial.NewDialQueue(),
 		closeCh:          make(chan struct{}),
 		emitterPeerEvent: emitter,
-		protocols:        map[common.ProtocolId]Protocol{},
+		protocols:        map[common.ProtocolID]Protocol{},
 		secretsManager:   config.SecretsManager,
 		bootnodes: &bootnodesWrapper{
 			bootnodeArr:       make([]*peer.AddrInfo, 0),
@@ -187,16 +187,16 @@ type PeerConnInfo struct {
 	Info peer.AddrInfo
 
 	connDirections  map[network.Direction]bool
-	protocolStreams map[common.ProtocolId]*rawGrpc.ClientConn
+	protocolStreams map[common.ProtocolID]*rawGrpc.ClientConn
 }
 
 // addProtocolStream adds a protocol stream
-func (pci *PeerConnInfo) addProtocolStream(protocol common.ProtocolId, stream *rawGrpc.ClientConn) {
+func (pci *PeerConnInfo) addProtocolStream(protocol common.ProtocolID, stream *rawGrpc.ClientConn) {
 	pci.protocolStreams[protocol] = stream
 }
 
 // removeProtocolStream removes and closes a protocol stream
-func (pci *PeerConnInfo) removeProtocolStream(protocol common.ProtocolId) error {
+func (pci *PeerConnInfo) removeProtocolStream(protocol common.ProtocolID) error {
 	stream, ok := pci.protocolStreams[protocol]
 	if !ok {
 		return nil
@@ -212,7 +212,7 @@ func (pci *PeerConnInfo) removeProtocolStream(protocol common.ProtocolId) error 
 }
 
 // getProtocolStream fetches the protocol stream, if any
-func (pci *PeerConnInfo) getProtocolStream(protocol common.ProtocolId) *rawGrpc.ClientConn {
+func (pci *PeerConnInfo) getProtocolStream(protocol common.ProtocolID) *rawGrpc.ClientConn {
 	return pci.protocolStreams[protocol]
 }
 
@@ -623,7 +623,7 @@ func (s *Server) Close() error {
 
 // newProtoConnection opens up a new stream on the set protocol to the peer,
 // and returns a reference to the connection
-func (s *Server) newProtoConnection(protocol common.ProtocolId, peerID peer.ID) (*rawGrpc.ClientConn, error) {
+func (s *Server) newProtoConnection(protocol common.ProtocolID, peerID peer.ID) (*rawGrpc.ClientConn, error) {
 	s.protocolsLock.Lock()
 	defer s.protocolsLock.Unlock()
 
@@ -640,7 +640,7 @@ func (s *Server) newProtoConnection(protocol common.ProtocolId, peerID peer.ID) 
 	return p.Client(stream), nil
 }
 
-func (s *Server) NewStream(proto common.ProtocolId, id peer.ID) (network.Stream, error) {
+func (s *Server) NewStream(proto common.ProtocolID, id peer.ID) (network.Stream, error) {
 	return s.host.NewStream(context.Background(), id, protocol.ID(proto))
 }
 
@@ -649,7 +649,7 @@ type Protocol interface {
 	Handler() func(network.Stream)
 }
 
-func (s *Server) RegisterProtocol(id common.ProtocolId, p Protocol) {
+func (s *Server) RegisterProtocol(id common.ProtocolID, p Protocol) {
 	s.protocolsLock.Lock()
 	defer s.protocolsLock.Unlock()
 
@@ -657,7 +657,7 @@ func (s *Server) RegisterProtocol(id common.ProtocolId, p Protocol) {
 	s.wrapStream(id, p.Handler())
 }
 
-func (s *Server) wrapStream(id common.ProtocolId, handle func(network.Stream)) {
+func (s *Server) wrapStream(id common.ProtocolID, handle func(network.Stream)) {
 	s.host.SetStreamHandler(protocol.ID(id), func(stream network.Stream) {
 		peerID := stream.Conn().RemotePeer()
 		s.logger.Debug("open stream", "protocol", id, "peer", peerID)

--- a/network/server.go
+++ b/network/server.go
@@ -483,14 +483,16 @@ func (s *Server) CheckPeerMatchProtocols(peerID peer.ID) bool {
 		return false
 	}
 
+	s.logger.Debug("peer protocols", "protocols", peerProtocols)
+
 	// check peer supports dogechain protocols
 	for _, peerProtocol := range peerProtocols {
-		if strings.Index(peerProtocol, common.ProtocolPrefix) < 1 {
-			return false
+		if strings.Index(peerProtocol, common.ProtocolPrefix) >= 0 {
+			return true
 		}
 	}
 
-	return true
+	return false
 }
 
 // removePeer removes a peer from the networking server's peer list,

--- a/network/server_discovery.go
+++ b/network/server_discovery.go
@@ -43,7 +43,7 @@ func (s *Server) GetBootnodeConnCount() int64 {
 
 // getProtoStream returns an active protocol stream if present, otherwise
 // it returns nil
-func (s *Server) getProtoStream(protocol common.ProtocolId, peerID peer.ID) *rawGrpc.ClientConn {
+func (s *Server) getProtoStream(protocol common.ProtocolID, peerID peer.ID) *rawGrpc.ClientConn {
 	s.peersLock.Lock()
 	defer s.peersLock.Unlock()
 
@@ -92,7 +92,7 @@ func (s *Server) NewDiscoveryClient(peerID peer.ID) (proto.DiscoveryClient, erro
 // saveProtocolStream saves the protocol stream to the peer
 // protocol stream reference [Thread safe]
 func (s *Server) saveProtocolStream(
-	protocol common.ProtocolId,
+	protocol common.ProtocolID,
 	stream *rawGrpc.ClientConn,
 	peerID peer.ID,
 ) {
@@ -116,7 +116,7 @@ func (s *Server) saveProtocolStream(
 }
 
 // CloseProtocolStream closes a protocol stream to the specified peer
-func (s *Server) CloseProtocolStream(protocol common.ProtocolId, peerID peer.ID) error {
+func (s *Server) CloseProtocolStream(protocol common.ProtocolID, peerID peer.ID) error {
 	s.peersLock.Lock()
 	defer s.peersLock.Unlock()
 

--- a/network/server_discovery.go
+++ b/network/server_discovery.go
@@ -43,7 +43,7 @@ func (s *Server) GetBootnodeConnCount() int64 {
 
 // getProtoStream returns an active protocol stream if present, otherwise
 // it returns nil
-func (s *Server) getProtoStream(protocol string, peerID peer.ID) *rawGrpc.ClientConn {
+func (s *Server) getProtoStream(protocol common.ProtocolId, peerID peer.ID) *rawGrpc.ClientConn {
 	s.peersLock.Lock()
 	defer s.peersLock.Unlock()
 
@@ -92,7 +92,7 @@ func (s *Server) NewDiscoveryClient(peerID peer.ID) (proto.DiscoveryClient, erro
 // saveProtocolStream saves the protocol stream to the peer
 // protocol stream reference [Thread safe]
 func (s *Server) saveProtocolStream(
-	protocol string,
+	protocol common.ProtocolId,
 	stream *rawGrpc.ClientConn,
 	peerID peer.ID,
 ) {
@@ -116,7 +116,7 @@ func (s *Server) saveProtocolStream(
 }
 
 // CloseProtocolStream closes a protocol stream to the specified peer
-func (s *Server) CloseProtocolStream(protocol string, peerID peer.ID) error {
+func (s *Server) CloseProtocolStream(protocol common.ProtocolId, peerID peer.ID) error {
 	s.peersLock.Lock()
 	defer s.peersLock.Unlock()
 

--- a/network/server_identity.go
+++ b/network/server_identity.go
@@ -62,7 +62,7 @@ func (s *Server) addPeerInfo(id peer.ID, direction network.Direction) bool {
 		connectionInfo = &PeerConnInfo{
 			Info:            s.host.Peerstore().PeerInfo(id),
 			connDirections:  make(map[network.Direction]bool),
-			protocolStreams: make(map[common.ProtocolId]*rawGrpc.ClientConn),
+			protocolStreams: make(map[common.ProtocolID]*rawGrpc.ClientConn),
 		}
 	}
 
@@ -111,6 +111,7 @@ func (s *Server) setupIdentity() error {
 		s.logger,
 		int64(s.config.Chain.Params.ChainID),
 		s.host.ID(),
+		s.config.Chain.Genesis.Hash(),
 	)
 
 	// Register the identity service protocol

--- a/network/server_identity.go
+++ b/network/server_identity.go
@@ -62,7 +62,7 @@ func (s *Server) addPeerInfo(id peer.ID, direction network.Direction) bool {
 		connectionInfo = &PeerConnInfo{
 			Info:            s.host.Peerstore().PeerInfo(id),
 			connDirections:  make(map[network.Direction]bool),
-			protocolStreams: make(map[string]*rawGrpc.ClientConn),
+			protocolStreams: make(map[common.ProtocolId]*rawGrpc.ClientConn),
 		}
 	}
 

--- a/network/testing/testing.go
+++ b/network/testing/testing.go
@@ -83,7 +83,7 @@ type checkPeerMatchProtocolsDelegate func(peer.ID) bool
 type getRandomBootnodeDelegate func() *peer.AddrInfo
 type getBootnodeConnCountDelegate func() int64
 type newDiscoveryClientDelegate func(peer.ID) (proto.DiscoveryClient, error)
-type closeProtocolStreamDelegate func(common.ProtocolId, peer.ID) error
+type closeProtocolStreamDelegate func(common.ProtocolID, peer.ID) error
 type addToPeerStoreDelegate func(*peer.AddrInfo)
 type removeFromPeerStoreDelegate func(peerInfo *peer.AddrInfo)
 type getPeerInfoDelegate func(peer.ID) *peer.AddrInfo
@@ -226,7 +226,7 @@ func (m *MockNetworkingServer) HookNewDiscoveryClient(fn newDiscoveryClientDeleg
 	m.newDiscoveryClientFn = fn
 }
 
-func (m *MockNetworkingServer) CloseProtocolStream(protocol common.ProtocolId, peerID peer.ID) error {
+func (m *MockNetworkingServer) CloseProtocolStream(protocol common.ProtocolID, peerID peer.ID) error {
 	if m.closeProtocolStreamFn != nil {
 		return m.closeProtocolStreamFn(protocol, peerID)
 	}

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -13,6 +13,7 @@ import (
 	cmap "github.com/dogechain-lab/dogechain/helper/concurrentmap"
 	"github.com/dogechain-lab/dogechain/helper/progress"
 	"github.com/dogechain-lab/dogechain/network"
+	"github.com/dogechain-lab/dogechain/network/common"
 	"github.com/dogechain-lab/dogechain/network/event"
 	libp2pGrpc "github.com/dogechain-lab/dogechain/network/grpc"
 	"github.com/dogechain-lab/dogechain/protocol/proto"
@@ -151,8 +152,6 @@ func (s *Syncer) updateStatus(status *Status) {
 	s.status = status
 }
 
-const syncerV1 = "/syncer/0.1"
-
 // enqueueBlock adds the specific block to the peerID queue
 func (s *Syncer) enqueueBlock(peerID peer.ID, b *types.Block) {
 	s.logger.Debug("enqueue block", "peer", peerID, "number", b.Number(), "hash", b.Hash())
@@ -273,7 +272,7 @@ func (s *Syncer) Start() {
 	grpcStream := libp2pGrpc.NewGrpcStream()
 	proto.RegisterV1Server(grpcStream.GrpcServer(), s.serviceV1)
 	grpcStream.Serve()
-	s.server.RegisterProtocol(syncerV1, grpcStream)
+	s.server.RegisterProtocol(common.SyncerV1Proto, grpcStream)
 
 	s.setupPeers()
 
@@ -355,7 +354,7 @@ func (s *Syncer) AddPeer(peerID peer.ID) error {
 		return nil
 	}
 
-	stream, err := s.server.NewStream(syncerV1, peerID)
+	stream, err := s.server.NewStream(common.SyncerV1Proto, peerID)
 	if err != nil {
 		return fmt.Errorf("failed to open a stream, err %w", err)
 	}

--- a/versioning/versioning.go
+++ b/versioning/versioning.go
@@ -6,4 +6,7 @@ var (
 	// Versioning should follow the SemVer guidelines
 	// https://semver.org/
 	Version = "v0.1.0"
+
+	// AppName is the name of the application
+	AppName string = "dogechain"
 )


### PR DESCRIPTION
# Description

Too many libp2p nodes named with the same protocol, other peer never forward block (not `dogechain` node)

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

* run single `dogechain` node 
* run `polygon-edge` node
* use `dogechain peers add [polygon-edge address]` 
