### PR TITLE
[Fix] logging: replacement non utf-8 characters

### DIFF
--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -405,7 +405,11 @@ func (d *Dispatcher) handleReq(req Request) ([]byte, Error) {
 }
 
 func (d *Dispatcher) logInternalError(method string, err error) {
-	d.logger.Error("failed to dispatch", "method", method, "err", err)
+	// replacement non utf-8 characters
+	errStr := strings.ToValidUTF8(err.Error(), "\uFFFD")
+	errStr = strings.ReplaceAll(errStr, "\x00", "")
+
+	d.logger.Error("failed to dispatch", "method", method, "err", errStr)
 }
 
 func (d *Dispatcher) registerService(serviceName string, service interface{}) {


### PR DESCRIPTION
# Description

`logInternalError` print `ech_call` error message, if there are non-utf-8 characters, the log file will be corrupted

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels

## Testing

- [x] I have tested this code with the official test suite
