### PR TITLE
[txpool] fix channel close

### DIFF
--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -174,6 +174,7 @@ type TxPool struct {
 
 	// shutdown channel
 	shutdownCh chan struct{}
+	shutdownWg sync.WaitGroup
 
 	// flag indicating if the current node is a sealer,
 	// and should therefore gossip transactions
@@ -356,10 +357,14 @@ func (p *TxPool) Close() {
 	}
 
 	p.logger.Info("txpool close all channels")
+	// signal all goroutines to exit
+	close(p.shutdownCh)
+	// wait for all goroutines to exit
+	p.shutdownWg.Wait()
+
 	// close all channels
 	close(p.enqueueReqCh)
 	close(p.promoteReqCh)
-	close(p.shutdownCh)
 }
 
 // SetSigner sets the signer the pool will use
@@ -761,6 +766,9 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 // If, afterwards, the account is eligible for promotion,
 // a promoteRequest is signaled.
 func (p *TxPool) handleEnqueueRequest(req enqueueRequest) {
+	p.shutdownWg.Add(1)
+	defer p.shutdownWg.Done()
+
 	tx := req.tx
 	addr := req.tx.From
 
@@ -816,6 +824,9 @@ func (p *TxPool) handleEnqueueRequest(req enqueueRequest) {
 // of some account from enqueued to promoted. Can only be
 // invoked by handleEnqueueRequest or resetAccount.
 func (p *TxPool) handlePromoteRequest(req promoteRequest) {
+	p.shutdownWg.Add(1)
+	defer p.shutdownWg.Done()
+
 	addr := req.account
 	account := p.accounts.get(addr)
 
@@ -845,6 +856,9 @@ func (p *TxPool) handlePromoteRequest(req promoteRequest) {
 // pruneStaleAccounts would find out all need-to-prune transactions,
 // remove them from txpool.
 func (p *TxPool) pruneStaleAccounts() {
+	p.shutdownWg.Add(1)
+	defer p.shutdownWg.Done()
+
 	pruned := p.accounts.pruneStaleEnqueuedTxs(p.promoteOutdateDuration)
 	if len(pruned) == 0 {
 		return


### PR DESCRIPTION
# Description

issue: txpool shutdown signal never wait goroutines exit

```
panic: send on closed channel

goroutine 15803 [running]:
github.com/dogechain-lab/dogechain/txpool.(*TxPool).handleEnqueueRequest(0xc00015a840, {0x0})
	/home/runner/work/dogechain/dogechain/txpool/txpool.go:812 +0x5b2
created by github.com/dogechain-lab/dogechain/txpool.(*TxPool).Start.func1
	/home/runner/work/dogechain/dogechain/txpool/txpool.go:319 +0x305
FAIL	github.com/dogechain-lab/dogechain/txpool	3.866s
?   	github.com/dogechain-lab/dogechain/txpool/proto	[no test files]
```



# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels

## Testing

- [x] I have tested this code with the official test suite
