### PR TITLE
[backup] Improved writing and reading of blockchain backup file

### DIFF
--- a/archive/backup.go
+++ b/archive/backup.go
@@ -241,9 +241,8 @@ func processExport(
 				err = blk.UnmarshalRLP(resp.Data)
 				if err != nil {
 					logger.Error("Failed to unmarshal block", "Number", num, "err", err)
-					time.Sleep(1 * time.Second)
 
-					continue
+					return
 				}
 
 				if blk.Number() != num {
@@ -270,7 +269,7 @@ func processExport(
 				return from, current, nil
 			}
 
-			// tips: writer.Write() not necessarily write all data, use io.Copy() instead
+			// tips: writer.Write() does not necessarily write all data, use io.Copy() instead
 			if _, err := io.Copy(writer, bytes.NewBuffer(block.MarshalRLP())); err != nil {
 				return from, current, err
 			}

--- a/archive/backup.go
+++ b/archive/backup.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
+	"time"
 
 	"github.com/dogechain-lab/dogechain/helper/common"
 	"github.com/dogechain-lab/dogechain/server/proto"
@@ -18,6 +20,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+var (
+	// Error Info
+	ErrBlockRange = errors.New("block range error: from is greater than or equal to to")
 )
 
 // CreateBackup fetches blockchain data with the specific range via gRPC
@@ -36,6 +43,37 @@ func CreateBackup(
 	resTo = 0
 	err = nil
 
+	signalCh := common.GetTerminationSignalCh()
+	ctx, cancelFn := context.WithCancel(context.Background())
+
+	defer cancelFn()
+
+	go func() {
+		<-signalCh
+		logger.Info("Caught termination signal, shutting down...")
+		cancelFn()
+	}()
+
+	clt := proto.NewSystemClient(conn)
+
+	var reqTo uint64
+
+	var reqToHash types.Hash
+
+	reqTo, reqToHash, err = determineTo(ctx, clt, to)
+	if err != nil {
+		return
+	}
+
+	if from <= reqTo {
+		logger.Info("Exporting blocks", "from", from, "to", reqTo)
+	} else {
+		err = ErrBlockRange
+
+		return
+	}
+
+	// open write file
 	// allow to overwrite the overwrites file only if it's explicitly set
 	fileFlag := os.O_WRONLY | os.O_CREATE | os.O_EXCL
 	if overwriteFile {
@@ -87,43 +125,12 @@ func CreateBackup(
 		writeBuf = fbuf
 	}
 
-	signalCh := common.GetTerminationSignalCh()
-	ctx, cancelFn := context.WithCancel(context.Background())
-
-	defer cancelFn()
-
-	go func() {
-		<-signalCh
-		logger.Info("Caught termination signal, shutting down...")
-		cancelFn()
-	}()
-
-	clt := proto.NewSystemClient(conn)
-
-	var reqTo uint64
-
-	var reqToHash types.Hash
-
-	reqTo, reqToHash, err = determineTo(ctx, clt, to)
-	if err != nil {
-		return
-	}
-
-	var stream proto.System_ExportClient
-
-	stream, err = clt.Export(ctx, &proto.ExportRequest{
-		From: from,
-		To:   reqTo,
-	})
-	if err != nil {
-		return
-	}
-
+	// write metadata
 	if err = writeMetadata(writeBuf, logger, reqTo, reqToHash); err != nil {
 		return
 	}
 
-	resFrom, resTo, err = processExportStream(stream, logger, writeBuf, from, reqTo)
+	resFrom, resTo, err = processExport(ctx, clt, logger, writeBuf, from, reqTo)
 	if err != nil {
 		return
 	}
@@ -171,59 +178,104 @@ func writeMetadata(writer io.Writer, logger hclog.Logger, to uint64, toHash type
 	return err
 }
 
-func processExportStream(
-	stream proto.System_ExportClient,
+func processExport(
+	ctx context.Context,
+	clt proto.SystemClient,
 	logger hclog.Logger,
 	writer io.Writer,
 	targetFrom, targetTo uint64,
 ) (uint64, uint64, error) {
-	var from, to, total uint64 = 0, 0, 0
+	var from, to, current, total uint64 = targetFrom, targetTo, targetFrom, 0
 
-	showProgress := func(event *proto.ExportEvent) {
-		num := event.To - event.From
-		total += num
-		expectedTo := targetTo
+	if (targetTo - targetFrom + 1) == 0 {
+		return 0, 0, ErrBlockRange
+	}
 
-		if targetTo == 0 {
-			expectedTo = event.Latest
-		}
+	showProgress := func(block *types.Block) {
+		current = block.Header.Number
+		total += 1
 
-		expectedTotal := expectedTo - targetFrom
-		progress := 100 * (float64(event.To) - float64(targetFrom)) / float64(expectedTotal)
-
+		progress := 100 * (float64(total) / float64(targetTo-targetFrom+1))
 		logger.Info(
-			fmt.Sprintf("%d blocks are written", num),
-			"total", total,
-			"from", targetFrom,
-			"to", expectedTo,
+			fmt.Sprintf("%d blocks are written", total),
+			"from", from,
+			"to", to,
+			"height", current,
 			"progress", fmt.Sprintf("%.2f%%", progress),
 		)
 	}
 
-	firstBlok := true
+	maxFetchBlockNum := runtime.NumCPU() * 2
 
+	// fetch blocks from channel
+	// block data channel: [from, to]
+	blockCh := make(chan *types.Block, maxFetchBlockNum)
+
+	go func(from uint64, to uint64) {
+		defer func() {
+			blockCh <- nil
+		}()
+
+		for num := from; num <= to; num++ {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+
+				resp, err := clt.BlockByNumber(context.Background(), &proto.BlockByNumberRequest{Number: num})
+				if status.Code(err) == codes.Canceled {
+					return
+				}
+
+				if err != nil {
+					logger.Error("Failed to fetch block", "Number", num, "err", err)
+					time.Sleep(1 * time.Second)
+
+					continue
+				}
+
+				blk := &types.Block{}
+
+				err = blk.UnmarshalRLP(resp.Data)
+				if err != nil {
+					logger.Error("Failed to unmarshal block", "Number", num, "err", err)
+					time.Sleep(1 * time.Second)
+
+					continue
+				}
+
+				if blk.Number() != num {
+					logger.Error("Fetch block number is wrong", "Number", num, "err", err)
+
+					return
+				}
+
+				blockCh <- blk
+
+				break
+			}
+		}
+	}(from, to)
+
+	// write blocks to writer
 	for {
-		event, err := stream.Recv()
-		if errors.Is(io.EOF, err) || status.Code(err) == codes.Canceled {
-			return from, to, nil
+		select {
+		case <-ctx.Done():
+			return from, current, nil
+		case block := <-blockCh:
+			// block == nil means all blocks are fetched
+			if block == nil {
+				return from, current, nil
+			}
+
+			// tips: writer.Write() not necessarily write all data, use io.Copy() instead
+			if _, err := io.Copy(writer, bytes.NewBuffer(block.MarshalRLP())); err != nil {
+				return from, current, err
+			}
+
+			showProgress(block)
 		}
-
-		if err != nil {
-			return from, to, err
-		}
-
-		// tips: writer.Write() not necessarily write all data, use io.Copy() instead
-		if _, err := io.Copy(writer, bytes.NewBuffer(event.Data)); err != nil {
-			return from, to, err
-		}
-
-		if firstBlok {
-			from = event.From
-			firstBlok = false
-		}
-
-		to = event.To
-
-		showProgress(event)
 	}
 }

--- a/archive/backup_test.go
+++ b/archive/backup_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io"
 	"testing"
 
 	"github.com/dogechain-lab/dogechain/server/proto"
@@ -15,28 +14,6 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-type recvData struct {
-	event *proto.ExportEvent
-	err   error
-}
-
-type mockSystemExportClient struct {
-	proto.System_ExportClient
-	recvs []recvData
-	cur   int
-}
-
-func (m *mockSystemExportClient) Recv() (*proto.ExportEvent, error) {
-	if m.cur >= len(m.recvs) {
-		return nil, io.EOF
-	}
-
-	recv := m.recvs[m.cur]
-	m.cur++
-
-	return recv.event, recv.err
-}
-
 var (
 	genesis = &types.Block{
 		Header: &types.Header{
@@ -45,6 +22,7 @@ var (
 		},
 	}
 	blocks = []*types.Block{
+		genesis,
 		{
 			Header: &types.Header{
 				Number: 1,
@@ -75,7 +53,7 @@ type systemClientMock struct {
 	proto.SystemClient
 	status       *proto.ServerStatus
 	errForStatus error
-	block        *proto.BlockResponse
+	blocks       []*types.Block
 	errForBlock  error
 }
 
@@ -84,10 +62,20 @@ func (m *systemClientMock) GetStatus(context.Context, *emptypb.Empty, ...grpc.Ca
 }
 
 func (m *systemClientMock) BlockByNumber(
-	context.Context,
-	*proto.BlockByNumberRequest, ...grpc.CallOption,
+	_ctx context.Context,
+	req *proto.BlockByNumberRequest,
+	_opts ...grpc.CallOption,
 ) (*proto.BlockResponse, error) {
-	return m.block, m.errForBlock
+	// find block by request number
+	for _, b := range m.blocks {
+		if b.Header.Number == req.Number {
+			return &proto.BlockResponse{
+				Data: b.MarshalRLP(),
+			}, m.errForBlock
+		}
+	}
+
+	return nil, m.errForBlock
 }
 
 func Test_determineTo(t *testing.T) {
@@ -116,9 +104,7 @@ func Test_determineTo(t *testing.T) {
 						Number: 10,
 					},
 				},
-				block: &proto.BlockResponse{
-					Data: blocks[1].MarshalRLP(),
-				},
+				blocks: blocks,
 			},
 			resTo:     2,
 			resToHash: blocks[1].Hash(),
@@ -135,6 +121,7 @@ func Test_determineTo(t *testing.T) {
 						Hash:   blocks[1].Hash().String(),
 					},
 				},
+				blocks: blocks,
 			},
 			resTo:     1,
 			resToHash: blocks[1].Hash(),
@@ -167,87 +154,108 @@ func Test_determineTo(t *testing.T) {
 
 func Test_processExportStream(t *testing.T) {
 	tests := []struct {
-		name                   string
-		mockSystemExportClient *mockSystemExportClient
+		name             string
+		systemClientMock proto.SystemClient
 		// result
-		from uint64
-		to   uint64
-		err  error
+		from  uint64
+		to    uint64
+		err   error
+		recvs []*proto.BlockResponse
 	}{
 		{
-			name: "should be succeed with event",
-			mockSystemExportClient: &mockSystemExportClient{
-				recvs: []recvData{
-					{
-						event: &proto.ExportEvent{
-							From: 1,
-							To:   2,
-							Data: append(blocks[0].MarshalRLP(), blocks[1].MarshalRLP()...),
-						},
+			name: "should be succeed with single block",
+			systemClientMock: &systemClientMock{
+				status: &proto.ServerStatus{
+					Current: &proto.ServerStatus_Block{
+						// greater than targetTo
+						Number: int64(blocks[2].Number()),
 					},
 				},
+				blocks: blocks,
 			},
-			from: 1,
-			to:   2,
+			from: blocks[1].Number(),
+			to:   blocks[1].Number(),
 			err:  nil,
+			recvs: []*proto.BlockResponse{
+				{
+					Data: blocks[1].MarshalRLP(),
+				},
+			},
 		},
 		{
-			name: "should succeed with multiple events",
-			mockSystemExportClient: &mockSystemExportClient{
-				recvs: []recvData{
-					{
-						event: &proto.ExportEvent{
-							From: 1,
-							To:   2,
-							Data: append(blocks[0].MarshalRLP(), blocks[1].MarshalRLP()...),
-						},
-					},
-					{
-						event: &proto.ExportEvent{
-							From: 3,
-							To:   3,
-							Data: blocks[2].MarshalRLP(),
-						},
+			name: "should be succeed multiple blocks",
+			systemClientMock: &systemClientMock{
+				status: &proto.ServerStatus{
+					Current: &proto.ServerStatus_Block{
+						// greater than targetTo
+						Number: int64(blocks[2].Number()),
 					},
 				},
+				blocks: blocks,
 			},
-			from: 1,
-			to:   3,
+			from: blocks[0].Number(),
+			to:   blocks[2].Number(),
 			err:  nil,
+			recvs: []*proto.BlockResponse{
+				{
+					Data: blocks[0].MarshalRLP(),
+				},
+				{
+					Data: blocks[1].MarshalRLP(),
+				},
+				{
+					Data: blocks[2].MarshalRLP(),
+				},
+			},
 		},
 		{
-			name: "should fail when received error",
-			mockSystemExportClient: &mockSystemExportClient{
-				recvs: []recvData{
-					{
-						event: &proto.ExportEvent{
-							From: 1,
-							To:   2,
-							Data: append(blocks[0].MarshalRLP(), blocks[1].MarshalRLP()...),
-						},
-					},
-					{
-						err: errors.New("failed to send"),
-					},
-					{
-						event: &proto.ExportEvent{
-							From: 3,
-							To:   3,
-							Data: blocks[2].MarshalRLP(),
-						},
+			name: "should be succeed select range of 2-3 blocks",
+			systemClientMock: &systemClientMock{
+				status: &proto.ServerStatus{
+					Current: &proto.ServerStatus_Block{
+						// greater than targetTo
+						Number: int64(blocks[2].Number()),
 					},
 				},
+				blocks: blocks,
 			},
-			from: 0,
-			to:   0,
-			err:  errors.New("failed to send"),
+			from: blocks[1].Number(),
+			to:   blocks[2].Number(),
+			err:  nil,
+			recvs: []*proto.BlockResponse{
+				{
+					Data: blocks[1].MarshalRLP(),
+				},
+				{
+					Data: blocks[2].MarshalRLP(),
+				},
+			},
+		},
+		{
+			name: "should be failed with error range",
+			systemClientMock: &systemClientMock{
+				status: &proto.ServerStatus{
+					Current: &proto.ServerStatus_Block{
+						// greater than targetTo
+						Number: int64(blocks[2].Number()),
+					},
+				},
+				blocks: blocks,
+			},
+			from:  blocks[2].Number(),
+			to:    blocks[1].Number(),
+			err:   ErrBlockRange,
+			recvs: []*proto.BlockResponse{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buffer bytes.Buffer
-			from, to, err := processExportStream(tt.mockSystemExportClient, hclog.NewNullLogger(), &buffer, 0, 0)
+			var ctx, cancel = context.WithCancel(context.Background())
+			defer cancel()
+
+			from, to, err := processExport(ctx, tt.systemClientMock, hclog.NewNullLogger(), &buffer, tt.from, tt.to)
 
 			assert.Equal(t, tt.err, err)
 			if err != nil {
@@ -259,11 +267,10 @@ func Test_processExportStream(t *testing.T) {
 
 			// create expected data
 			expectedData := make([]byte, 0)
-			for _, rv := range tt.mockSystemExportClient.recvs {
-				if rv.err != nil {
-					break
+			for _, rv := range tt.recvs {
+				if rv != nil {
+					expectedData = append(expectedData, rv.Data...)
 				}
-				expectedData = append(expectedData, rv.event.Data...)
 			}
 			assert.Equal(t, expectedData, buffer.Bytes())
 		})

--- a/archive/backup_test.go
+++ b/archive/backup_test.go
@@ -96,7 +96,7 @@ func Test_determineTo(t *testing.T) {
 	}{
 		{
 			name:     "should return expected 'to'",
-			targetTo: toPtr(2),
+			targetTo: toPtr(blocks[2].Number()),
 			systemClientMock: &systemClientMock{
 				status: &proto.ServerStatus{
 					Current: &proto.ServerStatus_Block{
@@ -106,24 +106,24 @@ func Test_determineTo(t *testing.T) {
 				},
 				blocks: blocks,
 			},
-			resTo:     2,
-			resToHash: blocks[1].Hash(),
+			resTo:     blocks[2].Number(),
+			resToHash: blocks[2].Hash(),
 			err:       nil,
 		},
 		{
 			name:     "should return latest if target to is greater than the latest in node",
-			targetTo: toPtr(2),
+			targetTo: toPtr(blocks[2].Number()),
 			systemClientMock: &systemClientMock{
 				status: &proto.ServerStatus{
 					Current: &proto.ServerStatus_Block{
 						// less than targetTo
-						Number: 1,
+						Number: int64(blocks[1].Number()),
 						Hash:   blocks[1].Hash().String(),
 					},
 				},
 				blocks: blocks,
 			},
-			resTo:     1,
+			resTo:     blocks[1].Number(),
 			resToHash: blocks[1].Hash(),
 			err:       nil,
 		},

--- a/command/backup/params.go
+++ b/command/backup/params.go
@@ -88,6 +88,7 @@ func (p *backupParams) createBackup(grpcAddress string) error {
 	if err != nil {
 		return err
 	}
+	defer connection.Close()
 
 	// resFrom and resTo represents the range of blocks that can be included in the file
 	resFrom, resTo, err := archive.CreateBackup(

--- a/command/backup/params.go
+++ b/command/backup/params.go
@@ -88,7 +88,7 @@ func (p *backupParams) createBackup(grpcAddress string) error {
 	if err != nil {
 		return err
 	}
-	defer connection.Close()
+	defer conn.Close()
 
 	// resFrom and resTo represents the range of blocks that can be included in the file
 	resFrom, resTo, err := archive.CreateBackup(

--- a/server/server.go
+++ b/server/server.go
@@ -354,7 +354,7 @@ func (s *Server) restoreChain() error {
 		return nil
 	}
 
-	if err := archive.RestoreChain(s.blockchain, *s.config.RestoreFile, s.restoreProgression); err != nil {
+	if err := archive.RestoreChain(s.logger, s.blockchain, *s.config.RestoreFile); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Description

- reading and writing use separate goroutine
- read block use `BlockByNumber`, circumventing block range limits (grpc load balancing is now available)

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

create backup 

```shell
dogechain backup --from 1 --to 100 --zstd --out blockchain.bin.zstd
```

restore backup

```shell
dogechain server --chain ./genesis.json --restore blockchain.bin.zstd --data-dir ./data
```






