### PR TITLE
[ibft] Fix build block write system transactions failed due to gas limit reach

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -788,6 +788,15 @@ func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, e
 }
 
 func increaseHeaderGasIfNeeded(transition *state.Transition, header *types.Header, tx *types.Transaction) {
+	if transition.TotalGas()+tx.Gas <= header.GasLimit {
+		return
+	}
+
+	extractAmount := transition.TotalGas() + tx.Gas - header.GasLimit
+
+	// increase it
+	header.GasLimit += extractAmount
+	transition.IncreaseSystemTransactionGas(extractAmount)
 }
 
 func (i *Ibft) currentRound() uint64 {

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -641,6 +641,7 @@ func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, e
 		return nil, err
 	}
 
+	// update gas limit first
 	header.GasLimit = gasLimit
 
 	if hookErr := i.runHook(CandidateVoteHook, header.Number, &candidateVoteHookParams{
@@ -710,6 +711,9 @@ func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, e
 					return nil, err
 				}
 
+				// system transaction, increase gas limit if needed
+				increaseHeaderGasIfNeeded(transition, header, tx)
+
 				// execute slash tx
 				if err := transition.Write(tx); err != nil {
 					return nil, err
@@ -724,6 +728,9 @@ func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, e
 		if err != nil {
 			return nil, err
 		}
+
+		// system transaction, increase gas limit if needed
+		increaseHeaderGasIfNeeded(transition, header, tx)
 
 		// execute deposit tx
 		if err := transition.Write(tx); err != nil {
@@ -778,6 +785,9 @@ func (i *Ibft) buildBlock(snap *Snapshot, parent *types.Header) (*types.Block, e
 	)
 
 	return block, nil
+}
+
+func increaseHeaderGasIfNeeded(transition *state.Transition, header *types.Header, tx *types.Transaction) {
 }
 
 func (i *Ibft) currentRound() uint64 {

--- a/contracts/validatorset/query.go
+++ b/contracts/validatorset/query.go
@@ -28,7 +28,7 @@ const (
 
 const (
 	// Gas limit used when querying the validator set
-	_systemContractGasLimit uint64 = 100_000
+	SystemTransactionGasLimit uint64 = 100_000
 )
 
 var (
@@ -106,7 +106,7 @@ func MakeDepositTx(t NonceHub, from types.Address) (*types.Transaction, error) {
 	tx := &types.Transaction{
 		Nonce:    t.GetNonce(from),
 		GasPrice: big.NewInt(0),
-		Gas:      _systemContractGasLimit,
+		Gas:      SystemTransactionGasLimit,
 		To:       &systemcontracts.AddrValidatorSetContract,
 		Value:    nil,
 		Input:    input,
@@ -132,7 +132,7 @@ func MakeSlashTx(t NonceHub, from types.Address, needPunished types.Address) (*t
 	tx := &types.Transaction{
 		Nonce:    t.GetNonce(from),
 		GasPrice: big.NewInt(0),
-		Gas:      _systemContractGasLimit,
+		Gas:      SystemTransactionGasLimit,
 		To:       &systemcontracts.AddrValidatorSetContract,
 		Value:    nil,
 		Input:    input,

--- a/contracts/validatorset/query.go
+++ b/contracts/validatorset/query.go
@@ -28,7 +28,7 @@ const (
 
 const (
 	// Gas limit used when querying the validator set
-	_systemContractGasLimit uint64 = 2_000_000
+	_systemContractGasLimit uint64 = 100_000
 )
 
 var (

--- a/contracts/validatorset/query_test.go
+++ b/contracts/validatorset/query_test.go
@@ -183,7 +183,7 @@ func TestQueryValidators(t *testing.T) {
 					Value:    big.NewInt(0),
 					Input:    method.ID(),
 					GasPrice: big.NewInt(0),
-					Gas:      _systemContractGasLimit,
+					Gas:      SystemTransactionGasLimit,
 					Nonce:    10,
 				},
 			},

--- a/state/executor.go
+++ b/state/executor.go
@@ -235,8 +235,9 @@ type Transition struct {
 	gasPool uint64
 
 	// result
-	receipts []*types.Receipt
-	totalGas uint64
+	receipts     []*types.Receipt
+	totalGas     uint64
+	totalGasHook func() uint64 // for testing
 
 	// evmLogger for debugging, set a dummy logger to 'collect' tracing,
 	// then we wouldn't have to judge any tracing flag
@@ -262,7 +263,18 @@ func (t *Transition) GetEVMLogger() runtime.EVMLogger {
 	return t.evmLogger
 }
 
+// HookTotalGas uses hook to return total gas
+//
+// Use it for testing
+func (t *Transition) HookTotalGas(fn func() uint64) {
+	t.totalGasHook = fn
+}
+
 func (t *Transition) TotalGas() uint64 {
+	if t.totalGasHook != nil {
+		return t.totalGasHook()
+	}
+
 	return t.totalGas
 }
 
@@ -440,6 +452,11 @@ func (t *Transition) subGasPool(amount uint64) error {
 	t.gasPool -= amount
 
 	return nil
+}
+
+// IncreaseSystemTransactionGas updates gas pool so that system contract transactions can be sealed.
+func (t *Transition) IncreaseSystemTransactionGas(amount uint64) {
+	t.addGasPool(amount)
 }
 
 func (t *Transition) addGasPool(amount uint64) {

--- a/state/executor.go
+++ b/state/executor.go
@@ -457,6 +457,8 @@ func (t *Transition) subGasPool(amount uint64) error {
 // IncreaseSystemTransactionGas updates gas pool so that system contract transactions can be sealed.
 func (t *Transition) IncreaseSystemTransactionGas(amount uint64) {
 	t.addGasPool(amount)
+	// don't forget to increase current context
+	t.ctx.GasLimit += int64(amount)
 }
 
 func (t *Transition) addGasPool(amount uint64) {


### PR DESCRIPTION
# Description

The PR fixes the bug when gas limit reach, then no block could be build or verified due to reaching gas limit.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

1. Set up a 4-node validators' network, set genesis block gas limit to 20000.
2. Send multiple transactions with tools, and make it reach block gas limit.

The PR branch could seal blocks and go on, while the base branch stop at certain block height.