### PR TITLE
[syncer] fix syncer block

### DIFF
--- a/e2e/ibft_test.go
+++ b/e2e/ibft_test.go
@@ -55,6 +55,8 @@ func TestIbft_Transfer(t *testing.T) {
 }
 
 func TestIbft_TransactionFeeRecipient(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name         string
 		contractCall bool
@@ -88,7 +90,9 @@ func TestIbft_TransactionFeeRecipient(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			senderKey, senderAddr := tests.GenerateKeyAndAddr(t)
 			_, receiverAddr := tests.GenerateKeyAndAddr(t)
 

--- a/helper/common/rand.go
+++ b/helper/common/rand.go
@@ -2,14 +2,15 @@ package common
 
 import (
 	"crypto/rand"
-	"log"
 	"math/big"
 )
 
 func SecureRandInt(max int) int {
 	nBig, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
 	if err != nil {
-		log.Println(err)
+		// if err not nil, it will panic, this is a low level error
+		// program should not continue
+		panic(err)
 	}
 
 	return ClampInt64ToInt(nBig.Int64())
@@ -18,7 +19,9 @@ func SecureRandInt(max int) int {
 func SecureRandInt64(max int64) int64 {
 	nBig, err := rand.Int(rand.Reader, big.NewInt(max))
 	if err != nil {
-		log.Println(err)
+		// if err not nil, it will panic, this is a low level error
+		// program should not continue
+		panic(err)
 	}
 
 	return nBig.Int64()

--- a/helper/common/rand.go
+++ b/helper/common/rand.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"crypto/rand"
+	"log"
+	"math/big"
+)
+
+func SecureRandInt(max int) int {
+	nBig, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+	if err != nil {
+		log.Println(err)
+	}
+
+	return ClampInt64ToInt(nBig.Int64())
+}
+
+func SecureRandInt64(max int64) int64 {
+	nBig, err := rand.Int(rand.Reader, big.NewInt(max))
+	if err != nil {
+		log.Println(err)
+	}
+
+	return nBig.Int64()
+}

--- a/protocol/peer.go
+++ b/protocol/peer.go
@@ -60,11 +60,8 @@ func (m *PeerMap) BestPeer(skipMap *map[peer.ID]int64) *NoForkPeer {
 		}
 
 		_, exists := (*skipMap)[id]
-		if !exists {
-			return false
-		}
 
-		return true
+		return exists
 	}
 
 	m.Range(func(key, value interface{}) bool {

--- a/protocol/peer.go
+++ b/protocol/peer.go
@@ -51,22 +51,20 @@ func (m *PeerMap) Remove(peerID peer.ID) {
 }
 
 // BestPeer returns the top of heap
-func (m *PeerMap) BestPeer(skipMap *sync.Map) *NoForkPeer {
+func (m *PeerMap) BestPeer(skipMap *map[peer.ID]int64) *NoForkPeer {
 	var bestPeer *NoForkPeer
 
-	needSkipPeer := func(skipMap *sync.Map, id peer.ID) bool {
+	needSkipPeer := func(skipMap *map[peer.ID]int64, id peer.ID) bool {
 		if skipMap == nil {
 			return false
 		}
 
-		v, exists := skipMap.Load(id)
+		_, exists := (*skipMap)[id]
 		if !exists {
 			return false
 		}
 
-		skip, ok := v.(bool)
-
-		return ok && skip
+		return true
 	}
 
 	m.Range(func(key, value interface{}) bool {

--- a/protocol/peer_test.go
+++ b/protocol/peer_test.go
@@ -2,8 +2,8 @@ package protocol
 
 import (
 	"sort"
-	"sync"
 	"testing"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/assert"
@@ -110,12 +110,12 @@ func TestPutPeer(t *testing.T) {
 func TestBestPeer(t *testing.T) {
 	t.Parallel()
 
-	skipList := new(sync.Map)
-	skipList.Store(peer.ID("C"), true)
+	skipList := make(map[peer.ID]int64)
+	skipList[peer.ID("C")] = time.Now().Unix()
 
 	tests := []struct {
 		name     string
-		skipList *sync.Map
+		skipList *map[peer.ID]int64
 		peers    []*NoForkPeer
 		result   *NoForkPeer
 	}{
@@ -133,7 +133,7 @@ func TestBestPeer(t *testing.T) {
 		},
 		{
 			name:     "should return the 2nd best peer if the best peer is in skip list",
-			skipList: skipList,
+			skipList: &skipList,
 			peers:    peers,
 			result:   peers[1],
 		},

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -634,7 +634,7 @@ func (s *noForkSyncer) putToPeerMap(status *NoForkPeer) {
 
 	// blockchain if nil, it running in test mode
 	if s.blockchain == nil ||
-		status.Number < s.blockchain.Header().Number {
+		s.blockchain.Header().Number < status.Number {
 		s.notifyNewStatusEvent()
 	}
 }

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -327,8 +327,9 @@ func (s *noForkSyncer) Sync(callback func(*types.Block) bool) error {
 			}
 
 			// remove expired peer
+			currentTime := time.Now().Unix()
 			for _, id := range keys {
-				if time.Now().Unix() > skipList[id] {
+				if currentTime > skipList[id] {
 					delete(skipList, id)
 				}
 			}

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -36,6 +36,8 @@ const (
 	// One step query blocks.
 	// Median rlp block size is around 20 - 50 KB, then 2 - 4 MB is suitable for one query.
 	_blockSyncStep = 100
+
+	_blockSyncTimeout = 30 * time.Second
 )
 
 var (
@@ -436,7 +438,7 @@ func (s *noForkSyncer) bulkSyncWithPeer(
 		return result, nil
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), _blockSyncTimeout)
 	defer cancel()
 
 	// sync up to the current known header

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -555,7 +555,10 @@ func (s *noForkSyncer) initializePeerMap() {
 func (s *noForkSyncer) startPeerStatusUpdateProcess() {
 	for peerStatus := range s.syncPeerClient.GetPeerStatusUpdateCh() {
 		s.logger.Debug("peer status updated", "id", peerStatus.ID, "number", peerStatus.Number)
-		s.putToPeerMap(peerStatus)
+
+		if s.server.HasPeer(peerStatus.ID) {
+			s.putToPeerMap(peerStatus)
+		}
 	}
 }
 
@@ -618,7 +621,10 @@ func (s *noForkSyncer) putToPeerMap(status *NoForkPeer) {
 	}
 
 	s.peerMap.Put(status)
-	s.notifyNewStatusEvent()
+
+	if status.Number < s.blockchain.Header().Number {
+		s.notifyNewStatusEvent()
+	}
 }
 
 // removeFromPeerMap removes the peer from peer map

--- a/protocol/syncer_test.go
+++ b/protocol/syncer_test.go
@@ -137,7 +137,7 @@ func NewTestSyncer(
 		syncProgression: mockProgression,
 		syncPeerService: &mockSyncPeerService{},
 		syncPeerClient:  mockSyncPeerClient,
-		newStatusCh:     make(chan struct{}),
+		newStatusCh:     make(chan struct{}, 1),
 		peerMap:         new(PeerMap),
 		syncing:         atomic.NewBool(false),
 		syncingPeer:     atomic.NewString(""),

--- a/protocol/syncer_test.go
+++ b/protocol/syncer_test.go
@@ -610,7 +610,6 @@ func Test_bulkSyncWithPeer(t *testing.T) {
 	var (
 		// mock errors
 		errPeerNoResponse       = errors.New("peer is not responding")
-		errInvalidBlock         = errors.New("invalid block")
 		errBlockInsertionFailed = errors.New("failed to insert block")
 	)
 
@@ -689,7 +688,7 @@ func Test_bulkSyncWithPeer(t *testing.T) {
 			},
 			verifyFinalizedBlockHandler: func(b *types.Block) error {
 				if b.Number() > 5 {
-					return errInvalidBlock
+					return ErrBlockVerifyFailed
 				}
 
 				return nil
@@ -700,7 +699,7 @@ func Test_bulkSyncWithPeer(t *testing.T) {
 			blocks:                blocks[:5],
 			lastSyncedBlockNumber: 5,
 			shouldTerminate:       false,
-			err:                   errInvalidBlock,
+			err:                   ErrBlockVerifyFailed,
 		},
 		{
 			name:             "should return error if block insertion is failed",


### PR DESCRIPTION
# Description

In the case of unstable network, if all peer is added to the `skipList`, the synchronization will be stuck until the connection is disconnected

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels

## Testing

- [x] I have tested this code with the official test suite
