### PR TITLE
[syncer] Forgetting non-Dogechain protocol peer

### DIFF
--- a/archive/restore.go
+++ b/archive/restore.go
@@ -96,7 +96,7 @@ func importBlocks(chain blockchainInterface, blockStream *blockStream, progressi
 	}
 
 	// Create a blockchain subscription for the sync progression and start tracking
-	progression.StartProgression(firstBlock.Number(), chain.SubscribeEvents())
+	progression.StartProgression("", firstBlock.Number(), chain.SubscribeEvents())
 	// Stop monitoring the sync progression upon exit
 	defer progression.StopProgression()
 

--- a/helper/progress/chain.go
+++ b/helper/progress/chain.go
@@ -19,6 +19,9 @@ type Progression struct {
 	// SyncType is indicating the sync method
 	SyncType ChainSyncType
 
+	// SyncingPeer is current syncing peer id
+	SyncingPeer string
+
 	// StartingBlock is the initial block that the node is starting
 	// the sync from. It is reset after every sync batch
 	StartingBlock uint64
@@ -54,15 +57,25 @@ func NewProgressionWrapper(syncType ChainSyncType) *ProgressionWrapper {
 
 // startProgression initializes the progression tracking
 func (pw *ProgressionWrapper) StartProgression(
+	syncingPeer string,
 	startingBlock uint64,
 	subscription blockchain.Subscription,
 ) {
 	pw.lock.Lock()
 	defer pw.lock.Unlock()
 
+	// set current block
+	var current uint64
+
+	if startingBlock > 0 {
+		current = startingBlock - 1
+	}
+
 	pw.progression = &Progression{
 		SyncType:      pw.syncType,
+		SyncingPeer:   syncingPeer,
 		StartingBlock: startingBlock,
+		CurrentBlock:  current,
 	}
 
 	go pw.RunUpdateLoop(subscription)

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -126,6 +126,7 @@ func (e *Eth) Syncing() (interface{}, error) {
 		// Node is bulk syncing, return the status
 		return progression{
 			Type:          string(syncProgression.SyncType),
+			SyncingPeer:   syncProgression.SyncingPeer,
 			StartingBlock: hex.EncodeUint64(syncProgression.StartingBlock),
 			CurrentBlock:  hex.EncodeUint64(syncProgression.CurrentBlock),
 			HighestBlock:  hex.EncodeUint64(syncProgression.HighestBlock),

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -318,6 +318,7 @@ type txnArgs struct {
 
 type progression struct {
 	Type          string `json:"type"`
+	SyncingPeer   string `json:"syncingPeer"`
 	StartingBlock string `json:"startingBlock"`
 	CurrentBlock  string `json:"currentBlock"`
 	HighestBlock  string `json:"highestBlock"`

--- a/protocol/client.go
+++ b/protocol/client.go
@@ -358,6 +358,8 @@ func (client *syncPeerClient) newSyncPeerClient(peerID peer.ID) (proto.V1Client,
 		// create new connection
 		conn, err = client.network.NewProtoConnection(_syncerV1, peerID)
 		if err != nil {
+			client.network.ForgetPeer(peerID, "not support syncer v1 protocol")
+
 			return nil, fmt.Errorf("failed to open a stream, err %w", err)
 		}
 

--- a/protocol/interface.go
+++ b/protocol/interface.go
@@ -80,7 +80,7 @@ type Network interface {
 
 type Progression interface {
 	// StartProgression starts progression
-	StartProgression(startingBlock uint64, subscription blockchain.Subscription)
+	StartProgression(syncingPeer string, startingBlock uint64, subscription blockchain.Subscription)
 	// UpdateHighestProgression updates highest block number
 	UpdateHighestProgression(highestBlock uint64)
 	// GetProgression returns Progression

--- a/protocol/interface.go
+++ b/protocol/interface.go
@@ -74,6 +74,8 @@ type Network interface {
 	SaveProtocolStream(protocol string, stream *rawGrpc.ClientConn, peerID peer.ID)
 	// CloseProtocolStream closes stream
 	CloseProtocolStream(protocol string, peerID peer.ID) error
+	// ForgetPeer disconnects, remove and forget peer to prevent broadcast discovery to other peers
+	ForgetPeer(peer peer.ID, reason string)
 }
 
 type Progression interface {

--- a/protocol/peer.go
+++ b/protocol/peer.go
@@ -33,6 +33,12 @@ func NewPeerMap(peers []*NoForkPeer) *PeerMap {
 	return peerMap
 }
 
+func (m *PeerMap) Exists(peerID peer.ID) bool {
+	_, exists := m.Load(peerID.String())
+
+	return exists
+}
+
 func (m *PeerMap) Put(peers ...*NoForkPeer) {
 	for _, peer := range peers {
 		m.Store(peer.ID.String(), peer)

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -490,6 +490,16 @@ func (s *noForkSyncer) startPeerConnectionEventProcess() {
 
 // initNewPeerStatus fetches status of the peer and put to peer map
 func (s *noForkSyncer) initNewPeerStatus(peerID peer.ID) {
+	if _, exists := s.peerMap.Load(peerID); exists {
+		s.logger.Info("peer already connected, no need to reinit it again", "id", peerID)
+
+		return
+	}
+
+	// save it without re-init
+	s.putToPeerMap(&NoForkPeer{ID: peerID})
+	s.logger.Info("peer connected", "id", peerID)
+
 	status, err := s.syncPeerClient.GetPeerStatus(peerID)
 	if err != nil {
 		s.logger.Warn("failed to get peer status, skip", "id", peerID, "err", err)
@@ -497,6 +507,7 @@ func (s *noForkSyncer) initNewPeerStatus(peerID peer.ID) {
 		return
 	}
 
+	// update its status
 	s.putToPeerMap(status)
 }
 

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -315,7 +315,7 @@ func (s *noForkSyncer) syncWithSkipList(
 	s.syncingPeer = bestPeer.ID.String()
 
 	// use subscription for updating progression
-	s.syncProgression.StartProgression(localLatest, s.blockchain.SubscribeEvents())
+	s.syncProgression.StartProgression(s.syncingPeer, localLatest, s.blockchain.SubscribeEvents())
 	s.syncProgression.UpdateHighestProgression(bestPeer.Number)
 
 	// fetch block from the peer

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -80,7 +80,7 @@ type noForkSyncer struct {
 	newStatusCh chan struct{}
 	// syncing state
 	syncing     *atomic.Bool
-	syncingPeer peer.ID
+	syncingPeer string
 
 	// stop chan
 	stopCh chan struct{}
@@ -312,7 +312,7 @@ func (s *noForkSyncer) syncWithSkipList(
 	}
 
 	// set up a peer to receive its status updates for progress updates
-	s.syncingPeer = bestPeer.ID
+	s.syncingPeer = bestPeer.ID.String()
 
 	// use subscription for updating progression
 	s.syncProgression.StartProgression(localLatest, s.blockchain.SubscribeEvents())
@@ -525,12 +525,11 @@ func (s *noForkSyncer) putToPeerMap(status *NoForkPeer) {
 
 	if !s.peerMap.Exists(status.ID) {
 		s.logger.Info("new connected peer", "id", status.ID, "number", status.Number)
-	} else {
-		s.logger.Debug("connected peer update status", "id", status.ID, "number", status.Number)
 	}
 
 	// update progression if needed
-	if status.ID == s.syncingPeer && status.Number > 0 {
+	if status.ID.String() == s.syncingPeer && status.Number > 0 {
+		s.logger.Debug("connected peer update status", "id", status.ID, "number", status.Number)
 		s.syncProgression.UpdateHighestProgression(status.Number)
 	}
 

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -497,7 +497,7 @@ func (s *noForkSyncer) initNewPeerStatus(peerID peer.ID) {
 	}
 
 	// save it without re-init
-	s.putToPeerMap(&NoForkPeer{ID: peerID})
+	s.peerMap.Put(&NoForkPeer{ID: peerID})
 	s.logger.Info("peer connected", "id", peerID)
 
 	status, err := s.syncPeerClient.GetPeerStatus(peerID)

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -502,11 +502,6 @@ func (s *noForkSyncer) initNewPeerStatus(peerID peer.ID) {
 
 // putToPeerMap puts given status to peer map
 func (s *noForkSyncer) putToPeerMap(status *NoForkPeer) {
-	// update progression if OK
-	if p := s.syncProgression; p != nil && status != nil {
-		p.UpdateHighestProgression(status.Number)
-	}
-
 	if status != nil {
 		if _, exists := s.peerMap.Load(status.ID); !exists {
 			s.logger.Info("new connected peer", "id", status.ID, "number", status.Number)

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -490,7 +490,7 @@ func (s *noForkSyncer) startPeerConnectionEventProcess() {
 
 // initNewPeerStatus fetches status of the peer and put to peer map
 func (s *noForkSyncer) initNewPeerStatus(peerID peer.ID) {
-	if _, exists := s.peerMap.Load(peerID); exists {
+	if s.peerMap.Exists(peerID) {
 		s.logger.Info("peer already connected, no need to reinit it again", "id", peerID)
 
 		return
@@ -514,7 +514,7 @@ func (s *noForkSyncer) initNewPeerStatus(peerID peer.ID) {
 // putToPeerMap puts given status to peer map
 func (s *noForkSyncer) putToPeerMap(status *NoForkPeer) {
 	if status != nil {
-		if _, exists := s.peerMap.Load(status.ID); !exists {
+		if !s.peerMap.Exists(status.ID) {
 			s.logger.Info("new connected peer", "id", status.ID, "number", status.Number)
 		} else {
 			s.logger.Debug("connected peer update status", "id", status.ID, "number", status.Number)

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -500,6 +500,7 @@ func (s *noForkSyncer) initNewPeerStatus(peerID peer.ID) {
 	status, err := s.syncPeerClient.GetPeerStatus(peerID)
 	if err != nil {
 		s.logger.Warn("failed to get peer status, skip", "id", peerID, "err", err)
+
 		status = &NoForkPeer{
 			ID: peerID,
 		}

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -495,21 +495,14 @@ func (s *noForkSyncer) startPeerConnectionEventProcess() {
 
 // initNewPeerStatus fetches status of the peer and put to peer map
 func (s *noForkSyncer) initNewPeerStatus(peerID peer.ID) {
-	if s.peerMap.Exists(peerID) {
-		s.logger.Info("peer already connected, no need to reinit it again", "id", peerID)
-
-		return
-	}
-
-	// save it without re-init
-	s.peerMap.Put(&NoForkPeer{ID: peerID})
 	s.logger.Info("peer connected", "id", peerID)
 
 	status, err := s.syncPeerClient.GetPeerStatus(peerID)
 	if err != nil {
 		s.logger.Warn("failed to get peer status, skip", "id", peerID, "err", err)
-
-		return
+		status = &NoForkPeer{
+			ID: peerID,
+		}
 	}
 
 	// update its status
@@ -518,7 +511,7 @@ func (s *noForkSyncer) initNewPeerStatus(peerID peer.ID) {
 
 // putToPeerMap puts given status to peer map
 func (s *noForkSyncer) putToPeerMap(status *NoForkPeer) {
-	if status != nil {
+	if status == nil {
 		// it should not be
 		return
 	}

--- a/protocol/syncer_test.go
+++ b/protocol/syncer_test.go
@@ -23,7 +23,7 @@ type mockProgression struct {
 	highestBlock  uint64
 }
 
-func (m *mockProgression) StartProgression(startingBlock uint64, subscription blockchain.Subscription) {
+func (m *mockProgression) StartProgression(syncingPeer string, startingBlock uint64, subscription blockchain.Subscription) {
 	m.startingBlock = startingBlock
 }
 


### PR DESCRIPTION
# Description

Currently, peers will discover and connect to non-Dogechain peers, which is frustrating and extremely draining of connection resources.

The PR fixes it by forgetting (disconnect and remove it from store) the peer which is not supporting Dogechain `syncer` protocol.

Also, we print out the node ID that is currently syncing in `eth_syncing` endpoint and update its progress when the node status is updated.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

* Start a new MainNet node from Genesis block.
* Observe its peers protocol list.
  * `dogechain peers list | grep "=" | awk '{print $3}' | while read p; do dogechain peers status --peer-id $p; done`
* Observe its log.
* Observe its syncing status.
  * `curl -X POST http://localhost:8545 -d '{"id": 0, "jsonrpc":"2.0", "method": "eth_syncing", "params": []}'`

PR branch result:
* The connected nodes all support the Dogechain `syncer` protocol.
* There are some `forget peer` in the log.
* Return correct and upgraded progression.

Base branch result:
* Due to unfiltered protocol reply discovery, connected peers contain some non-Dogechain peers.
* No and never "forget" any peer in the log.
* Print out unobtrusive and sometimes erroneous sync status.

* The connected peers contain some non-Dogechain peers due to unfiltered protocol reply discovery.
* No and never 'forget' any peer in the log.
* Progress sometimes go wrong.

# Documentation update

Should update official documentation once the version bumped.