### PR TITLE
Update detroit hard fork block height on mainnet

### DIFF
--- a/mainnet-genesis.json
+++ b/mainnet-genesis.json
@@ -77,7 +77,7 @@
             "EIP158": 0,
             "EIP155": 0,
             "portland": 1981991,
-            "detroit": 4116385
+            "detroit": 4490834
         },
         "chainID": 2000,
         "engine": {


### PR DESCRIPTION
# Description

The PR determines and updates `detroit` hard fork block height on `MainNet`. The new version should include this `mainnet-genesis.json` in its archive file.

# Changes include

- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

From the height it sets, not updated node would not be able to sync with the MainNet network.

## Testing

- [x] I have tested this code with the official test suite