### PR TITLE
[network] fix workqueue close

### DIFF
--- a/network/gossip.go
+++ b/network/gossip.go
@@ -92,6 +92,8 @@ func (t *topicImp) readLoop(sub *pubsub.Subscription, handler func(obj interface
 	t.wg.Add(1)
 	// work queue for less goroutine allocation
 	workqueue := make(chan *task, _workerNum*4)
+	defer close(workqueue)
+
 	// cancel context
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -114,7 +116,7 @@ func (t *topicImp) readLoop(sub *pubsub.Subscription, handler func(obj interface
 		timeoutCancel()
 
 		cancel()
-		close(workqueue)
+
 		t.wg.Done()
 	}()
 


### PR DESCRIPTION
# Description

panic when the program exit, close `workqueue` channel need wait context cancel and `readLoop` return

unit test failed reason

```
panic: send on closed channel

goroutine 4094 [running]:
github.com/dogechain-lab/dogechain/protocol.(*syncPeerClient).handleStatusUpdate(0xc0007573b0, {0xf97ac0, 0xc003114e10}, {0xc00001d260, 0xc0032b7801})
	/work/protocol/client.go:217 +0x333
github.com/dogechain-lab/dogechain/network.(*topicImp).readLoop.func2()
	/work/network/gossip.go:129 +0x43
created by github.com/dogechain-lab/dogechain/network.(*topicImp).readLoop
	/work/network/gossip.go:122 +0x17d
FAIL	github.com/dogechain-lab/dogechain/protocol	3.060s
```

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels

## Testing

- [x] I have tested this code with the official test suite

