### PR TITLE
[Trace]: fix incorrect captured `result` when defer function executed

### DIFF
--- a/state/executor.go
+++ b/state/executor.go
@@ -764,19 +764,19 @@ func (t *Transition) applyCall(
 		if c.Depth == 0 {
 			t.evmLogger.CaptureStart(t.Txn(), c.Caller, c.Address, false, c.Input, c.Gas, c.Value)
 
-			defer func(result *runtime.ExecutionResult) {
+			defer func() {
 				if result != nil {
 					t.evmLogger.CaptureEnd(result.ReturnValue, result.GasUsed, time.Since(time.Now()), result.Err)
 				}
-			}(result)
+			}()
 		} else {
 			t.evmLogger.CaptureEnter(int(evm.RuntimeType2OpCode(callType)), c.Caller, c.Address, c.Input, c.Gas, c.Value)
 
-			defer func(result *runtime.ExecutionResult) {
+			defer func() {
 				if result != nil {
 					t.evmLogger.CaptureExit(result.ReturnValue, result.GasUsed, result.Err)
 				}
-			}(result)
+			}()
 		}
 	}
 
@@ -857,19 +857,19 @@ func (t *Transition) applyCreate(c *runtime.Contract, host runtime.Host) *runtim
 		if c.Depth == 0 {
 			t.evmLogger.CaptureStart(t.Txn(), c.Caller, c.Address, true, c.Input, c.Gas, c.Value)
 
-			defer func(result *runtime.ExecutionResult) {
+			defer func() {
 				if result != nil {
 					t.evmLogger.CaptureEnd(result.ReturnValue, result.GasUsed, time.Since(time.Now()), result.Err)
 				}
-			}(result)
+			}()
 		} else {
 			t.evmLogger.CaptureEnter(int(evm.RuntimeType2OpCode(c.Type)), c.Caller, c.Address, c.Input, c.Gas, c.Value)
 
-			defer func(result *runtime.ExecutionResult) {
+			defer func() {
 				if result != nil {
 					t.evmLogger.CaptureExit(result.ReturnValue, result.GasUsed, result.Err)
 				}
-			}(result)
+			}()
 		}
 	}
 


### PR DESCRIPTION
# Description

This PR addresses an issue in code where the result variable was captured inside a defer function. As defer functions in Go capture variables at the point of definition, not execution, the captured result was potentially outdated or incorrect when the defer function executed.

The fix involves ensuring the defer statement is executed after the result variable has been updated. This can be done by placing the code that updates result inside a function, and then putting the defer statement at the end of this function. This allows the defer function to capture the updated result value correctly.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [] I have assigned this PR to myself
- [] I have added at least 1 reviewer
- [] I have added the relevant labels
- [] I have updated the official documentation
- [] I have added sufficient documentation in code

## Testing

- [X] I have tested this code with the official test suite
- [X] I have tested this code manually

