### PR TITLE
[Fix] eth_getStorageAt always returning 0

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dogechain-lab/dogechain/state"
 	"github.com/dogechain-lab/dogechain/state/runtime"
 	"github.com/dogechain-lab/dogechain/types"
-	"github.com/dogechain-lab/fastrlp"
 	"github.com/hashicorp/go-hclog"
 )
 
@@ -443,22 +442,8 @@ func (e *Eth) GetStorageAt(
 
 		return nil, err
 	}
-	// Parse the RLP value
-	p := &fastrlp.Parser{}
 
-	v, err := p.Parse(result)
-	if err != nil {
-		return argBytesPtr(types.ZeroHash[:]), nil
-	}
-
-	data, err := v.Bytes()
-
-	if err != nil {
-		return argBytesPtr(types.ZeroHash[:]), nil
-	}
-
-	// Pad to return 32 bytes data
-	return argBytesPtr(types.BytesToHash(data).Bytes()), nil
+	return argBytesPtr(result), nil
 }
 
 // GasPrice returns the average gas price based on the last x blocks

--- a/jsonrpc/eth_state_test.go
+++ b/jsonrpc/eth_state_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dogechain-lab/dogechain/state"
 	"github.com/dogechain-lab/dogechain/state/runtime"
 	"github.com/dogechain-lab/dogechain/types"
-	"github.com/dogechain-lab/fastrlp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -557,10 +556,7 @@ func TestEth_State_GetStorageAt(t *testing.T) {
 				}
 				account := store.account
 				for index, data := range storage {
-					a := &fastrlp.Arena{}
-					value := a.NewBytes(data.Bytes())
-					newData := value.MarshalTo(nil)
-					account.Storage(index, newData)
+					account.Storage(index, data.Bytes())
 				}
 			}
 


### PR DESCRIPTION
# Description

upstream PR: [#1546](https://github.com/0xPolygon/polygon-edge/pull/1546), [#1558](https://github.com/0xPolygon/polygon-edge/pull/1558)

The RLP Parsing is already being done by the Snapshot's GetStorage method

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

# Breaking changes

`eth_getStorageAt` result change

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests
