### PR TITLE
[Feature] Return Revet result as Data

### DIFF
--- a/jsonrpc/codec.go
+++ b/jsonrpc/codec.go
@@ -93,6 +93,25 @@ func (e *ObjectError) Error() string {
 	return string(data)
 }
 
+func (e *ObjectError) MarshalJSON() ([]byte, error) {
+	var ds string
+
+	data, ok := e.Data.([]byte)
+	if ok && len(data) > 0 {
+		ds = "0x" + string(data)
+	}
+
+	return json.Marshal(&struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Data    string `json:"data,omitempty"`
+	}{
+		Code:    e.Code,
+		Message: e.Message,
+		Data:    ds,
+	})
+}
+
 const (
 	PendingBlockFlag  = "pending"
 	LatestBlockFlag   = "latest"
@@ -192,8 +211,8 @@ func (b *BlockNumber) UnmarshalJSON(buffer []byte) error {
 }
 
 // NewRPCErrorResponse is used to create a custom error response
-func NewRPCErrorResponse(id interface{}, errCode int, err string, jsonrpcver string) Response {
-	errObject := &ObjectError{errCode, err, nil}
+func NewRPCErrorResponse(id interface{}, errCode int, err string, data []byte, jsonrpcver string) Response {
+	errObject := &ObjectError{errCode, err, data}
 
 	response := &ErrorResponse{
 		JSONRPC: jsonrpcver,
@@ -211,7 +230,7 @@ func NewRPCResponse(id interface{}, jsonrpcver string, reply []byte, err Error) 
 	case nil:
 		response = &SuccessResponse{JSONRPC: jsonrpcver, ID: id, Result: reply}
 	default:
-		response = NewRPCErrorResponse(id, err.ErrorCode(), err.Error(), jsonrpcver)
+		response = NewRPCErrorResponse(id, err.ErrorCode(), err.Error(), reply, jsonrpcver)
 	}
 
 	return response

--- a/jsonrpc/eth_blockchain_test.go
+++ b/jsonrpc/eth_blockchain_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/dogechain-lab/dogechain/blockchain"
+	"github.com/dogechain-lab/dogechain/helper/hex"
 	"github.com/dogechain-lab/dogechain/helper/progress"
 	"github.com/dogechain-lab/dogechain/state/runtime"
 	"github.com/dogechain-lab/dogechain/types"
@@ -292,6 +293,31 @@ func TestEth_Call(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 	})
+
+	t.Run("returns error and result as data of a reverted transaction execution", func(t *testing.T) {
+		returnValue := []byte("Reverted()")
+
+		store := newMockBlockStore()
+		store.add(newTestBlock(100, hash1))
+		store.ethCallError = runtime.ErrExecutionReverted
+		store.returnValue = returnValue
+		eth := newTestEthEndpoint(store)
+		contractCall := &txnArgs{
+			From:     &addr0,
+			To:       &addr1,
+			Gas:      argUintPtr(100000),
+			GasPrice: argBytesPtr([]byte{0x64}),
+			Value:    argBytesPtr([]byte{0x64}),
+			Data:     nil,
+			Nonce:    argUintPtr(0),
+		}
+
+		res, err := eth.Call(contractCall, BlockNumberOrHash{})
+		assert.Error(t, err)
+		assert.NotNil(t, res)
+		bres := res.([]byte) //nolint:forcetypeassert
+		assert.Equal(t, []byte(hex.EncodeToString(returnValue)), bres)
+	})
 }
 
 type mockBlockStore struct {
@@ -303,6 +329,7 @@ type mockBlockStore struct {
 	isSyncing       bool
 	averageGasPrice int64
 	ethCallError    error
+	returnValue     []byte
 }
 
 func newMockBlockStore() *mockBlockStore {
@@ -482,7 +509,10 @@ func (m *mockBlockStore) GetAvgGasPrice() *big.Int {
 }
 
 func (m *mockBlockStore) ApplyTxn(header *types.Header, txn *types.Transaction) (*runtime.ExecutionResult, error) {
-	return &runtime.ExecutionResult{Err: m.ethCallError}, nil
+	return &runtime.ExecutionResult{
+		Err:         m.ethCallError,
+		ReturnValue: m.returnValue,
+	}, nil
 }
 
 func (m *mockBlockStore) SubscribeEvents() blockchain.Subscription {

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -519,7 +519,7 @@ func (e *Eth) Call(arg *txnArgs, filter BlockNumberOrHash) (interface{}, error) 
 
 	// Check if an EVM revert happened
 	if result.Reverted() {
-		return nil, constructErrorFromRevert(result)
+		return []byte(hex.EncodeToString(result.ReturnValue)), constructErrorFromRevert(result)
 	}
 
 	if result.Failed() {


### PR DESCRIPTION
# Description

upstream PR: [#1566](https://github.com/0xPolygon/polygon-edge/pull/1566)

This allows returning custom revert errors from solidity, they are ABI encoded functions that can represent rich and gas efficient revert messages.

Details of custom errors: https://blog.soliditylang.org/2021/04/21/custom-errors/

This is the implementation expected by ethers.js and web3.js and the format go-ethereum chose https://github.com/ethereum/go-ethereum/issues/19027#issuecomment-640500608

# Changes include

- [x] New feature (non-breaking change that adds functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels

## Testing

- [x] I have tested this code with the official test suite


