### PR TITLE
Fix transaction index shadowed when querying transaction receipt

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -335,23 +335,23 @@ func (e *Eth) GetTransactionReceipt(hash types.Hash) (interface{}, error) {
 		return nil, nil
 	}
 	// find the transaction in the body
-	indx := -1
+	txIndex := -1
 
 	for i, txn := range block.Transactions {
 		if txn.Hash() == hash {
-			indx = i
+			txIndex = i
 
 			break
 		}
 	}
 
-	if indx == -1 {
+	if txIndex == -1 {
 		// txn not found
 		return nil, nil
 	}
 
-	txn := block.Transactions[indx]
-	raw := receipts[indx]
+	txn := block.Transactions[txIndex]
+	raw := receipts[txIndex]
 
 	logs := make([]*Log, len(raw.Logs))
 	for indx, elem := range raw.Logs {
@@ -362,7 +362,7 @@ func (e *Eth) GetTransactionReceipt(hash types.Hash) (interface{}, error) {
 			BlockHash:   block.Hash(),
 			BlockNumber: argUint64(block.Number()),
 			TxHash:      txn.Hash(),
-			TxIndex:     argUint64(indx),
+			TxIndex:     argUint64(txIndex),
 			LogIndex:    argUint64(indx),
 			Removed:     false,
 		}
@@ -374,7 +374,7 @@ func (e *Eth) GetTransactionReceipt(hash types.Hash) (interface{}, error) {
 		LogsBloom:         raw.LogsBloom,
 		Status:            argUint64(*raw.Status),
 		TxHash:            txn.Hash(),
-		TxIndex:           argUint64(indx),
+		TxIndex:           argUint64(txIndex),
 		BlockHash:         block.Hash(),
 		BlockNumber:       argUint64(block.Number()),
 		GasUsed:           argUint64(raw.GasUsed),


### PR DESCRIPTION
# Description

`eth_getTransactionReceipt` returns shadowed `indx` of log instead of real transaction index.

The PR fixes it.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

* Set up a one-node dev mode network.
* Deploy a contract with several logs emit in one function call.
* Call the method with RPC.
* Check the transaction receipt.

The PR branch should return right transaction index instead of log index. In contrast, the base branch would failed the test.