### PR TITLE
[protocol] Move close channel after close topics

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -1471,13 +1471,11 @@ func (i *Ibft) IsLastOfEpoch(number uint64) bool {
 
 // Close closes the IBFT consensus mechanism, and does write back to disk
 func (i *Ibft) Close() error {
-	if i.isClosed.Load() {
+	if !i.isClosed.CAS(false, true) {
 		i.logger.Error("IBFT consensus is Closed")
 
 		return nil
 	}
-
-	i.isClosed.Store(true)
 
 	close(i.closeCh)
 

--- a/protocol/client.go
+++ b/protocol/client.go
@@ -83,15 +83,15 @@ func (client *syncPeerClient) Close() {
 		client.subscription = nil
 	}
 
-	close(client.peerStatusUpdateCh)
-	close(client.peerConnectionUpdateCh)
-
 	if client.topic != nil {
 		// close topic when needed
 		client.topic.Close()
 
 		client.topic = nil
 	}
+
+	close(client.peerStatusUpdateCh)
+	close(client.peerConnectionUpdateCh)
 }
 
 // DisablePublishingPeerStatus disables publishing own status via gossip

--- a/protocol/client.go
+++ b/protocol/client.go
@@ -37,7 +37,7 @@ type syncPeerClient struct {
 	peerConnectionUpdateCh chan *event.PeerEvent   // peer connection update channel
 
 	shouldEmitBlocks bool // flag for emitting blocks in the topic
-	isClose          *atomic.Bool
+	isClosed         *atomic.Bool
 }
 
 func NewSyncPeerClient(
@@ -53,7 +53,7 @@ func NewSyncPeerClient(
 		peerStatusUpdateCh:     make(chan *NoForkPeer, 1),
 		peerConnectionUpdateCh: make(chan *event.PeerEvent, 1),
 		shouldEmitBlocks:       true,
-		isClose:                atomic.NewBool(false),
+		isClosed:               atomic.NewBool(false),
 	}
 }
 
@@ -71,11 +71,9 @@ func (client *syncPeerClient) Start() error {
 
 // Close terminates running processes for SyncPeerClient
 func (client *syncPeerClient) Close() {
-	if client.isClose.Load() {
+	if !client.isClosed.CAS(false, true) {
 		return
 	}
-
-	client.isClose.Store(true)
 
 	if client.subscription != nil {
 		client.subscription.Close()
@@ -208,7 +206,7 @@ func (client *syncPeerClient) handleStatusUpdate(obj interface{}, from peer.ID) 
 
 	client.logger.Debug("get connected peer status update", "from", from, "status", status.Number)
 
-	if client.isClose.Load() {
+	if client.isClosed.Load() {
 		client.logger.Debug("client is closed, ignore status update", "from", from, "status", status.Number)
 
 		return
@@ -254,7 +252,7 @@ func (client *syncPeerClient) startPeerEventProcess() {
 
 	for e := range peerEventCh {
 		if e.Type == event.PeerConnected || e.Type == event.PeerDisconnected {
-			if client.isClose.Load() {
+			if client.isClosed.Load() {
 				client.logger.Debug("client is closed, ignore peer connection update", "peer", e.PeerID, "type", e.Type)
 
 				return

--- a/protocol/client_test.go
+++ b/protocol/client_test.go
@@ -44,7 +44,7 @@ func newTestSyncPeerClient(network network.Network, blockchain Blockchain) *sync
 		id:                     network.AddrInfo().ID.String(),
 		peerStatusUpdateCh:     make(chan *NoForkPeer, 1),
 		peerConnectionUpdateCh: make(chan *event.PeerEvent, 1),
-		isClose:                atomic.NewBool(false),
+		isClosed:               atomic.NewBool(false),
 	}
 
 	// need to register protocol

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -336,13 +336,11 @@ func (p *TxPool) Start() {
 
 // Close shuts down the pool's main loop.
 func (p *TxPool) Close() {
-	if p.isClosed.Load() {
+	if !p.isClosed.CAS(false, true) {
 		p.logger.Error("txpool is Closed")
 
 		return
 	}
-
-	p.isClosed.Store(true)
 
 	p.ddosReductionTicker.Stop()
 


### PR DESCRIPTION
# Description

unit test exist random crash, `isClosed` atomic var not use CAS swap and the channel is closed before canceling the topic subscription

```
panic: send on closed channel

goroutine 2696 [running]:
github.com/dogechain-lab/dogechain/protocol.(*syncPeerClient).handleStatusUpdate(0xc001275680, {0xf98aa0, 0xc0039ef590}, {0xc0039fb440, 0x1484f01})
	/home/runner/work/dogechain/dogechain/protocol/client.go:217 +0x333
github.com/dogechain-lab/dogechain/network.(*topicImp).readLoop.func2()
	/home/runner/work/dogechain/dogechain/network/gossip.go:131 +0x43
created by github.com/dogechain-lab/dogechain/network.(*topicImp).readLoop
	/home/runner/work/dogechain/dogechain/network/gossip.go:124 +0x1b3
FAIL	github.com/dogechain-lab/dogechain/protocol	5.132s
```

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels

## Testing

- [x] I have tested this code with the official test suite
