### PR TITLE
[discover] Filtering peers using CIDR ranges

### DIFF
--- a/command/common.go
+++ b/command/common.go
@@ -4,7 +4,7 @@ const (
 	ConsensusFlag  = "consensus"
 	NoDiscoverFlag = "no-discover"
 
-	DiscoverIgnoreCIDRFlag = "discover-ignore-cidr"
+	IgnoreDiscoverCIDRFlag = "ignore-discover-cidr"
 
 	BootnodeFlag = "bootnode"
 	LogLevelFlag = "log-level"

--- a/command/common.go
+++ b/command/common.go
@@ -3,6 +3,9 @@ package command
 const (
 	ConsensusFlag  = "consensus"
 	NoDiscoverFlag = "no-discover"
-	BootnodeFlag   = "bootnode"
-	LogLevelFlag   = "log-level"
+
+	DiscoverIgnoreCIDRFlag = "discover-ignore-cidr"
+
+	BootnodeFlag = "bootnode"
+	LogLevelFlag = "log-level"
 )

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -45,6 +45,8 @@ type Telemetry struct {
 
 // Network defines the network configuration params
 type Network struct {
+	DiscoverIgnoreCIDR string `json:"discover_ignore_peer_cidr"`
+
 	NoDiscover       bool   `json:"no_discover"`
 	Libp2pAddr       string `json:"libp2p_addr"`
 	NatAddr          string `json:"nat_addr"`
@@ -79,10 +81,11 @@ func DefaultConfig() *Config {
 		DataDir:        "./dogechain-chain",
 		BlockGasTarget: "0x0", // Special value signaling the parent gas limit should be applied
 		Network: &Network{
-			NoDiscover:       defaultNetworkConfig.NoDiscover,
-			MaxPeers:         defaultNetworkConfig.MaxPeers,
-			MaxOutboundPeers: defaultNetworkConfig.MaxOutboundPeers,
-			MaxInboundPeers:  defaultNetworkConfig.MaxInboundPeers,
+			DiscoverIgnoreCIDR: "",
+			NoDiscover:         defaultNetworkConfig.NoDiscover,
+			MaxPeers:           defaultNetworkConfig.MaxPeers,
+			MaxOutboundPeers:   defaultNetworkConfig.MaxOutboundPeers,
+			MaxInboundPeers:    defaultNetworkConfig.MaxInboundPeers,
 		},
 		Telemetry:  &Telemetry{},
 		ShouldSeal: false,

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -45,7 +45,7 @@ type Telemetry struct {
 
 // Network defines the network configuration params
 type Network struct {
-	DiscoverIgnoreCIDR string `json:"discover_ignore_peer_cidr"`
+	IgnoreDiscoverCIDR string `json:"ignore_discover_cidr"`
 
 	NoDiscover       bool   `json:"no_discover"`
 	Libp2pAddr       string `json:"libp2p_addr"`
@@ -81,7 +81,7 @@ func DefaultConfig() *Config {
 		DataDir:        "./dogechain-chain",
 		BlockGasTarget: "0x0", // Special value signaling the parent gas limit should be applied
 		Network: &Network{
-			DiscoverIgnoreCIDR: "",
+			IgnoreDiscoverCIDR: "",
 			NoDiscover:         defaultNetworkConfig.NoDiscover,
 			MaxPeers:           defaultNetworkConfig.MaxPeers,
 			MaxOutboundPeers:   defaultNetworkConfig.MaxOutboundPeers,

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -177,6 +177,19 @@ func (p *serverParams) generateConfig() *server.Config {
 	// namespace
 	ns := strings.Split(p.rawConfig.JSONNamespace, ",")
 
+	// ignore cidr
+	cidrList := strings.Split(p.rawConfig.Network.DiscoverIgnoreCIDR, ",")
+	ingoreCIDRs := []*net.IPNet{}
+
+	for _, s := range cidrList {
+		_, ipnet, err := net.ParseCIDR(s)
+		if err != nil {
+			panic(err)
+		}
+
+		ingoreCIDRs = append(ingoreCIDRs, ipnet)
+	}
+
 	return &server.Config{
 		Chain: chainCfg,
 		JSONRPC: &server.JSONRPC{
@@ -201,7 +214,9 @@ func (p *serverParams) generateConfig() *server.Config {
 			PrometheusAddr: p.prometheusAddress,
 		},
 		Network: &network.Config{
-			NoDiscover:       p.rawConfig.Network.NoDiscover,
+			NoDiscover:         p.rawConfig.Network.NoDiscover,
+			DiscoverIngoreCIDR: ingoreCIDRs,
+
 			Addr:             p.libp2pAddress,
 			NatAddr:          p.natAddress,
 			DNS:              p.dnsAddress,

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"errors"
+	"log"
 	"net"
 	"strings"
 
@@ -182,9 +183,15 @@ func (p *serverParams) generateConfig() *server.Config {
 	ingoreCIDRs := []*net.IPNet{}
 
 	for _, s := range cidrList {
+		if s == "" {
+			continue
+		}
+
 		_, ipnet, err := net.ParseCIDR(s)
 		if err != nil {
-			panic(err)
+			log.Printf("CIDR formart error: %s \n", err)
+
+			continue
 		}
 
 		ingoreCIDRs = append(ingoreCIDRs, ipnet)

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -179,7 +179,7 @@ func (p *serverParams) generateConfig() *server.Config {
 	ns := strings.Split(p.rawConfig.JSONNamespace, ",")
 
 	// ignore cidr
-	cidrList := strings.Split(p.rawConfig.Network.DiscoverIgnoreCIDR, ",")
+	cidrList := strings.Split(p.rawConfig.Network.IgnoreDiscoverCIDR, ",")
 	ingoreCIDRs := []*net.IPNet{}
 
 	for _, s := range cidrList {

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -182,12 +182,13 @@ func (p *serverParams) generateConfig() *server.Config {
 	cidrList := strings.Split(p.rawConfig.Network.IgnoreDiscoverCIDR, ",")
 	ingoreCIDRs := []*net.IPNet{}
 
-	for _, s := range cidrList {
-		if s == "" {
+	for _, cidrStr := range cidrList {
+		cidrStr = strings.TrimSpace(cidrStr)
+		if cidrStr == "" {
 			continue
 		}
 
-		_, ipnet, err := net.ParseCIDR(s)
+		_, ipnet, err := net.ParseCIDR(cidrStr)
 		if err != nil {
 			log.Printf("CIDR formart error: %s \n", err)
 

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -220,10 +220,10 @@ func setFlags(cmd *cobra.Command) {
 	// network flags
 	{
 		cmd.Flags().StringVar(
-			&params.rawConfig.Network.DiscoverIgnoreCIDR,
-			command.DiscoverIgnoreCIDRFlag,
-			defaultConfig.Network.DiscoverIgnoreCIDR,
-			"the comma separated list of CIDR ranges to ignore when discover to peers",
+			&params.rawConfig.Network.IgnoreDiscoverCIDR,
+			command.IgnoreDiscoverCIDRFlag,
+			defaultConfig.Network.IgnoreDiscoverCIDR,
+			"The comma separated list of CIDR ranges to ignore when discovering peers",
 		)
 
 		cmd.Flags().BoolVar(

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -219,6 +219,13 @@ func setFlags(cmd *cobra.Command) {
 
 	// network flags
 	{
+		cmd.Flags().StringVar(
+			&params.rawConfig.Network.DiscoverIgnoreCIDR,
+			command.DiscoverIgnoreCIDRFlag,
+			defaultConfig.Network.DiscoverIgnoreCIDR,
+			"the comma separated list of CIDR ranges to ignore when discover to peers",
+		)
+
 		cmd.Flags().BoolVar(
 			&params.rawConfig.Network.NoDiscover,
 			command.NoDiscoverFlag,

--- a/network/common/common_test.go
+++ b/network/common/common_test.go
@@ -1,0 +1,87 @@
+package common
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"testing"
+
+	ma "github.com/multiformats/go-multiaddr"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseMultiaddrIP(t *testing.T) {
+	t.Parallel()
+
+	type multiAddrs struct {
+		MultiAddr ma.Multiaddr
+		IP        net.IP
+	}
+
+	ipv4Tests := func() []multiAddrs {
+		mas := []multiAddrs{}
+
+		for i := 0; i < 1024; i++ {
+			buf := make([]byte, 4)
+			for i := 0; i < 4; i++ {
+				buf[i] = byte(rand.Intn(256))
+			}
+
+			ip := net.IP(buf)
+
+			addr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/90", ip.String()))
+			assert.NoError(t, err)
+
+			mas = append(mas, multiAddrs{
+				MultiAddr: addr,
+				IP:        ip,
+			})
+		}
+
+		return mas
+	}()
+
+	ipv6Tests := func() []multiAddrs {
+		mas := []multiAddrs{}
+
+		for i := 0; i < 1024; i++ {
+			buf := make([]byte, 16)
+			for i := 0; i < 16; i++ {
+				buf[i] = byte(rand.Intn(256))
+			}
+
+			ip := net.IP(buf)
+
+			addr, err := ma.NewMultiaddr(fmt.Sprintf("/ip6/%s/tcp/90", ip.String()))
+			assert.NoError(t, err)
+
+			mas = append(mas, multiAddrs{
+				MultiAddr: addr,
+				IP:        ip.To16(),
+			})
+		}
+
+		return mas
+	}()
+
+	t.Run("ipv4", func(t *testing.T) {
+		t.Parallel()
+
+		for _, test := range ipv4Tests {
+			ip, err := ParseMultiaddrIP(test.MultiAddr)
+			assert.NoError(t, err)
+			assert.True(t, ip.Equal(test.IP))
+		}
+	})
+
+	t.Run("ipv6", func(t *testing.T) {
+		t.Parallel()
+
+		for _, test := range ipv6Tests {
+			ip, err := ParseMultiaddrIP(test.MultiAddr)
+			assert.NoError(t, err)
+			assert.True(t, ip.Equal(test.IP))
+		}
+	})
+}

--- a/network/config.go
+++ b/network/config.go
@@ -10,6 +10,8 @@ import (
 
 // Config details the params for the base networking server
 type Config struct {
+	DiscoverIngoreCIDR []*net.IPNet // list of CIDR ranges to ignore when discovering peers
+
 	NoDiscover       bool                   // flag indicating if the discovery mechanism should be turned on
 	Addr             *net.TCPAddr           // the base address
 	NatAddr          *net.TCPAddr           // the NAT address
@@ -25,6 +27,8 @@ type Config struct {
 
 func DefaultConfig() *Config {
 	return &Config{
+		// The discovery service ignore peer IP ranges
+		DiscoverIngoreCIDR: []*net.IPNet{},
 		// The discovery service is turned on by default
 		NoDiscover: false,
 		// Addresses are bound to localhost by default


### PR DESCRIPTION
# Description

`server` subcommand provide a `--ignore-discover-cidr` flag, filtering peers that cannot be connected to (like `192.168.1.0/24` etc intranet address)

# Changes include

- [x] New feature (non-breaking change that adds functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels

## Testing

- [x] I have tested this code with the official test suite
