### PR TITLE
[CI] Update GitHub actions config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,16 +16,24 @@ jobs:
         # uses: actions/setup-go@v3.3.0
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: "1.17.x"
 
       - name: Build Dogechain
-        run: go build -ldflags="-X \"github.com/dogechain-lab/dogechain/versioning.Version=${GITHUB_REF_NAME}\" -X \"github.com/dogechain-lab/dogechain/versioning.Commit=${GITHUB_SHA}\"" -a -o dogechain . && tar -czvf dogechain.tar.gz dogechain
+        run: |
+          go build -a -o dogechain -ldflags="\
+            -X 'github.com/dogechain-lab/dogechain/versioning.Version=${GITHUB_REF_NAME}' \
+            -X 'github.com/dogechain-lab/dogechain/versioning.Commit=${GITHUB_COMMIT_HASH}' \
+            -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime=${GITHUB_BUILT_AT}' \
+            -extldflags '"-Wl,-z,stack-size=0x800000" "-static"' "\
+            -tags 'osusergo netgo static_build' && tar -czvf dogechain.tar.gz dogechain
         env:
           CGO_ENABLED: 0
           CC: gcc
           CXX: g++
           GOARC: amd64
           GOOS: linux
+          GITHUB_COMMIT_HASH: ${{ github.sha }}
+          GITHUB_BUILT_AT: ${{ github.event.head_commit.timestamp }}
 
       - name: Extract branch name
         # if: github.event_name != 'pull_request'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: "1.17.x"
       - name: Run tests
         run: make test-e2e
       # - name: Archive test logs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: "1.17.x"
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
               --privileged \
               -e CGO_ENABLED=0 \
               -e GITHUB_TOKEN \
+              -e GITHUB_COMMIT_HASH \
+              -e GITHUB_BUILT_AT \
               -e DOCKER_USERNAME \
               -e DOCKER_PASSWORD \
               -e SLACK_WEBHOOK \
@@ -45,11 +47,11 @@ jobs:
           PACKAGE_NAME: github.com/dogechain-lab/dogechain
           GOLANG_CROSS_VERSION: "1.17.9"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_COMMIT_HASH: ${{ github.sha }}
+          GITHUB_BUILT_AT: ${{ github.event.head_commit.timestamp }}
           VERSION: ${{ steps.prepare.outputs.tag_name }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          GITHUB_COMMIT_HASH: ${{ github.sha }}
-          GITHUB_BUILT_AT: ${{ github.event.head_commit.timestamp }}
     if: github.actor == 'abrahamcruise321' || github.actor == 'DarianShawn'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           docker run \
               --rm \
               --privileged \
-              -e CGO_ENABLED=1 \
+              -e CGO_ENABLED=0 \
               -e GITHUB_TOKEN \
               -e DOCKER_USERNAME \
               -e DOCKER_PASSWORD \
@@ -39,15 +39,17 @@ jobs:
               -v /var/run/docker.sock:/var/run/docker.sock \
               -v `pwd`:/go/src/$(PACKAGE_NAME) \
               -w /go/src/$(PACKAGE_NAME) \
-              ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+              ghcr.io/goreleaser/goreleaser-cross:v${GOLANG_CROSS_VERSION} \
               --rm-dist --skip-validate
         env:
           PACKAGE_NAME: github.com/dogechain-lab/dogechain
-          GOLANG_CROSS_VERSION: v1.17.9
+          GOLANG_CROSS_VERSION: "1.17.9"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.prepare.outputs.tag_name }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          GITHUB_COMMIT_HASH: ${{ github.sha }}
+          GITHUB_BUILT_AT: ${{ github.event.head_commit.timestamp }}
     if: github.actor == 'abrahamcruise321' || github.actor == 'DarianShawn'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,6 @@ jobs:
               --privileged \
               -e CGO_ENABLED=0 \
               -e GITHUB_TOKEN \
-              -e GITHUB_COMMIT_HASH \
-              -e GITHUB_BUILT_AT \
               -e DOCKER_USERNAME \
               -e DOCKER_PASSWORD \
               -e SLACK_WEBHOOK \
@@ -47,8 +45,6 @@ jobs:
           PACKAGE_NAME: github.com/dogechain-lab/dogechain
           GOLANG_CROSS_VERSION: "1.17.9"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_COMMIT_HASH: ${{ github.sha }}
-          GITHUB_BUILT_AT: ${{ github.event.head_commit.timestamp }}
           VERSION: ${{ steps.prepare.outputs.tag_name }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: "1.17.x"
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,13 @@ builds:
     env:
       - CC=o64-clang
       - CXX=o64-clang++
-    ldflags: -s -w -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}'
+    ldflags: >
+      -s -w
+      -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}
+      -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .GITHUB_COMMIT_HASH }}'
+      -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .GITHUB_BUILT_AT }}'
+      -extldflags "-Wl,-z,stack-size=0x800000" "-static"
+      -tags 'osusergo netgo static_build'
 
   - id: darwin-arm64
     main: ./main.go
@@ -28,7 +34,13 @@ builds:
     env:
       - CC=oa64-clang
       - CXX=oa64-clang++
-    ldflags: -s -w -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}'
+    ldflags: >
+      -s -w
+      -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}
+      -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .GITHUB_COMMIT_HASH }}'
+      -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .GITHUB_BUILT_AT }}'
+      -extldflags "-Wl,-z,stack-size=0x800000" "-static"
+      -tags 'osusergo netgo static_build'
 
   - id: linux-amd64
     main: ./main.go
@@ -40,9 +52,14 @@ builds:
     env:
       - CC=gcc
       - CXX=g++
-    ldflags:
-      # We need to build a static binary because we are building in a glibc based system and running in a musl container
-      -s -w -linkmode external -extldflags "-static" -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}'
+    # We need to build a static binary because we are building in a glibc based system and running in a musl container
+    ldflags: >
+      -s -w
+      -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}
+      -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .GITHUB_COMMIT_HASH }}'
+      -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .GITHUB_BUILT_AT }}'
+      -extldflags "-Wl,-z,stack-size=0x800000" "-static"
+      -tags 'osusergo netgo static_build'
 
   - id: linux-arm64
     main: ./main.go
@@ -54,9 +71,13 @@ builds:
     env:
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
-    ldflags:
-      # We need to build a static binary because we are building in a glibc based system and running in a musl container
-      -s -w -linkmode external -extldflags "-static" -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}'
+    ldflags: >
+      -s -w
+      -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}
+      -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .GITHUB_COMMIT_HASH }}'
+      -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .GITHUB_BUILT_AT }}'
+      -extldflags "-Wl,-z,stack-size=0x800000" "-static"
+      -tags 'osusergo netgo static_build'
 
 archives:
   - files:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,10 @@ builds:
       -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}
       -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .GITHUB_COMMIT_HASH }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .GITHUB_BUILT_AT }}'
-      -tags 'osusergo netgo static_build'
+    tags:
+      - osusergo
+      - netgo
+      - static_build
 
   - id: darwin-arm64
     main: ./main.go
@@ -38,7 +41,10 @@ builds:
       -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}
       -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .GITHUB_COMMIT_HASH }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .GITHUB_BUILT_AT }}'
-      -tags 'osusergo netgo static_build'
+    tags:
+      - osusergo
+      - netgo
+      - static_build
 
   - id: linux-amd64
     main: ./main.go
@@ -57,7 +63,10 @@ builds:
       -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .GITHUB_COMMIT_HASH }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .GITHUB_BUILT_AT }}'
       -extldflags "-Wl,-z,stack-size=0x800000" "-static"
-      -tags 'osusergo netgo static_build'
+    tags:
+      - osusergo
+      - netgo
+      - static_build
 
   - id: linux-arm64
     main: ./main.go
@@ -75,7 +84,10 @@ builds:
       -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .GITHUB_COMMIT_HASH }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .GITHUB_BUILT_AT }}'
       -extldflags "-Wl,-z,stack-size=0x800000" "-static"
-      -tags 'osusergo netgo static_build'
+    tags:
+      - osusergo
+      - netgo
+      - static_build
 
 archives:
   - files:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,7 +62,7 @@ builds:
       -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .Commit }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .Date }}'
-      -extldflags "-Wl,-z,stack-size=0x800000" "-static"
+      -extldflags '"-Wl,-z,stack-size=0x800000" "-static"'
     tags:
       - osusergo
       - netgo
@@ -83,7 +83,7 @@ builds:
       -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .Commit }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .Date }}'
-      -extldflags "-Wl,-z,stack-size=0x800000" "-static"
+      -extldflags '"-Wl,-z,stack-size=0x800000" "-static"'
     tags:
       - osusergo
       - netgo

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,9 +18,9 @@ builds:
       - CXX=o64-clang++
     ldflags: >
       -s -w
-      -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}
-      -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .GITHUB_COMMIT_HASH }}'
-      -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .GITHUB_BUILT_AT }}'
+      -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{.Version}}
+      -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .Commit }}'
+      -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .Date }}'
     tags:
       - osusergo
       - netgo
@@ -39,8 +39,8 @@ builds:
     ldflags: >
       -s -w
       -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}
-      -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .GITHUB_COMMIT_HASH }}'
-      -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .GITHUB_BUILT_AT }}'
+      -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .Commit }}'
+      -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .Date }}'
     tags:
       - osusergo
       - netgo
@@ -60,8 +60,8 @@ builds:
     ldflags: >
       -s -w
       -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}
-      -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .GITHUB_COMMIT_HASH }}'
-      -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .GITHUB_BUILT_AT }}'
+      -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .Commit }}'
+      -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .Date }}'
       -extldflags "-Wl,-z,stack-size=0x800000" "-static"
     tags:
       - osusergo
@@ -81,8 +81,8 @@ builds:
     ldflags: >
       -s -w
       -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}
-      -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .GITHUB_COMMIT_HASH }}'
-      -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .GITHUB_BUILT_AT }}'
+      -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .Commit }}'
+      -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .Date }}'
       -extldflags "-Wl,-z,stack-size=0x800000" "-static"
     tags:
       - osusergo

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,6 @@ builds:
       -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}
       -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .GITHUB_COMMIT_HASH }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .GITHUB_BUILT_AT }}'
-      -extldflags "-Wl,-z,stack-size=0x800000" "-static"
       -tags 'osusergo netgo static_build'
 
   - id: darwin-arm64
@@ -39,7 +38,6 @@ builds:
       -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}
       -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .GITHUB_COMMIT_HASH }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .GITHUB_BUILT_AT }}'
-      -extldflags "-Wl,-z,stack-size=0x800000" "-static"
       -tags 'osusergo netgo static_build'
 
   - id: linux-amd64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,7 +18,7 @@ builds:
       - CXX=o64-clang++
     ldflags: >
       -s -w
-      -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{.Version}}
+      -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{.Version}}'
       -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .Commit }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .Date }}'
     tags:
@@ -38,7 +38,7 @@ builds:
       - CXX=oa64-clang++
     ldflags: >
       -s -w
-      -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}
+      -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .Commit }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .Date }}'
     tags:
@@ -59,7 +59,7 @@ builds:
     # We need to build a static binary because we are building in a glibc based system and running in a musl container
     ldflags: >
       -s -w
-      -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}
+      -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .Commit }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .Date }}'
       -extldflags "-Wl,-z,stack-size=0x800000" "-static"
@@ -80,7 +80,7 @@ builds:
       - CXX=aarch64-linux-gnu-g++
     ldflags: >
       -s -w
-      -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}
+      -X 'github.com/dogechain-lab/dogechain/versioning.Version=v{{ .Version }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.Commit={{ .Commit }}'
       -X 'github.com/dogechain-lab/dogechain/versioning.BuildTime={{ .Date }}'
       -extldflags "-Wl,-z,stack-size=0x800000" "-static"

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN set -x \
     && apk add --update --no-cache \

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build:
 	go build -o dogechain -ldflags="\
 		-X 'github.com/dogechain-lab/dogechain/versioning.Version=$(LATEST_VERSION)'\
 		-X 'github.com/dogechain-lab/dogechain/versioning.Commit=$(COMMIT_HASH)'\
-		-X 'github.com/dogechain-lab/dogechain/versioning.BuildTime=$(DATE)' \
+		-X 'github.com/dogechain-lab/dogechain/versioning.BuildTime=$(DATE)' "\
 		-tags 'osusergo netgo static_build' \
 	main.go
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build:
 	$(eval LATEST_VERSION = $(shell git describe --tags --abbrev=0))
 	$(eval COMMIT_HASH = $(shell git rev-parse HEAD))
 	$(eval DATE = $(shell date -u +'%Y-%m-%dT%TZ'))
-	go build -a -o dogechain -ldflags="\
+	go build -o dogechain -ldflags="\
 		-X 'github.com/dogechain-lab/dogechain/versioning.Version=$(LATEST_VERSION)'\
 		-X 'github.com/dogechain-lab/dogechain/versioning.Commit=$(COMMIT_HASH)'\
 		-X 'github.com/dogechain-lab/dogechain/versioning.BuildTime=$(DATE)' \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+CGO_ENABLED ?= 0
 
 .PHONY: download-spec-tests
 download-spec-tests:
@@ -21,10 +22,12 @@ build:
 	$(eval LATEST_VERSION = $(shell git describe --tags --abbrev=0))
 	$(eval COMMIT_HASH = $(shell git rev-parse HEAD))
 	$(eval DATE = $(shell date -u +'%Y-%m-%dT%TZ'))
-	go build -o dogechain -ldflags="\
+	go build -a -o dogechain -ldflags="\
 		-X 'github.com/dogechain-lab/dogechain/versioning.Version=$(LATEST_VERSION)'\
 		-X 'github.com/dogechain-lab/dogechain/versioning.Commit=$(COMMIT_HASH)'\
-		-X 'github.com/dogechain-lab/dogechain/versioning.BuildTime=$(DATE)'" \
+		-X 'github.com/dogechain-lab/dogechain/versioning.BuildTime=$(DATE)' \
+		-extldflags '"-Wl,-z,stack-size=0x800000" "-static"' "\
+		-tags 'osusergo netgo static_build' \
 	main.go
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ build:
 		-X 'github.com/dogechain-lab/dogechain/versioning.Version=$(LATEST_VERSION)'\
 		-X 'github.com/dogechain-lab/dogechain/versioning.Commit=$(COMMIT_HASH)'\
 		-X 'github.com/dogechain-lab/dogechain/versioning.BuildTime=$(DATE)' \
-		-extldflags '"-Wl,-z,stack-size=0x800000" "-static"' "\
 		-tags 'osusergo netgo static_build' \
 	main.go
 


### PR DESCRIPTION
# Description

Release build missing commit hash information, binaries are not statically linked, this will cause problems on different distributions (glibc compatibility), this PR updates the build command, and increases the default stack size to reduce GC pressure

build config add commit hash info, disable cgo and upgrade docker image to alpine linux 3.17 (alpine linux 3.14 EOL on 2023-05-01)

# Changes include

- [x] New feature (non-breaking change that adds functionality)

