### PR TITLE
WIP: [ibft] Fix validator panic due to repeat notification in syncing

### DIFF
--- a/consensus/ibft/consensus.go
+++ b/consensus/ibft/consensus.go
@@ -12,21 +12,19 @@ import (
 	"github.com/dogechain-lab/dogechain/types"
 )
 
-func (i *Ibft) runSequenceAtHeight(ctx context.Context, cancel context.CancelFunc, height uint64) {
+func (i *Ibft) runSequenceAtHeight(ctx context.Context, height uint64) {
+	// Set the starting state data
+	i.setState(currentstate.AcceptState)
+	i.logger.Info("sequence started", "height", height)
+
 	defer func() {
-		// Set the starting state data
+		// clear up
 		i.state.Clear(height)
 		i.msgQueue.PruneByHeight(height)
 		i.alreadyInCycle.CompareAndSwap(true, false)
 
-		i.logger.Info("clear sequence state and jump out cycle", "height", height)
-
-		// work done or cancel by other event, thread safe to call multiple times.
-		cancel()
+		i.logger.Info("clear state", "height", height)
 	}()
-
-	i.logger.Info("sequence started", "height", height)
-	defer i.logger.Info("sequence done", "height", height)
 
 	for {
 		select {

--- a/consensus/ibft/consensus.go
+++ b/consensus/ibft/consensus.go
@@ -117,7 +117,7 @@ func (i *Ibft) runAcceptState(ctx context.Context) (shouldStop bool) { // start 
 	number := parent.Number + 1
 
 	if number != i.state.Sequence() {
-		logger.Error("sequence not correct", "parent", parent.Number, "sequence", i.state.Sequence())
+		logger.Error("consensus sequence not correct when prepare", "parent", parent.Number, "sequence", i.state.Sequence())
 		time.Sleep(1 * time.Second)
 
 		return
@@ -252,7 +252,7 @@ func (i *Ibft) runAcceptState(ctx context.Context) (shouldStop bool) { // start 
 
 		// Make sure the proposing block height match the current sequence
 		if block.Number() != i.state.Sequence() {
-			logger.Error("sequence not correct", "block", block.Number, "sequence", i.state.Sequence())
+			logger.Error("consensu sequence not correct when accepting", "block", block.Number, "sequence", i.state.Sequence())
 			i.handleStateErr(errIncorrectBlockHeight)
 
 			return

--- a/consensus/ibft/consensus.go
+++ b/consensus/ibft/consensus.go
@@ -14,6 +14,7 @@ import (
 
 func (i *Ibft) runSequenceAtHeight(ctx context.Context, height uint64) {
 	// Set the starting state data
+	i.startNewSequence()
 	i.setState(currentstate.AcceptState)
 	i.logger.Info("sequence started", "height", height)
 

--- a/consensus/ibft/currentstate/state.go
+++ b/consensus/ibft/currentstate/state.go
@@ -111,16 +111,12 @@ func (c *CurrentState) Clear(height uint64) {
 
 // GetState returns the current state
 func (c *CurrentState) GetState() IbftState {
-	stateAddr := &c.state
-
-	return IbftState(atomic.LoadUint64(stateAddr))
+	return IbftState(atomic.LoadUint64(&c.state))
 }
 
 // SetState sets the current state
 func (c *CurrentState) SetState(s IbftState) {
-	stateAddr := &c.state
-
-	atomic.StoreUint64(stateAddr, uint64(s))
+	atomic.StoreUint64(&c.state, uint64(s))
 }
 
 func (c *CurrentState) SetBlock(b *types.Block) {

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -509,15 +509,18 @@ func (i *Ibft) startConsensus() {
 				continue
 			}
 
-			if ev.Source == protocol.WriteBlockSource {
-				if ev.NewChain[0].Number < i.blockchain.Header().Number {
-					// The blockchain notification system can eventually deliver
-					// stale block notifications. These should be ignored
-					continue
-				}
-
-				syncerBlockCh <- struct{}{}
+			// would only accept write block event from syncer
+			if ev.Source != protocol.WriteBlockSource {
+				continue
 			}
+
+			if ev.NewChain[0].Number < i.blockchain.Header().Number {
+				// The blockchain notification system can eventually deliver
+				// stale block notifications. These should be ignored
+				continue
+			}
+
+			syncerBlockCh <- struct{}{}
 		}
 	}()
 

--- a/consensus/ibft/snapshot.go
+++ b/consensus/ibft/snapshot.go
@@ -486,8 +486,10 @@ func (s *snapshotStore) replace(snap *Snapshot) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	for i, sn := range s.list {
-		if sn.Number == snap.Number {
+	// reverse for faster searching
+	listlen := len(s.list)
+	for i := listlen - 1; i >= listlen; i-- {
+		if s.list[i].Number == snap.Number {
 			s.list[i] = snap
 
 			return

--- a/e2e/framework/config.go
+++ b/e2e/framework/config.go
@@ -54,6 +54,7 @@ type TestServerConfig struct {
 	IsWSEnable        bool                 // enable websocket or not
 	RestoreFile       string               // blockchain restore file
 	BlockTime         uint64               // minimum block generation time (in s)
+	ChainID           uint64               // chainid for seperating parallel e2e test cases
 }
 
 // DataDir returns path of data directory server uses
@@ -190,4 +191,8 @@ func (t *TestServerConfig) SetRestoreFile(path string) {
 
 func (t *TestServerConfig) SetBlockTime(blockTime uint64) {
 	t.BlockTime = blockTime
+}
+
+func (t *TestServerConfig) SetChainID(chainID uint64) {
+	t.ChainID = chainID
 }

--- a/e2e/framework/testserver.go
+++ b/e2e/framework/testserver.go
@@ -261,6 +261,11 @@ func (t *TestServer) GenerateGenesis() error {
 		genesisCmd.Use,
 	}
 
+	// chain id
+	if t.Config.ChainID > 0 {
+		args = append(args, "--chain-id", strconv.FormatUint(t.Config.ChainID, 10))
+	}
+
 	// add pre-mined accounts
 	for _, acct := range t.Config.PremineAccts {
 		args = append(args, "--premine", acct.Addr.String()+":0x"+acct.Balance.Text(16))

--- a/protocol/client.go
+++ b/protocol/client.go
@@ -295,9 +295,6 @@ func (client *syncPeerClient) GetBlocks(
 		return nil, fmt.Errorf("failed to create sync peer client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, defaultTimeoutForStatus)
-	defer cancel()
-
 	rsp, err := clt.GetBlocks(ctx, &proto.GetBlocksRequest{
 		From: from,
 		To:   to,

--- a/protocol/service.go
+++ b/protocol/service.go
@@ -3,7 +3,6 @@ package protocol
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/dogechain-lab/dogechain/network"
 	"github.com/dogechain-lab/dogechain/network/grpc"
@@ -259,43 +258,4 @@ func (s *syncPeerService) GetHeaders(_ context.Context, req *proto.GetHeadersReq
 	}
 
 	return resp, nil
-}
-
-// Helper functions to decode responses from the grpc layer
-func getBodies(ctx context.Context, clt proto.V1Client, hashes []types.Hash) ([]*types.Body, error) {
-	input := make([]string, 0, len(hashes))
-
-	for _, h := range hashes {
-		input = append(input, h.String())
-	}
-
-	resp, err := clt.GetObjectsByHash(
-		ctx,
-		&proto.HashRequest{
-			Hash: input,
-			Type: proto.HashRequest_BODIES,
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	res := make([]*types.Body, 0, len(resp.Objs))
-
-	for _, obj := range resp.Objs {
-		var body types.Body
-		if obj.Spec.Value != nil {
-			if err := body.UnmarshalRLP(obj.Spec.Value); err != nil {
-				return nil, err
-			}
-		}
-
-		res = append(res, &body)
-	}
-
-	if len(res) != len(input) {
-		return nil, fmt.Errorf("not correct size")
-	}
-
-	return res, nil
 }

--- a/protocol/syncer.go
+++ b/protocol/syncer.go
@@ -529,7 +529,11 @@ func (s *noForkSyncer) bulkSyncWithPeer(
 	return result, nil
 }
 
-func (s *noForkSyncer) getBlocksFromBestPeer(p *NoForkPeer, from, to uint64, result *bulkSyncResult) ([]*types.Block, error) {
+func (s *noForkSyncer) getBlocksFromBestPeer(
+	p *NoForkPeer,
+	from, to uint64,
+	result *bulkSyncResult,
+) ([]*types.Block, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), _blockSyncTimeout)
 	defer cancel()
 


### PR DESCRIPTION
# Description

The validators will panic after syncing a bulk of blocks, due to incorrectly implementation of IBFT consensus context handling.
The consensus routine will be triggered multiple times even it is not thread-safe, and occasionally, the built block is clear before gossip it, then the server panic with nil object access.
The PR:
* Uses an atomic value to disable reentrant before last routine stopped.
  * To prevent reentrant, which will crash all states.
* Update validator set only when notified new block.
  * It is a better triggered point because it will never meet sequence problem before join in IBFT consensus cycle.

# Changes include

- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)

## Testing

- [x] I have tested this code with the official test suite
