### PR TITLE
[blockchain] Exclude zero values from gas price metrics

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1029,8 +1029,11 @@ func (b *Blockchain) collectMetrics(number, gasused uint64, txcount int) {
 	b.gpAverage.RLock()
 	defer b.gpAverage.RUnlock()
 
-	b.metrics.MaxGasPriceObserve(float64(b.gpAverage.max.Uint64()))
-	b.metrics.GasPriceAverageObserve(float64(b.gpAverage.price.Uint64()))
+	// only collect price value with value
+	if b.gpAverage.max.Sign() > 0 {
+		b.metrics.MaxGasPriceObserve(float64(b.gpAverage.max.Uint64()))
+		b.metrics.GasPriceAverageObserve(float64(b.gpAverage.price.Uint64()))
+	}
 }
 
 // extractBlockReceipts extracts the receipts from the passed in block

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -54,8 +54,9 @@ type Blockchain struct {
 	executor  Executor
 	stopped   atomic.Bool // used in executor halting
 
-	config  *chain.Chain // Config containing chain information
-	genesis types.Hash   // The hash of the genesis block
+	config           *chain.Chain // Config containing chain information
+	priceBottomLimit uint64       // bottom limit of gas price
+	genesis          types.Hash   // The hash of the genesis block
 
 	headersCache    *lru.Cache // LRU cache for the headers
 	difficultyCache *lru.Cache // LRU cache for the difficulty
@@ -157,6 +158,7 @@ func (b *Blockchain) updateGasPriceAvg(newValues []*big.Int) {
 func NewBlockchain(
 	logger hclog.Logger,
 	config *chain.Chain,
+	priceBottomLimit uint64, // to correctly collect gas price metrics
 	storageBuilder storage.StorageBuilder,
 	consensus Verifier,
 	executor Executor,
@@ -167,11 +169,12 @@ func NewBlockchain(
 	}
 
 	b := &Blockchain{
-		logger:    logger.Named("blockchain"),
-		config:    config,
-		consensus: consensus,
-		executor:  executor,
-		stream:    newEventStream(context.Background()),
+		logger:           logger.Named("blockchain"),
+		config:           config,
+		priceBottomLimit: priceBottomLimit,
+		consensus:        consensus,
+		executor:         executor,
+		stream:           newEventStream(context.Background()),
 		gpAverage: &gasPriceAverage{
 			max:   new(big.Int),
 			price: new(big.Int),
@@ -1015,24 +1018,30 @@ func (b *Blockchain) WriteBlock(block *types.Block, source string) error {
 	b.logger.Info("new block", logArgs...)
 
 	if header != nil {
-		b.collectMetrics(header.Number, header.GasUsed, len(block.Transactions))
+		b.collectMetrics(header.Number, header.GasUsed)
 	}
 
 	return nil
 }
 
-func (b *Blockchain) collectMetrics(number, gasused uint64, txcount int) {
+func (b *Blockchain) collectMetrics(number, gasused uint64) {
 	b.metrics.GasUsedObserve(float64(gasused))
 	b.metrics.SetBlockHeight(float64(number))
-	b.metrics.TransactionNumObserve(float64(txcount))
 
 	b.gpAverage.RLock()
 	defer b.gpAverage.RUnlock()
+
+	// collect non-miner transaction count
+	b.metrics.TransactionNumObserve(float64(b.gpAverage.count.Uint64()))
 
 	// only collect price value with value
 	if b.gpAverage.max.Sign() > 0 {
 		b.metrics.MaxGasPriceObserve(float64(b.gpAverage.max.Uint64()))
 		b.metrics.GasPriceAverageObserve(float64(b.gpAverage.price.Uint64()))
+	} else {
+		// use price bottom limit
+		b.metrics.MaxGasPriceObserve(float64(b.priceBottomLimit))
+		b.metrics.GasPriceAverageObserve(float64(b.priceBottomLimit))
 	}
 }
 

--- a/blockchain/metrics.go
+++ b/blockchain/metrics.go
@@ -21,7 +21,7 @@ type Metrics struct {
 	blockWrittenSeconds prometheus.Histogram
 	// Block execution duration
 	blockExecutionSeconds prometheus.Histogram
-	// Transaction number
+	// Non-miner transaction number
 	transactionNum prometheus.Histogram
 }
 
@@ -104,7 +104,7 @@ func GetPrometheusMetrics(namespace string, labelsWithValues ...string) *Metrics
 			Namespace:   namespace,
 			Subsystem:   subsystem,
 			Name:        "transaction_number",
-			Help:        "Transaction number",
+			Help:        "Non-miner transaction number",
 			ConstLabels: constLabels,
 		}),
 	}

--- a/blockchain/testing.go
+++ b/blockchain/testing.go
@@ -350,6 +350,7 @@ func newBlockChain(config *chain.Chain, executor Executor) (*Blockchain, error) 
 	b, err := NewBlockchain(
 		hclog.NewNullLogger(),
 		config,
+		0,
 		kvstorage.NewMemoryStorageBuilder(hclog.NewNullLogger()),
 		&MockVerifier{},
 		executor,

--- a/reverify/chain.go
+++ b/reverify/chain.go
@@ -120,6 +120,7 @@ func createBlockchain(
 	chain, err := blockchain.NewBlockchain(
 		logger,
 		genesis,
+		0, // don't care price bottom limit when reverify.
 		kvstorage.NewLevelDBStorageBuilder(
 			logger,
 			newLevelDBBuilder(logger, filepath.Join(dataDir, "blockchain")),

--- a/server/server.go
+++ b/server/server.go
@@ -274,6 +274,7 @@ func NewServer(config *Config) (*Server, error) {
 	m.blockchain, err = blockchain.NewBlockchain(
 		logger,
 		config.Chain,
+		m.config.PriceLimit,
 		kvstorage.NewLevelDBStorageBuilder(logger, leveldbBuilder),
 		nil,
 		m.executor,


### PR DESCRIPTION
# Description

The maximum and average gas price metrics were disturbed by the zero values of the system contract transaction. With zero values adopted, they do not accurately reflect actual user gas prices.

The PR fixes this, by removing miner transactions from transaction count, and providing price bottom limit to metric collector when no user transactions are included.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

## Testing

- [x] I have tested this code with the official test suite
