### PR TITLE
[ibft] Banish ddos contract without release

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -877,6 +877,11 @@ func (b *Blockchain) executeBlockTransactions(block *types.Block) (*BlockResult,
 	b.wg.Add(1)
 	defer b.wg.Done()
 
+	begin := time.Now()
+	defer func() {
+		b.metrics.BlockExecutionSeconds.Observe(time.Since(begin).Seconds())
+	}()
+
 	header := block.Header
 
 	parent, ok := b.readHeader(header.ParentHash)
@@ -1075,10 +1080,9 @@ func (b *Blockchain) updateGasPriceAvgWithBlock(block *types.Block) {
 // writeBody writes the block body to the DB.
 // Additionally, it also updates the txn lookup, for txnHash -> block lookups
 func (b *Blockchain) writeBody(block *types.Block) error {
-	startT := time.Now()
+	begin := time.Now()
 	defer func() {
-		endT := time.Now()
-		b.metrics.BlockWrittenSeconds.Observe(endT.Sub(startT).Seconds())
+		b.metrics.BlockWrittenSeconds.Observe(time.Since(begin).Seconds())
 	}()
 
 	body := block.Body()

--- a/blockchain/metrics.go
+++ b/blockchain/metrics.go
@@ -15,8 +15,10 @@ type Metrics struct {
 	GasUsed metrics.Histogram
 	// Block height
 	BlockHeight metrics.Gauge
-	// Block write duration time
+	// Block written duration
 	BlockWrittenSeconds metrics.Histogram
+	// Block execution duration
+	BlockExecutionSeconds metrics.Histogram
 	// Transaction number
 	TransactionNum metrics.Histogram
 }
@@ -54,6 +56,15 @@ func GetPrometheusMetrics(namespace string, labelsWithValues ...string) *Metrics
 			Name:      "block_write_seconds",
 			Help:      "block write time (seconds)",
 		}, labels).With(labelsWithValues...),
+		BlockExecutionSeconds: prometheus.NewHistogramFrom(
+			stdprometheus.HistogramOpts{
+				Namespace: namespace,
+				Subsystem: "blockchain",
+				Name:      "block_write_seconds",
+				Help:      "block write time (seconds)",
+			},
+			labels,
+		).With(labelsWithValues...),
 		TransactionNum: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: "blockchain",
@@ -66,11 +77,12 @@ func GetPrometheusMetrics(namespace string, labelsWithValues ...string) *Metrics
 // NilMetrics will return the non operational blockchain metrics
 func NilMetrics() *Metrics {
 	return &Metrics{
-		GasPriceAverage:     discard.NewHistogram(),
-		GasUsed:             discard.NewHistogram(),
-		BlockHeight:         discard.NewGauge(),
-		BlockWrittenSeconds: discard.NewHistogram(),
-		TransactionNum:      discard.NewHistogram(),
+		GasPriceAverage:       discard.NewHistogram(),
+		GasUsed:               discard.NewHistogram(),
+		BlockHeight:           discard.NewGauge(),
+		BlockWrittenSeconds:   discard.NewHistogram(),
+		BlockExecutionSeconds: discard.NewHistogram(),
+		TransactionNum:        discard.NewHistogram(),
 	}
 }
 

--- a/chain/params.go
+++ b/chain/params.go
@@ -11,7 +11,7 @@ type Params struct {
 	Engine         map[string]interface{} `json:"engine"`
 	BlockGasTarget uint64                 `json:"blockGasTarget"`
 	BlackList      []string               `json:"blackList,omitempty"`
-	DDOSPretection bool                   `json:"ddosPretection,omitempty"`
+	DDOSProtection bool                   `json:"ddosProtection,omitempty"`
 }
 
 func (p *Params) GetEngine() string {

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -1105,6 +1105,7 @@ func (i *Ibft) markLongTimeConsumingContract(tx *types.Transaction, begin time.T
 		"to", tx.To,
 		"gasPrice", tx.GasPrice,
 		"gas", tx.Gas,
+		"hash", tx.Hash(),
 	)
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -281,7 +281,7 @@ func NewServer(config *Config) (*Server, error) {
 				PruneTickSeconds:      m.config.PruneTickSeconds,
 				PromoteOutdateSeconds: m.config.PromoteOutdateSeconds,
 				BlackList:             blackList,
-				DDOSPretection:        m.config.Chain.Params.DDOSPretection,
+				DDOSProtection:        m.config.Chain.Params.DDOSProtection,
 			},
 		)
 		if err != nil {

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -326,7 +326,7 @@ func (p *TxPool) Start() {
 				}
 			case _, ok := <-p.ddosReductionTicker.C:
 				if ok {
-					go p.reduceDDOSCounts()
+					// go p.reduceDDOSCounts()
 				}
 			}
 		}

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -94,7 +94,7 @@ type Config struct {
 	PruneTickSeconds      uint64
 	PromoteOutdateSeconds uint64
 	BlackList             []types.Address
-	DDOSPretection        bool
+	DDOSProtection        bool
 }
 
 /* All requests are passed to the main loop
@@ -197,7 +197,7 @@ type TxPool struct {
 	// some very bad guys whose txs should never be included
 	blacklist map[types.Address]struct{}
 	// ddos protection fields
-	ddosPretection      bool         // enable ddos protection
+	ddosProtection      bool         // enable ddos protection
 	ddosReductionTicker *time.Ticker // ddos reduction ticker for releasing from imprisonment
 	ddosContracts       sync.Map     // ddos contract caching
 
@@ -245,7 +245,7 @@ func NewTxPool(
 		priceLimit:             config.PriceLimit,
 		pruneTick:              time.Second * time.Duration(pruneTickSeconds),
 		promoteOutdateDuration: time.Second * time.Duration(promoteOutdateSeconds),
-		ddosPretection:         config.DDOSPretection,
+		ddosProtection:         config.DDOSProtection,
 		isClosed:               atomic.NewBool(false),
 	}
 
@@ -712,7 +712,7 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 
 // IsDDOSTx returns whether a contract transaction marks as ddos attack
 func (p *TxPool) IsDDOSTx(tx *types.Transaction) bool {
-	if !p.ddosPretection || tx.To == nil {
+	if !p.ddosProtection || tx.To == nil {
 		return false
 	}
 
@@ -727,7 +727,7 @@ func (p *TxPool) IsDDOSTx(tx *types.Transaction) bool {
 
 // MarkDDOSTx marks resource consuming transaction as a might-be attack
 func (p *TxPool) MarkDDOSTx(tx *types.Transaction) {
-	if !p.ddosPretection || tx.To == nil {
+	if !p.ddosProtection || tx.To == nil {
 		return
 	}
 


### PR DESCRIPTION
# Description

I/O consuming transactions take longer than we think, like 8-30 seconds, which makes the whole ibft protocol not work properly.

The PR bans the contract, otherwise we need to make our large transactions smaller and smaller, which is not better UX practice.

# Changes include

- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)

## Testing

- [x] I have tested this code with the official test suite