### PR TITLE
Fix validator build block when syncing

### DIFF
--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -542,11 +542,10 @@ func (i *Ibft) startConsensus() {
 			)
 		}
 
-		// validator must not be in syncing mode
-		isValidator = !i.syncer.IsSyncing() && i.isValidSnapshot()
+		isValidator = i.isValidSnapshot()
 
-		if isValidator {
-			// i.startNewSequence()
+		// validator must not be in syncing mode to start a new block
+		if isValidator && !i.syncer.IsSyncing() {
 			sequenceCh = i.runSequence(pending)
 		}
 

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -542,7 +542,8 @@ func (i *Ibft) startConsensus() {
 			)
 		}
 
-		isValidator = i.isValidSnapshot()
+		// validator must not be in syncing mode
+		isValidator = !i.syncer.IsSyncing() && i.isValidSnapshot()
 
 		if isValidator {
 			// i.startNewSequence()

--- a/protocol/interface.go
+++ b/protocol/interface.go
@@ -21,6 +21,8 @@ type Syncer interface {
 	GetSyncProgression() *progress.Progression
 	// HasSyncPeer returns whether syncer has the peer syncer can sync with
 	HasSyncPeer() bool
+	// IsSyncing returns whether syncer is syncing
+	IsSyncing() bool
 	// Sync starts routine to sync blocks
 	Sync(func(*types.Block) bool) error
 }

--- a/protocol/syncer_test.go
+++ b/protocol/syncer_test.go
@@ -212,7 +212,7 @@ func Test_startPeerStatusUpdateProcess(t *testing.T) {
 		&mockProgression{},
 	)
 
-	syncer.setSyncing(true) // to skip channel blocking
+	syncer.startSyncingStatus() // to skip channel blocking
 
 	go syncer.Sync(nil)
 


### PR DESCRIPTION
# Description

Validator nodes build blocks during sync, which makes it slow to sync and full of error logs.
This PR fixes it to only start building blocks when syncing is done.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

1. start up a 4-validators network.
2. stop a validator for about 2-3 minutes.
3. restart the stopped validator and check its logs.

On current branch, validator will print out "sequence started" only when it catch up to the latest height.
On the target branch, validator will print out "sequence started" every time a new block arrives, and try to build an outdated block every turn.