### PR TITLE
[network] grpc client passing timeout context

### DIFF
--- a/network/client/identity.go
+++ b/network/client/identity.go
@@ -22,10 +22,36 @@ type identityClient struct {
 	conn *rawGrpc.ClientConn
 
 	isClosed *atomic.Bool
+
+	metrics Metrics
 }
 
+const (
+	/**
+	from grpc.UnaryServerInfo
+
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/v1.Identity/Hello",
+	}
+	**/
+	methodNameHello = "/v1.Identity/Hello"
+)
+
 func (i *identityClient) Hello(ctx context.Context, in *proto.Status) (*proto.Status, error) {
-	return i.clt.Hello(ctx, in, rawGrpc.WaitForReady(false))
+	i.metrics.rpcMethodCallCountInc(methodNameHello)
+
+	begin := i.metrics.rpcMethodCallBegin(methodNameHello)
+	defer i.metrics.rpcMethodCallEnd(methodNameHello, begin)
+
+	status, err := i.clt.Hello(ctx, in, rawGrpc.WaitForReady(false))
+	if err != nil {
+		i.metrics.rpcMethodCallErrorCountInc(methodNameHello)
+
+		return nil, err
+	}
+
+	return status, nil
 }
 
 func (i *identityClient) Close() error {
@@ -42,6 +68,7 @@ func (i *identityClient) IsClose() bool {
 
 func NewIdentityClient(
 	logger hclog.Logger,
+	metrics Metrics,
 	clt proto.IdentityClient,
 	conn *rawGrpc.ClientConn,
 ) IdentityClient {
@@ -49,6 +76,7 @@ func NewIdentityClient(
 		clt:      clt,
 		conn:     conn,
 		isClosed: atomic.NewBool(false),
+		metrics:  metrics,
 	}
 
 	// print a error log if the client is not closed before GC

--- a/network/client/metrics.go
+++ b/network/client/metrics.go
@@ -1,0 +1,96 @@
+package client
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type methodName string
+
+// Metrics represents the grpc client metrics
+type Metrics interface {
+	// rpcMethodCallBegin is the duration of a grpc client call
+	rpcMethodCallBegin(method methodName) time.Time
+
+	// rpcMethodCallEnd is the duration of a grpc client call
+	rpcMethodCallEnd(method methodName, begin time.Time)
+
+	// GrpcClientCallCount is the count of a grpc client call
+	rpcMethodCallCountInc(method methodName)
+
+	// GrpcClientCallErrorCount is the count of a grpc client call error
+	rpcMethodCallErrorCountInc(method methodName)
+}
+
+type metrics struct {
+	// GrpcClientCallDurations is the duration of a grpc client call
+	rpcMethodCallDurationVec *prometheus.HistogramVec
+
+	// GrpcClientCallCount is the count of a grpc client call
+	rpcMethodCallCount *prometheus.CounterVec
+
+	// GrpcClientCallErrorCount is the count of a grpc client call error
+	rpcMethodCallErrorCount *prometheus.CounterVec
+}
+
+func NewMetrics() Metrics {
+	m := &metrics{
+		rpcMethodCallDurationVec: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "grpc_client_call_durations_seconds",
+				Help:    "The grpc client call latencies in seconds.",
+				Buckets: prometheus.ExponentialBuckets(0.0001, 2, 10),
+			},
+			[]string{"method"},
+		),
+		rpcMethodCallCount: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "grpc_client_call_count",
+				Help: "The grpc client call count.",
+			},
+			[]string{"method"},
+		),
+		rpcMethodCallErrorCount: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "grpc_client_call_error_count",
+				Help: "The grpc client call error count.",
+			},
+			[]string{"method"},
+		),
+	}
+
+	prometheus.MustRegister(
+		m.rpcMethodCallDurationVec,
+		m.rpcMethodCallCount,
+		m.rpcMethodCallErrorCount,
+	)
+
+	return m
+}
+
+func (m *metrics) rpcMethodCallBegin(method methodName) time.Time {
+	return time.Now()
+}
+
+func (m *metrics) rpcMethodCallEnd(method methodName, begin time.Time) {
+	if m.rpcMethodCallDurationVec != nil {
+		m.rpcMethodCallDurationVec.WithLabelValues(string(method)).Observe(time.Since(begin).Seconds())
+	}
+}
+
+func (m *metrics) rpcMethodCallCountInc(method methodName) {
+	if m.rpcMethodCallCount != nil {
+		m.rpcMethodCallCount.WithLabelValues(string(method)).Inc()
+	}
+}
+
+func (m *metrics) rpcMethodCallErrorCountInc(method methodName) {
+	if m.rpcMethodCallErrorCount != nil {
+		m.rpcMethodCallErrorCount.WithLabelValues(string(method)).Inc()
+	}
+}
+
+func NilMetrics() Metrics {
+	return &metrics{}
+}

--- a/network/client/syncerV1.go
+++ b/network/client/syncerV1.go
@@ -29,30 +29,114 @@ type syncerV1Client struct {
 	conn *rawGrpc.ClientConn
 
 	isClosed *atomic.Bool
+
+	metrics Metrics
 }
 
-func (i *syncerV1Client) GetCurrent(ctx context.Context, in *emptypb.Empty) (*proto.V1Status, error) {
-	return i.clt.GetCurrent(ctx, in, rawGrpc.WaitForReady(false))
+const (
+	/**
+	from grpc.UnaryServerInfo
+
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/v1.Syncer/GetCurrent",
+	}
+	**/
+
+	methodNameGetCurrent       = "/v1.Syncer/GetCurrent"
+	methodNameGetObjectsByHash = "/v1.Syncer/GetObjectsByHash"
+	methodNameGetHeaders       = "/v1.Syncer/GetHeaders"
+	methodNameNotify           = "/v1.Syncer/Notify"
+	methodNameGetBlocks        = "/v1.Syncer/GetBlocks"
+	methodNameGetStatus        = "/v1.Syncer/GetStatus"
+)
+
+func (i *syncerV1Client) wrapMetricsCall(name methodName, call func() error) {
+	i.metrics.rpcMethodCallCountInc(name)
+
+	begin := i.metrics.rpcMethodCallBegin(name)
+	defer i.metrics.rpcMethodCallEnd(name, begin)
+
+	err := call()
+	if err != nil {
+		i.metrics.rpcMethodCallErrorCountInc(name)
+	}
 }
 
-func (i *syncerV1Client) GetObjectsByHash(ctx context.Context, in *proto.HashRequest) (*proto.Response, error) {
-	return i.clt.GetObjectsByHash(ctx, in, rawGrpc.WaitForReady(false))
+func (i *syncerV1Client) GetCurrent(
+	ctx context.Context,
+	in *emptypb.Empty,
+) (status *proto.V1Status, err error) {
+	i.wrapMetricsCall(methodNameGetCurrent, func() error {
+		status, err = i.clt.GetCurrent(ctx, in, rawGrpc.WaitForReady(false))
+
+		return err
+	})
+
+	return status, err
 }
 
-func (i *syncerV1Client) GetHeaders(ctx context.Context, in *proto.GetHeadersRequest) (*proto.Response, error) {
-	return i.clt.GetHeaders(ctx, in, rawGrpc.WaitForReady(false))
+func (i *syncerV1Client) GetObjectsByHash(
+	ctx context.Context,
+	in *proto.HashRequest,
+) (response *proto.Response, err error) {
+	i.wrapMetricsCall(methodNameGetObjectsByHash, func() error {
+		response, err = i.clt.GetObjectsByHash(
+			ctx,
+			in,
+			rawGrpc.WaitForReady(false),
+		)
+
+		return err
+	})
+
+	return response, err
 }
 
-func (i *syncerV1Client) Notify(ctx context.Context, in *proto.NotifyReq) (*emptypb.Empty, error) {
-	return i.clt.Notify(ctx, in, rawGrpc.WaitForReady(false))
+func (i *syncerV1Client) GetHeaders(
+	ctx context.Context,
+	in *proto.GetHeadersRequest,
+) (response *proto.Response, err error) {
+	i.wrapMetricsCall(methodNameGetHeaders, func() error {
+		response, err = i.clt.GetHeaders(ctx, in, rawGrpc.WaitForReady(false))
+
+		return err
+	})
+
+	return response, err
 }
 
-func (i *syncerV1Client) GetBlocks(ctx context.Context, in *proto.GetBlocksRequest) (*proto.GetBlocksResponse, error) {
-	return i.clt.GetBlocks(ctx, in, rawGrpc.WaitForReady(false))
+func (i *syncerV1Client) Notify(ctx context.Context, in *proto.NotifyReq) (response *emptypb.Empty, err error) {
+	i.wrapMetricsCall(methodNameNotify, func() error {
+		response, err = i.clt.Notify(ctx, in, rawGrpc.WaitForReady(false))
+
+		return err
+	})
+
+	return response, err
 }
 
-func (i *syncerV1Client) GetStatus(ctx context.Context, in *emptypb.Empty) (*proto.SyncPeerStatus, error) {
-	return i.clt.GetStatus(ctx, in, rawGrpc.WaitForReady(false))
+func (i *syncerV1Client) GetBlocks(
+	ctx context.Context,
+	in *proto.GetBlocksRequest,
+) (response *proto.GetBlocksResponse, err error) {
+	i.wrapMetricsCall(methodNameGetBlocks, func() error {
+		response, err = i.clt.GetBlocks(ctx, in, rawGrpc.WaitForReady(false))
+
+		return err
+	})
+
+	return response, err
+}
+
+func (i *syncerV1Client) GetStatus(ctx context.Context, in *emptypb.Empty) (response *proto.SyncPeerStatus, err error) {
+	i.wrapMetricsCall(methodNameGetStatus, func() error {
+		response, err = i.clt.GetStatus(ctx, in, rawGrpc.WaitForReady(false))
+
+		return err
+	})
+
+	return response, err
 }
 
 func (i *syncerV1Client) Close() error {
@@ -69,6 +153,7 @@ func (i *syncerV1Client) IsClose() bool {
 
 func NewSyncerV1Client(
 	logger hclog.Logger,
+	metrics Metrics,
 	clt proto.V1Client,
 	conn *rawGrpc.ClientConn,
 ) SyncerV1Client {
@@ -76,6 +161,7 @@ func NewSyncerV1Client(
 		clt:      clt,
 		conn:     conn,
 		isClosed: atomic.NewBool(false),
+		metrics:  metrics,
 	}
 
 	// print a error log if the client is not closed before GC

--- a/network/discovery/discovery.go
+++ b/network/discovery/discovery.go
@@ -49,7 +49,7 @@ type networkingServer interface {
 	// PROTOCOL MANIPULATION //
 
 	// NewDiscoveryClient returns a discovery gRPC client connection
-	NewDiscoveryClient(peerID peer.ID) (client.DiscoveryClient, error)
+	NewDiscoveryClient(ctx context.Context, peerID peer.ID) (client.DiscoveryClient, error)
 
 	// PEER MANIPULATION //
 
@@ -400,10 +400,12 @@ func (d *DiscoveryService) findPeersCall(
 	ctx, cancel := context.WithTimeout(d.ctx, maxDiscoveryPeerReqTimeout)
 	defer cancel()
 
-	clt, clientErr := d.baseServer.NewDiscoveryClient(peerID)
+	clt, clientErr := d.baseServer.NewDiscoveryClient(ctx, peerID)
 	if clientErr != nil {
 		return nil, clientErr
 	}
+
+	defer clt.Close()
 
 	resp, err := clt.FindPeers(
 		ctx,

--- a/network/discovery/discovery_test.go
+++ b/network/discovery/discovery_test.go
@@ -249,7 +249,7 @@ func TestDiscoveryService_RegularPeerDiscoveryUnconnected(t *testing.T) {
 			})
 
 			// Define the new discovery client creation
-			server.HookNewDiscoveryClient(func(id peer.ID) (client.DiscoveryClient, error) {
+			server.HookNewDiscoveryClient(func(ctx context.Context, id peer.ID) (client.DiscoveryClient, error) {
 				return nil, errors.New("peer is not connected anymore")
 			})
 

--- a/network/grpc/grpc.go
+++ b/network/grpc/grpc.go
@@ -79,7 +79,7 @@ func interceptor(
 	)
 }
 
-func (g *GrpcStream) Client(ctx context.Context, stream network.Stream) *grpc.ClientConn {
+func (g *GrpcStream) Client(ctx context.Context, stream network.Stream) (*grpc.ClientConn, error) {
 	return WrapClient(ctx, stream)
 }
 
@@ -131,7 +131,7 @@ func (g *GrpcStream) Close() error {
 
 // --- conn ---
 
-func WrapClient(ctx context.Context, s network.Stream) *grpc.ClientConn {
+func WrapClient(ctx context.Context, s network.Stream) (*grpc.ClientConn, error) {
 	opts := grpc.WithContextDialer(func(ctx context.Context, peerIdStr string) (net.Conn, error) {
 		return &streamConn{s}, nil
 	})
@@ -148,11 +148,10 @@ func WrapClient(ctx context.Context, s network.Stream) *grpc.ClientConn {
 		opts)
 
 	if err != nil {
-		// TODO: this should not fail at all
-		panic(err)
+		return nil, err
 	}
 
-	return conn
+	return conn, nil
 }
 
 // streamConn represents a net.Conn wrapped to be compatible with net.conn

--- a/network/interface.go
+++ b/network/interface.go
@@ -3,7 +3,6 @@ package network
 import (
 	"context"
 
-	"github.com/dogechain-lab/dogechain/network/client"
 	"github.com/dogechain-lab/dogechain/network/event"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -48,12 +47,11 @@ type Network interface {
 	GetProtocols(peerID peer.ID) ([]string, error)
 	// NewProtoConnection opens up a new client connect on the set protocol to the peer,
 	// and returns a reference to the connection
-	NewProtoConnection(protocol string, peerID peer.ID) (*rawGrpc.ClientConn, error)
-	// GetProtoClient returns an active protocol client if present, otherwise
-	// it returns nil
-	GetProtoClient(protocol string, peerID peer.ID) client.GrpcClientCloser
-	// SaveProtoClient saves protocol client
-	SaveProtoClient(protocol string, stream client.GrpcClientCloser, peerID peer.ID)
+	NewProtoConnection(ctx context.Context, protocol string, peerID peer.ID) (*rawGrpc.ClientConn, error)
+
+	// **Metrics**
+	// GetMetrics returns the metrics of the network
+	GetMetrics() *Metrics
 }
 
 type Protocol interface {

--- a/network/interface.go
+++ b/network/interface.go
@@ -55,7 +55,7 @@ type Network interface {
 }
 
 type Protocol interface {
-	Client(context.Context, network.Stream) *rawGrpc.ClientConn
+	Client(context.Context, network.Stream) (*rawGrpc.ClientConn, error)
 	Handler() func(network.Stream)
 }
 

--- a/network/server.go
+++ b/network/server.go
@@ -821,8 +821,14 @@ func (s *DefaultServer) NewProtoConnection(
 
 	s.logger.Debug("create grpc client", "protocol", protocol, "peer", peerID)
 
-	// don't need context.WithTimeout, rpc client is fake
-	return p.Client(ctx, stream), nil
+	clt, err := p.Client(ctx, stream)
+	if err != nil {
+		s.logger.Error("create grpc client failed", "protocol", protocol, "peer", peerID, "err", err)
+
+		return nil, err
+	}
+
+	return clt, nil
 }
 
 func (s *DefaultServer) GetMetrics() *Metrics {

--- a/network/server.go
+++ b/network/server.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/dogechain-lab/dogechain/helper/telemetry"
-	"github.com/dogechain-lab/dogechain/network/client"
 	"github.com/dogechain-lab/dogechain/network/common"
 	"github.com/dogechain-lab/dogechain/network/dial"
 	"github.com/dogechain-lab/dogechain/network/discovery"
@@ -660,19 +659,6 @@ func (s *DefaultServer) removePeerConnect(ctx context.Context, peerID peer.ID, d
 		// No more connections to the peer, remove it from the peers map
 		delete(s.peers, peerID)
 
-		if errs := connectionInfo.cleanProtocolStreams(span.Context(), s.tracer); len(errs) > 0 {
-			for _, err := range errs {
-				if err != nil {
-					s.logger.Error("close protocol streams failed", "err", err)
-				}
-			}
-		}
-
-		span.AddEvent("remove_peer_store", map[string]interface{}{
-			"peer":      peerID.String(),
-			"dorection": direction.String(),
-		})
-
 		// NOTO: Remove the peer from the peer store,
 		// if not removed, host.Network().Notify never triggered
 		s.RemoveFromPeerStore(peerID)
@@ -737,6 +723,7 @@ var (
 	// Github action runners are very slow, so we need to increase the timeout
 	DefaultJoinTimeout   = 100 * time.Second
 	DefaultBufferTimeout = DefaultJoinTimeout + time.Second*30
+	MaxConnectionTimeout = 5 * time.Minute
 )
 
 // JoinPeer attempts to add a new peer to the networking server
@@ -800,35 +787,13 @@ func (s *DefaultServer) Close() error {
 	return s.host.Close()
 }
 
-// SaveProtoClient saves the protocol client to the peer
-// protocol stream reference [Thread safe]
-func (s *DefaultServer) SaveProtoClient(
-	protocol string,
-	stream client.GrpcClientCloser,
-	peerID peer.ID,
-) {
-	s.peersLock.Lock()
-	defer s.peersLock.Unlock()
-
-	connectionInfo, ok := s.peers[peerID]
-	if !ok {
-		s.logger.Error(
-			fmt.Sprintf(
-				"Attempted to save protocol %s stream for non-existing peer %s",
-				protocol,
-				peerID,
-			),
-		)
-
-		return
-	}
-
-	connectionInfo.addProtocolClient(protocol, stream)
-}
-
 // NewProtoConnection opens up a new stream on the set protocol to the peer,
 // and returns a reference to the connection
-func (s *DefaultServer) NewProtoConnection(protocol string, peerID peer.ID) (*rawGrpc.ClientConn, error) {
+func (s *DefaultServer) NewProtoConnection(
+	ctx context.Context,
+	protocol string,
+	peerID peer.ID,
+) (*rawGrpc.ClientConn, error) {
 	s.protocolsLock.RLock()
 	defer s.protocolsLock.RUnlock()
 
@@ -841,37 +806,35 @@ func (s *DefaultServer) NewProtoConnection(protocol string, peerID peer.ID) (*ra
 
 	s.logger.Debug("create new libp2p stream", "protocol", protocol, "peer", peerID)
 
-	stream, err := s.NewStream(protocol, peerID)
+	beginTime := time.Now()
+
+	s.metrics.NewProtoConnectionCountInc()
+
+	stream, err := s.NewStream(ctx, protocol, peerID)
 	if err != nil {
+		s.metrics.NewProtoConnectionErrorCountInc()
+
 		return nil, err
 	}
+
+	s.metrics.NewProtoConnectionSecondObserve(time.Since(beginTime).Seconds())
 
 	s.logger.Debug("create grpc client", "protocol", protocol, "peer", peerID)
 
 	// don't need context.WithTimeout, rpc client is fake
-	return p.Client(context.Background(), stream), nil
+	return p.Client(ctx, stream), nil
 }
 
-func (s *DefaultServer) NewStream(proto string, id peer.ID) (network.Stream, error) {
+func (s *DefaultServer) GetMetrics() *Metrics {
+	return s.metrics
+}
+
+func (s *DefaultServer) NewStream(ctx context.Context, proto string, id peer.ID) (network.Stream, error) {
 	// by default NewStream will dial if not connected
 	// this bypasses connection control
-	ctx := network.WithNoDial(context.Background(), "grpc client stream")
+	streamCtx := network.WithNoDial(ctx, "grpc client stream")
 
-	return s.host.NewStream(ctx, id, protocol.ID(proto))
-}
-
-// GetProtoClient returns an active protocol client if present, otherwise
-// it returns nil
-func (s *DefaultServer) GetProtoClient(protocol string, peerID peer.ID) client.GrpcClientCloser {
-	s.peersLock.Lock()
-	defer s.peersLock.Unlock()
-
-	connectionInfo, ok := s.peers[peerID]
-	if !ok {
-		return nil
-	}
-
-	return connectionInfo.getProtocolClient(protocol)
+	return s.host.NewStream(streamCtx, id, protocol.ID(proto))
 }
 
 func (s *DefaultServer) RegisterProtocol(id string, p Protocol) {

--- a/network/server_discovery.go
+++ b/network/server_discovery.go
@@ -45,17 +45,10 @@ func (s *DefaultServer) GetRandomBootnode() *peer.AddrInfo {
 }
 
 // NewDiscoveryClient returns a new or existing discovery service client connection
-func (s *DefaultServer) NewDiscoveryClient(peerID peer.ID) (client.DiscoveryClient, error) {
-	// Check if there is an active stream connection already
-	if protoStream := s.GetProtoClient(common.DiscProto, peerID); protoStream != nil {
-		if discoveryClt, ok := protoStream.(client.DiscoveryClient); ok {
-			return discoveryClt, nil
-		}
-	}
-
+func (s *DefaultServer) NewDiscoveryClient(ctx context.Context, peerID peer.ID) (client.DiscoveryClient, error) {
 	// Create a new stream connection and save, only single object
 	// close and clear only when the peer is disconnected
-	protoStream, err := s.NewProtoConnection(common.DiscProto, peerID)
+	protoStream, err := s.NewProtoConnection(ctx, common.DiscProto, peerID)
 	if err != nil {
 		return nil, err
 	}
@@ -63,10 +56,10 @@ func (s *DefaultServer) NewDiscoveryClient(peerID peer.ID) (client.DiscoveryClie
 	// Save the stream connection
 	clt := client.NewDiscoveryClient(
 		s.logger,
+		s.metrics.GetGrpcMetrics(),
 		proto.NewDiscoveryClient(protoStream),
 		protoStream,
 	)
-	s.SaveProtoClient(common.DiscProto, clt, peerID)
 
 	return clt, nil
 }

--- a/network/server_nonnetwork.go
+++ b/network/server_nonnetwork.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/dogechain-lab/dogechain/network/client"
 	"github.com/dogechain-lab/dogechain/network/event"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -70,15 +69,16 @@ func (s *NonetworkServer) NewTopic(protoID string, obj proto.Message) (Topic, er
 
 func (s *NonetworkServer) RegisterProtocol(string, Protocol) {}
 
-func (s *NonetworkServer) NewProtoConnection(protocol string, peerID peer.ID) (*rawGrpc.ClientConn, error) {
+func (s *NonetworkServer) NewProtoConnection(
+	ctx context.Context,
+	protocol string,
+	peerID peer.ID,
+) (*rawGrpc.ClientConn, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (s *NonetworkServer) GetProtoClient(protocol string, peerID peer.ID) client.GrpcClientCloser {
-	return nil
-}
-
-func (s *NonetworkServer) SaveProtoClient(protocol string, stream client.GrpcClientCloser, peerID peer.ID) {
+func (s *NonetworkServer) GetMetrics() *Metrics {
+	return NilMetrics()
 }
 
 func (s *NonetworkServer) ForgetPeer(peer peer.ID, reason string) {}

--- a/network/testing/testing.go
+++ b/network/testing/testing.go
@@ -70,7 +70,7 @@ func (m *MockNetworkingServer) GetMockPeerMetrics() *MockPeerMetrics {
 
 // Define the mock hooks //
 // Required for Identity
-type newIdentityClientDelegate func(peer.ID) (client.IdentityClient, error)
+type newIdentityClientDelegate func(context.Context, peer.ID) (client.IdentityClient, error)
 type connectDelegate func(addrInfo peer.AddrInfo) error
 type disconnectFromPeerDelegate func(peer.ID, string)
 type addPeerDelegate func(peer.ID, network.Direction)
@@ -80,7 +80,7 @@ type hasFreeConnectionSlotDelegate func(network.Direction) bool
 
 // Required for Discovery
 type getRandomBootnodeDelegate func() *peer.AddrInfo
-type newDiscoveryClientDelegate func(peer.ID) (client.DiscoveryClient, error)
+type newDiscoveryClientDelegate func(context.Context, peer.ID) (client.DiscoveryClient, error)
 type addToPeerStoreDelegate func(*peer.AddrInfo)
 type removeFromPeerStoreDelegate func(peerInfo peer.ID)
 type getPeerInfoDelegate func(peer.ID) *peer.AddrInfo
@@ -93,9 +93,9 @@ type hasPeerDelegate func(peer.ID) bool
 // tracer
 type getTraceDelegate func() telemetry.Tracer
 
-func (m *MockNetworkingServer) NewIdentityClient(peerID peer.ID) (client.IdentityClient, error) {
+func (m *MockNetworkingServer) NewIdentityClient(ctx context.Context, peerID peer.ID) (client.IdentityClient, error) {
 	if m.newIdentityClientFn != nil {
-		return m.newIdentityClientFn(peerID)
+		return m.newIdentityClientFn(ctx, peerID)
 	}
 
 	return m.mockIdentityClient, nil
@@ -181,9 +181,9 @@ func (m *MockNetworkingServer) HookGetRandomBootnode(fn getRandomBootnodeDelegat
 	m.getRandomBootnodeFn = fn
 }
 
-func (m *MockNetworkingServer) NewDiscoveryClient(peerID peer.ID) (client.DiscoveryClient, error) {
+func (m *MockNetworkingServer) NewDiscoveryClient(ctx context.Context, peerID peer.ID) (client.DiscoveryClient, error) {
 	if m.newDiscoveryClientFn != nil {
-		return m.newDiscoveryClientFn(peerID)
+		return m.newDiscoveryClientFn(ctx, peerID)
 	}
 
 	return m.mockDiscoveryClient, nil


### PR DESCRIPTION
# Description

PR #323 

Two questions

1. When node A is getting blocks from node B, if node B is forced to shut down (or when the network connection is disconnected), `GetBlocks` will never expire, causing node A to block synchronously. Although difficult to reproduce, the problem does exist.

2. `PeerConnInfo.protocolClient` saves the grpc client, but the timeout period can't be set in the libp2p stream. libp2p stream leaks if peer disconnects
 
This PR removes grpc client saving, passing timeout context, enforcing timeouts in libp2p streams

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels

## Testing

- [x] I have tested this code with the official test suite
- [x] Use test environment  [dogechain-testenv](https://github.com/0xcb9ff9/dogechain-testenv.git) , random reset TCP connection  tested

