### PR TITLE
Fix ibft test crash after using hardfork compatible signer

### DIFF
--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/dogechain-lab/dogechain/blockchain"
+	"github.com/dogechain-lab/dogechain/chain"
 	"github.com/dogechain-lab/dogechain/consensus"
 	"github.com/dogechain-lab/dogechain/consensus/ibft/currentstate"
 	"github.com/dogechain-lab/dogechain/consensus/ibft/proto"
@@ -1214,8 +1215,13 @@ func newMockIbft(t *testing.T, accounts []string, validatorAccount string) *mock
 	}
 
 	ibft := &Ibft{
-		logger:           hclog.NewNullLogger(),
-		config:           &consensus.Config{},
+		logger: hclog.NewNullLogger(),
+		config: &consensus.Config{
+			Params: &chain.Params{
+				Forks:   chain.AllForksEnabled,
+				ChainID: 100,
+			},
+		},
 		blockchain:       m,
 		validatorKey:     addr.priv,
 		validatorKeyAddr: addr.Address(),
@@ -1273,8 +1279,13 @@ func newMockIBFTWithMockBlockchain(
 	}
 
 	ibft := &Ibft{
-		logger:           hclog.NewNullLogger(),
-		config:           &consensus.Config{},
+		logger: hclog.NewNullLogger(),
+		config: &consensus.Config{
+			Params: &chain.Params{
+				Forks:   chain.AllForksEnabled,
+				ChainID: 404,
+			},
+		},
 		blockchain:       m,
 		validatorKey:     addr.priv,
 		validatorKeyAddr: addr.Address(),


### PR DESCRIPTION
# Description

The PR fixes test crash recently brought in by using hard fork compatible signer instead of a fixed type one.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

## Testing

- [x] I have tested this code with the official test suite