### PR TITLE
[ibft] Fix ddos mark count increase insanely with only one transaction

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -984,6 +984,8 @@ func (i *Ibft) writeTransactions(
 				"address", tx.To,
 				"from", tx.From,
 			)
+			// don't forget to pop the transaction if not execute it
+			priceTxs.Pop()
 
 			// drop tx
 			shouldDropTxs = append(shouldDropTxs, tx)

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -32,8 +32,8 @@ import (
 
 const (
 	DefaultEpochSize = 100000
-	// banish abnormal contract whose execution consumes too much time
-	DefaultBanishAbnormalContract = false
+	// When threshold reached, we mark it as a really annoying contract
+	_annoyingContractThrshold = 3
 )
 
 var (
@@ -125,7 +125,8 @@ type Ibft struct {
 	currentValidators validator.Validators // Validator set at current sequence
 	// Recording resource exhausting contracts
 	// but would not banish it until it became a real ddos attack
-	exhaustingContracts map[types.Address]struct{}
+	// not thread safe, but can be used sequentially
+	exhaustingContracts map[types.Address]uint64
 }
 
 // runHook runs a specified hook if it is present in the hook map
@@ -193,7 +194,7 @@ func Factory(
 		metrics:             params.Metrics,
 		secretsManager:      params.SecretsManager,
 		blockTime:           time.Duration(params.BlockTime) * time.Second,
-		exhaustingContracts: make(map[types.Address]struct{}),
+		exhaustingContracts: make(map[types.Address]uint64),
 	}
 
 	// Initialize the mechanism
@@ -1074,9 +1075,9 @@ func (i *Ibft) shouldMarkLongConsumingTx(tx *types.Transaction) bool {
 		return false
 	}
 
-	_, exists := i.exhaustingContracts[*tx.To]
+	count, exists := i.exhaustingContracts[*tx.To]
 
-	return exists
+	return exists && count >= _annoyingContractThrshold
 }
 
 func (i *Ibft) countDDOSAttack(tx *types.Transaction) {
@@ -1091,10 +1092,13 @@ func (i *Ibft) markLongTimeConsumingContract(tx *types.Transaction, begin time.T
 	}
 
 	// banish the contract
-	i.exhaustingContracts[*tx.To] = struct{}{}
+	count := i.exhaustingContracts[*tx.To]
+	count++
+	i.exhaustingContracts[*tx.To] = count
 
 	i.logger.Info("mark contract who consumes too many CPU or I/O time",
 		"duration", duration,
+		"count", count,
 		"from", tx.From,
 		"to", tx.To,
 		"gasPrice", tx.GasPrice,

--- a/consensus/ibft/ibft_test.go
+++ b/consensus/ibft/ibft_test.go
@@ -1252,7 +1252,7 @@ func newMockIbft(t *testing.T, accounts []string, validatorAccount string) *mock
 		state:               currentstate.NewState(),
 		epochSize:           DefaultEpochSize,
 		metrics:             consensus.NilMetrics(),
-		exhaustingContracts: make(map[types.Address]struct{}),
+		exhaustingContracts: make(map[types.Address]uint64),
 	}
 
 	initIbftMechanism(PoA, ibft)
@@ -1819,34 +1819,49 @@ func Test_shouldMarkLongConsumingTx(t *testing.T) {
 	}
 
 	i := newMockIbft(t, []string{"A", "B", "C", "D"}, "A")
-	i.Ibft.exhaustingContracts[addr2] = struct{}{}
+	i.Ibft.exhaustingContracts[addr2] = _annoyingContractThrshold
 
 	assert.True(t, i.shouldMarkLongConsumingTx(mockTx))
 }
 
 func Test_markLongTimeConsumingContract(t *testing.T) {
-	mockTx := &types.Transaction{
-		Nonce:    0,
-		GasPrice: big.NewInt(1000),
-		Gas:      defaultBlockGasLimit,
-		To:       &addr2,
-		Value:    big.NewInt(10),
-		Input:    []byte{'m', 'o', 'k', 'e'},
-		From:     addr1,
+	tests := []*struct {
+		markTimes         int
+		expectedContracts map[types.Address]uint64
+	}{
+		{
+			0,
+			map[types.Address]uint64{},
+		},
+		{
+			_annoyingContractThrshold - 1,
+			map[types.Address]uint64{addr2: _annoyingContractThrshold - 1},
+		},
+		{
+			_annoyingContractThrshold,
+			map[types.Address]uint64{addr2: _annoyingContractThrshold},
+		},
 	}
 
-	i := newMockIbft(t, []string{"A", "B", "C", "D"}, "A")
+	for _, tt := range tests {
+		mockTx := &types.Transaction{
+			Nonce:    0,
+			GasPrice: big.NewInt(1000),
+			Gas:      defaultBlockGasLimit,
+			To:       &addr2,
+			Value:    big.NewInt(10),
+			Input:    []byte{'m', 'o', 'k', 'e'},
+			From:     addr1,
+		}
 
-	// make sure begin time out what we set
-	begin := time.Now().Add(-1*i.blockTime - 1)
+		i := newMockIbft(t, []string{"A", "B", "C", "D"}, "A")
+		// make sure begin time out what we set
+		begin := time.Now().Add(-1*i.blockTime - 1)
 
-	i.markLongTimeConsumingContract(mockTx, begin)
+		for idx := 0; idx < tt.markTimes; idx++ {
+			i.markLongTimeConsumingContract(mockTx, begin)
+		}
 
-	assert.Equal(
-		t,
-		map[types.Address]struct{}{
-			addr2: {},
-		},
-		i.exhaustingContracts,
-	)
+		assert.Equal(t, tt.expectedContracts, i.exhaustingContracts)
+	}
 }

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -564,7 +564,10 @@ func (s *Syncer) BulkSyncWithPeer(p *SyncPeer, newBlockHandler func(block *types
 	}
 
 	// find in batches
-	s.logger.Debug("fork found", "ancestor", ancestor.Number)
+	s.logger.Info("fork found",
+		"peer", p.peer,
+		"ancestor", ancestor.Number,
+	)
 
 	startBlock := fork
 
@@ -598,12 +601,11 @@ func (s *Syncer) BulkSyncWithPeer(p *SyncPeer, newBlockHandler func(block *types
 		}
 
 		for {
-			s.logger.Debug(
+			s.logger.Info(
 				"sync up to block",
-				"from",
-				currentSyncHeight,
-				"to",
-				target,
+				"peer", p.peer,
+				"from", currentSyncHeight,
+				"to", target,
 			)
 
 			// Create the base request skeleton


### PR DESCRIPTION
# Description

The PR fixes a bug imported by #254.
A marked "DDOS" transaction would block the whole block building work, and mark insanely until it was dropped.
The mark count is not right, due to not skip by (`Pop()` in fact).

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

1. Set up a 4-validator network, all enable `ddosProtection`.
2. Deploy CoinTool contact, and call it with some scripts.
3. Send 6 transactions all together to one validator.
4. Check whether it is able to send more contract transactions to the validator, after 1 minutes.

In the PR branch, it is OK to go on with step 4. In contrast, the base branch would failed on it.