### PR TITLE
[jsonrpc] Fix unit test failure on json unmarshal

### DIFF
--- a/jsonrpc/types_test.go
+++ b/jsonrpc/types_test.go
@@ -151,7 +151,7 @@ func Test_toJSONHeader(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	expectedHeader := &jsonHeader{
+	expectedHeader := jsonHeader{
 		ParentHash:   types.StringToHash("0x5b1840d0a559112b42208b074284c92d32ddc876ab36d3a40a6ef109c3230899"),
 		Sha3Uncles:   types.StringToHash("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"),
 		Miner:        types.StringToAddress("0x32fC6Db2B0500fF103A810B46Daa26d35CE5172f"),
@@ -170,14 +170,9 @@ func Test_toJSONHeader(t *testing.T) {
 		Hash:         types.StringToHash("0x85492e41d07c4886706650c1d0754856dc7c92d1dd311fb18f6d425c2dd1f897"),
 	}
 
-	raw, err := json.Marshal(rawHeaderStr)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+	jh := jsonHeader{}
 
-	jh := &jsonHeader{}
-
-	err = json.Unmarshal(raw, &jh)
+	err = json.Unmarshal([]byte(rawHeaderStr), &jh)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/types/header.go
+++ b/types/header.go
@@ -77,6 +77,11 @@ func (n Nonce) MarshalText() ([]byte, error) {
 	return []byte(n.String()), nil
 }
 
+// UnmarshalText implements encoding.Unmarshaler
+func (n *Nonce) UnmarshalJSON(input []byte) error {
+	return n.Scan(StringToBytes(string(input)))
+}
+
 func (h *Header) Copy() *Header {
 	newHeader := &Header{
 		ParentHash:   h.ParentHash,


### PR DESCRIPTION
# Description

The unit test failed due to not implemented `UnmarshalJSON` method. The PR fixes it.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

## Testing

- [x] I have tested this code with the official test suite